### PR TITLE
Fix: Transfers over the limit cannot be made via `window.arweaveWallet.sign`.

### DIFF
--- a/src/background/api/transaction.ts
+++ b/src/background/api/transaction.ts
@@ -138,13 +138,21 @@ export const signTransaction = (message: MessageFormat, tabURL: string) =>
               sender: "popup",
               type: "sign_auth_result"
             }) ||
-            !msg.decryptionKey ||
             !msg.res
-          )
-            throw new Error();
-
-          decryptionKey = msg.decryptionKey;
-          resolve(await sign());
+          ) {
+            resolve({
+              res: false,
+              message: msg.message
+            });
+          } else if (!decryptionKey && !msg.decryptionKey) {
+            resolve({
+              res: false,
+              message: msg.message
+            });
+          } else {
+            decryptionKey = decryptionKey || msg.decryptionKey;
+            resolve(await sign());
+          }
         });
       } else resolve(await sign());
     } catch {

--- a/src/views/Auth/App.tsx
+++ b/src/views/Auth/App.tsx
@@ -74,14 +74,7 @@ export default function App() {
 
     // invalid auth
     if (!authVal) {
-      browser.runtime.sendMessage({
-        type: getReturnType(),
-        ext: "arconnect",
-        res: false,
-        message: "Invalid auth call",
-        sender: "popup"
-      });
-      window.close();
+      invalidAuthCall();
       return;
     }
 
@@ -98,14 +91,7 @@ export default function App() {
 
     // if the type does not exist, this is an invalid call
     if (!decodedAuthParam.type) {
-      browser.runtime.sendMessage({
-        type: getReturnType(),
-        ext: "arconnect",
-        res: false,
-        message: "Invalid auth call",
-        sender: "popup"
-      });
-      window.close();
+      invalidAuthCall();
       return;
     } else setType(decodedAuthParam.type);
 
@@ -158,14 +144,7 @@ export default function App() {
 
       // if non of the types matched, this is an invalid auth call
     } else {
-      browser.runtime.sendMessage({
-        type: getReturnType(),
-        ext: "arconnect",
-        res: false,
-        message: "Invalid auth call",
-        sender: "popup"
-      });
-      window.close();
+      invalidAuthCall();
       return;
     }
 
@@ -203,16 +182,11 @@ export default function App() {
 
       // any event that needs authentication, but not the connect event
       if (type !== "connect") {
-        if (!currentURL) return urlError();
-        else {
-          browser.runtime.sendMessage({
-            type: getReturnType(),
-            ext: "arconnect",
-            res: true,
-            message: "Success",
-            sender: "popup"
-          });
-          window.close();
+        if (!currentURL) {
+          return urlError();
+        } else {
+          successCall();
+          return;
         }
 
         // connect event
@@ -226,6 +200,35 @@ export default function App() {
     }
   }
 
+  function closeWindow() {
+    window.removeEventListener("beforeunload", cancel);
+    setTimeout(() => {
+      window.close();
+    }, 1000);
+  }
+
+  function successCall() {
+    browser.runtime.sendMessage({
+      type: getReturnType(),
+      ext: "arconnect",
+      res: true,
+      message: "Success",
+      sender: "popup"
+    });
+    closeWindow();
+  }
+
+  function invalidAuthCall() {
+    browser.runtime.sendMessage({
+      type: getReturnType(),
+      ext: "arconnect",
+      res: false,
+      message: "Invalid auth call",
+      sender: "popup"
+    });
+    closeWindow();
+  }
+
   // invalid url sent
   function urlError() {
     browser.runtime.sendMessage({
@@ -235,7 +238,7 @@ export default function App() {
       message: "No tab selected",
       sender: "popup"
     });
-    window.close();
+    closeWindow();
   }
 
   // get the type that needs to be returned in the message
@@ -256,16 +259,7 @@ export default function App() {
     dispatch(setPermissions(currentURL, allowedPermissions));
 
     // give time for the state to update
-    setTimeout(() => {
-      browser.runtime.sendMessage({
-        type: getReturnType(),
-        ext: "arconnect",
-        res: true,
-        message: "Success",
-        sender: "popup"
-      });
-      window.close();
-    }, 500);
+    setTimeout(successCall, 500);
   }
 
   // cancel login or permission request
@@ -274,10 +268,10 @@ export default function App() {
       type: getReturnType(),
       ext: "arconnect",
       res: false,
-      message: "User cancelled the login",
+      message: "User cancelled the login 12123",
       sender: "popup"
     });
-    window.close();
+    closeWindow();
   }
 
   // return the description of a permission

--- a/src/views/Auth/App.tsx
+++ b/src/views/Auth/App.tsx
@@ -74,7 +74,14 @@ export default function App() {
 
     // invalid auth
     if (!authVal) {
-      invalidAuthCall();
+      browser.runtime.sendMessage({
+        type: getReturnType(),
+        ext: "arconnect",
+        res: false,
+        message: "Invalid auth call",
+        sender: "popup"
+      });
+      window.close();
       return;
     }
 
@@ -91,7 +98,14 @@ export default function App() {
 
     // if the type does not exist, this is an invalid call
     if (!decodedAuthParam.type) {
-      invalidAuthCall();
+      browser.runtime.sendMessage({
+        type: getReturnType(),
+        ext: "arconnect",
+        res: false,
+        message: "Invalid auth call",
+        sender: "popup"
+      });
+      window.close();
       return;
     } else setType(decodedAuthParam.type);
 
@@ -144,7 +158,14 @@ export default function App() {
 
       // if non of the types matched, this is an invalid auth call
     } else {
-      invalidAuthCall();
+      browser.runtime.sendMessage({
+        type: getReturnType(),
+        ext: "arconnect",
+        res: false,
+        message: "Invalid auth call",
+        sender: "popup"
+      });
+      window.close();
       return;
     }
 
@@ -182,11 +203,16 @@ export default function App() {
 
       // any event that needs authentication, but not the connect event
       if (type !== "connect") {
-        if (!currentURL) {
-          return urlError();
-        } else {
-          successCall();
-          return;
+        if (!currentURL) return urlError();
+        else {
+          browser.runtime.sendMessage({
+            type: getReturnType(),
+            ext: "arconnect",
+            res: true,
+            message: "Success",
+            sender: "popup"
+          });
+          window.close();
         }
 
         // connect event
@@ -200,35 +226,6 @@ export default function App() {
     }
   }
 
-  function closeWindow() {
-    window.removeEventListener("beforeunload", cancel);
-    setTimeout(() => {
-      window.close();
-    }, 1000);
-  }
-
-  function successCall() {
-    browser.runtime.sendMessage({
-      type: getReturnType(),
-      ext: "arconnect",
-      res: true,
-      message: "Success",
-      sender: "popup"
-    });
-    closeWindow();
-  }
-
-  function invalidAuthCall() {
-    browser.runtime.sendMessage({
-      type: getReturnType(),
-      ext: "arconnect",
-      res: false,
-      message: "Invalid auth call",
-      sender: "popup"
-    });
-    closeWindow();
-  }
-
   // invalid url sent
   function urlError() {
     browser.runtime.sendMessage({
@@ -238,7 +235,7 @@ export default function App() {
       message: "No tab selected",
       sender: "popup"
     });
-    closeWindow();
+    window.close();
   }
 
   // get the type that needs to be returned in the message
@@ -259,7 +256,16 @@ export default function App() {
     dispatch(setPermissions(currentURL, allowedPermissions));
 
     // give time for the state to update
-    setTimeout(successCall, 500);
+    setTimeout(() => {
+      browser.runtime.sendMessage({
+        type: getReturnType(),
+        ext: "arconnect",
+        res: true,
+        message: "Success",
+        sender: "popup"
+      });
+      window.close();
+    }, 500);
   }
 
   // cancel login or permission request
@@ -268,10 +274,10 @@ export default function App() {
       type: getReturnType(),
       ext: "arconnect",
       res: false,
-      message: "User cancelled the login 12123",
+      message: "User cancelled the login",
       sender: "popup"
     });
-    closeWindow();
+    window.close();
   }
 
   // return the description of a permission


### PR DESCRIPTION
Fixes.
1. beyond 0.1 AR, cancel, cannot get error message; even if the password is entered correctly, the transfer cannot be made.
2. `window.addEventListener("beforeunload", cancel);` causes the cancel function to be called even if the password is entered correctly and the correct result is transmitted, resulting in the transfer never being completed