### PR TITLE
fix signature interface and wrong result

### DIFF
--- a/src/background/api/encryption.ts
+++ b/src/background/api/encryption.ts
@@ -90,10 +90,10 @@ export const signature = (message: MessageFormat, tabURL: string) =>
         data: await doSignature(message),
         message: "Success"
       });
-    } catch (e) {
+    } catch {
       resolve({
         res: false,
-        message: e.message || "Error signing data"
+        message: "Error signing data"
       });
     }
   });
@@ -232,7 +232,7 @@ async function doSignature(message: MessageFormat) {
   const signature = await crypto.subtle.sign(
     message.options,
     cryptoKey,
-    new Uint8Array(Object.values(message.data))
+    new Uint8Array(message.data)
   );
 
   return new Uint8Array(signature);

--- a/src/background/api/encryption.ts
+++ b/src/background/api/encryption.ts
@@ -90,10 +90,10 @@ export const signature = (message: MessageFormat, tabURL: string) =>
         data: await doSignature(message),
         message: "Success"
       });
-    } catch {
+    } catch (e) {
       resolve({
         res: false,
-        message: "Error signing data"
+        message: e.message || "Error signing data"
       });
     }
   });
@@ -232,7 +232,7 @@ async function doSignature(message: MessageFormat) {
   const signature = await crypto.subtle.sign(
     message.options,
     cryptoKey,
-    new Uint8Array(message.data)
+    new Uint8Array(Object.values(message.data))
   );
 
   return new Uint8Array(signature);

--- a/src/scripts/injected.ts
+++ b/src/scripts/injected.ts
@@ -236,20 +236,14 @@ const WalletAPI = {
       throw new Error(e);
     }
   },
-  async signature(
-    data: Uint8Array,
-    options: {
-      algorithm: string;
-      signing: any;
-    }
-  ): Promise<string> {
+  async signature(data: Uint8Array, algorithm: any): Promise<string> {
     try {
       const result = await callAPI({
         type: "signature",
         ext: "arconnect",
         sender: "api",
         data,
-        options
+        options: algorithm
       });
       if (!result.res || !result.data) throw new Error(result.message);
       return result.data;

--- a/src/scripts/injected.ts
+++ b/src/scripts/injected.ts
@@ -236,14 +236,20 @@ const WalletAPI = {
       throw new Error(e);
     }
   },
-  async signature(data: Uint8Array, algorithm: any): Promise<string> {
+  async signature(
+    data: Uint8Array,
+    options: {
+      algorithm: string;
+      signing: any;
+    }
+  ): Promise<string> {
     try {
       const result = await callAPI({
         type: "signature",
         ext: "arconnect",
         sender: "api",
         data,
-        options: algorithm
+        options
       });
       if (!result.res || !result.data) throw new Error(result.message);
       return result.data;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -111,14 +111,16 @@ declare global {
        * Get the signature for data array
        *
        * @param data `Uint8Array` data to get the signature for
-       * @param algorithm
+       * @param options Signature options
        *
        * @returns Promise of signature
        */
       signature(
         data: Uint8Array,
-        // https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/sign#parameters
-        algorithm: any
+        options: {
+          algorithm: string;
+          signing: any;
+        }
       ): Promise<string>;
 
       /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -111,16 +111,14 @@ declare global {
        * Get the signature for data array
        *
        * @param data `Uint8Array` data to get the signature for
-       * @param options Signature options
+       * @param algorithm
        *
        * @returns Promise of signature
        */
       signature(
         data: Uint8Array,
-        options: {
-          algorithm: string;
-          signing: any;
-        }
+        // https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/sign#parameters
+        algorithm: any
       ): Promise<string>;
 
       /**


### PR DESCRIPTION
1. add `Object.values` before pass `message.data` to `new Uint8Array`
2. change signature param interface, because of that options in signature function just passed to `crypto.subtle.sign` (https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/sign#parameters)
3. more specific error message