### PR TITLE
fix: multiple fee txs sent when allowance needed

### DIFF
--- a/src/background/api/transaction.ts
+++ b/src/background/api/transaction.ts
@@ -144,7 +144,8 @@ export const signTransaction = (message: MessageFormat, tabURL: string) =>
           url: tabURL,
           spendingLimitReached: openAllowance
         });
-        browser.runtime.onMessage.addListener(async (msg) => {
+        const listenerCallback = async (msg) => {
+          browser.runtime.onMessage.removeListener(listenerCallback);
           if (
             !validateMessage(msg, {
               sender: "popup",
@@ -165,7 +166,8 @@ export const signTransaction = (message: MessageFormat, tabURL: string) =>
             decryptionKey = decryptionKey || msg.decryptionKey;
             resolve(await sign());
           }
-        });
+        };
+        browser.runtime.onMessage.addListener(listenerCallback);
       } else resolve(await sign());
     } catch {
       resolve({


### PR DESCRIPTION
When allowance is required, the registered listener function is not removed, resulting in the previously registered listener function being executed all the time every time the sign function is called. This results in multiple fee transactions being generated and sent.

