### PR TITLE
Update Drive GQL Query

### DIFF
--- a/src/views/Archive/App.tsx
+++ b/src/views/Archive/App.tsx
@@ -297,6 +297,7 @@ export default function App() {
             tags: [
               { name: "App-Name", values: ["ArDrive-Desktop", "ArDrive-Web"] }
               { name: "Entity-Type", values: "drive" }
+              { name: "Drive-Privacy", values: "public" } 
             ]
           ) {
             edges {


### PR DESCRIPTION
Fixes the graphQL query to only return public drives by including a filter for "Drive-Privacy" === "public".  This should fix the issue https://github.com/th8ta/ArConnect/issues/21