### PR TITLE
Corrected unixTime and lastModifiedDate

### DIFF
--- a/src/utils/archive.ts
+++ b/src/utils/archive.ts
@@ -72,7 +72,7 @@ export async function createMetadataTransaction(
       data: JSON.stringify({
         name: data.filename,
         size: getSizeBytes(data.content),
-        lastModifiedDate: data.timestamp,
+        lastModifiedDate: Math.round(data.timestamp / 1000),
         dataTxId: data.dataTxId,
         dataContentType: data.contentType
       })
@@ -86,7 +86,7 @@ export async function createMetadataTransaction(
   tx.addTag("ArFS", ArFS);
   tx.addTag("Entity-Type", "file");
   tx.addTag("Drive-Id", data.driveInfo.id);
-  tx.addTag("Unix-Time", data.timestamp.toString());
+  tx.addTag("Unix-Time", Math.round(data.timestamp / 1000).toString());
   tx.addTag("File-Id", uuidv4());
   tx.addTag("Parent-Folder-Id", data.driveInfo.rootFolderId);
   tx.addTag("ArDrive-Client", `ArConnect/${manifest.version}`);
@@ -145,7 +145,7 @@ export async function createPublicDrive(
     rootFolderName: data.name,
     isPrivate: false
   };
-  const timestamp = new Date().getTime();
+  const timestamp = Math.round(new Date().getTime() / 1000);
 
   /**
    * The drive transaction


### PR DESCRIPTION
Corrected unixTime and lastModifiedDate for drive, root folder and file transactions to show seconds since unix epoch not milliseconds, by dividing by 1000 and rounding.