### PR TITLE
Rename from Limestone to Redstone

### DIFF
--- a/src/views/Popup/routes/Home.tsx
+++ b/src/views/Popup/routes/Home.tsx
@@ -278,7 +278,7 @@ export default function Home() {
             text={
               <p style={{ textAlign: "center", margin: "0" }}>
                 Calculated using <br />
-                limestone.finance
+                redstone.finance
               </p>
             }
             style={{ marginLeft: ".18em" }}


### PR DESCRIPTION
As requested by redstone-ppe in Discord, it's become evident that Limestone has changed their protocol name to Redstone. This PR updates ArConnect to display the new name properly.