### PR TITLE
Fixes fees and Unix-Time stamp

### DIFF
--- a/src/utils/archive.ts
+++ b/src/utils/archive.ts
@@ -87,7 +87,7 @@ export async function createMetadataTransaction(
   tx.addTag("ArFS", ArFS);
   tx.addTag("Entity-Type", "file");
   tx.addTag("Drive-Id", data.driveInfo.id);
-  tx.addTag("Unix-Time", data.timestamp.toString());
+  tx.addTag("Unix-Time", (data.timestamp / 1000).toString());
   tx.addTag("File-Id", uuidv4());
   tx.addTag("Parent-Folder-Id", data.driveInfo.rootFolderId);
   tx.addTag("ArDrive-Client", `ArConnect/${manifest.version}`);
@@ -146,7 +146,7 @@ export async function createPublicDrive(
     rootFolderName: data.name,
     isPrivate: false
   };
-  const timestamp = new Date().getTime();
+  const timestamp = Math.round(Date.now() / 1000);
 
   /**
    * The drive transaction

--- a/src/utils/archive.ts
+++ b/src/utils/archive.ts
@@ -11,7 +11,7 @@ import Transaction from "arweave/node/lib/transaction";
 const ardriveClient = "ArDrive-Web";
 const ardriveVersion = "0.1.0";
 const ArFS = "0.11";
-const defaultArDriveMinimumTipAR = 0.000_010_000_000;
+export const defaultArDriveMinimumTipAR = 0.000_010_000_000;
 /**
  * Create an archive file transaction
  * This will archive the file on Arweave using ArDrive

--- a/src/utils/archive.ts
+++ b/src/utils/archive.ts
@@ -87,7 +87,7 @@ export async function createMetadataTransaction(
   tx.addTag("ArFS", ArFS);
   tx.addTag("Entity-Type", "file");
   tx.addTag("Drive-Id", data.driveInfo.id);
-  tx.addTag("Unix-Time", (data.timestamp / 1000).toString());
+  tx.addTag("Unix-Time", Math.round(data.timestamp / 1000).toString());
   tx.addTag("File-Id", uuidv4());
   tx.addTag("Parent-Folder-Id", data.driveInfo.rootFolderId);
   tx.addTag("ArDrive-Client", `ArConnect/${manifest.version}`);

--- a/src/views/Archive/App.tsx
+++ b/src/views/Archive/App.tsx
@@ -22,7 +22,8 @@ import {
   createMetadataTransaction,
   Drive,
   createPublicDrive,
-  sendArDriveFee
+  sendArDriveFee,
+  defaultArDriveMinimumTipAR
 } from "../../utils/archive";
 import { useColorScheme } from "use-color-scheme";
 import { run } from "ar-gql";
@@ -41,7 +42,10 @@ import Arweave from "arweave";
 import ardriveLogoLight from "../../assets/ardrive_light.svg";
 import ardriveLogoDark from "../../assets/ardrive_dark.svg";
 import styles from "../../styles/views/Archive/view.module.sass";
-import { getWinstonPriceForByteCount } from "../../utils/pst";
+import {
+  getArDriveTipPercentage,
+  getWinstonPriceForByteCount
+} from "../../utils/pst";
 
 export default function App() {
   const [safeMode, setSafeMode] = useState(true),
@@ -389,7 +393,17 @@ export default function App() {
   useEffect(() => {
     (async () => {
       const size = getSizeBytes(previewHTML);
-      setFee(arweave.ar.winstonToAr(await arweave.transactions.getPrice(size)));
+      const dataFee = arweave.ar.winstonToAr(
+        await arweave.transactions.getPrice(size)
+      );
+      const communityTip = Math.max(
+        dataFee * (await getArDriveTipPercentage()),
+        defaultArDriveMinimumTipAR // If the fee is too small, we assign a minimum
+      );
+      // Sum both the data fees and the community tip
+      const totalFee = +dataFee + communityTip;
+
+      setFee(totalFee);
     })();
     // eslint-disable-next-line
   }, [previewHTML]);


### PR DESCRIPTION
The fee displayed to users when archiving an HTML page now correctly shows both the data price and ArDrive community tip included.

The unix-time tag for drive, root folder and file transactions is now properly set to "seconds since unix epoch"