### PR TITLE
Make dev green again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        run: |
+          git config --global url."https://github.com/".insteadOf git://github.com/
 
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Git
+        run: git config --global url."https://github.com/".insteadOf git://github.com/
+
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Git
-        run: git config --global url."https://github.com/".insteadOf git://github.com/
+      - uses: actions/checkout@v3
+      - run: |
+          git config --global url."https://github.com/".insteadOf git://github.com/
 
-      - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
           node-version: "14"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - run: |
-          git config --global url."https://github.com/".insteadOf git://github.com/
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        run: |
+      - uses: actions/checkout@v3
+      - run: |
           git config --global url."https://github.com/".insteadOf git://github.com/
 
       - uses: actions/setup-node@v1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        run: |
+          git config --global url."https://github.com/".insteadOf git://github.com/
 
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -8,11 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - run: |
-          git config --global url."https://github.com/".insteadOf git://github.com/
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
           node-version: "14"

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Git
+        run: git config --global url."https://github.com/".insteadOf git://github.com/
+
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -8,9 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        run: |
+      - uses: actions/checkout@v3
+      - run: |
           git config --global url."https://github.com/".insteadOf git://github.com/
 
       - uses: actions/setup-node@v1

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -8,8 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Git
-        run: git config --global url."https://github.com/".insteadOf git://github.com/
+      - uses: actions/checkout@v3
+      - run: |
+          git config --global url."https://github.com/".insteadOf git://github.com/
 
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,8 @@ jobs:
         browser: [chrome, firefox]
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        run: |
+      - uses: actions/checkout@v3
+      - run: |
           git config --global url."https://github.com/".insteadOf git://github.com/
 
       - name: Setup Node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        run: |
+          git config --global url."https://github.com/".insteadOf git://github.com/
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
         browser: [chrome, firefox]
 
     steps:
+      - name: Git
+        run: git config --global url."https://github.com/".insteadOf git://github.com/
+
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,9 @@ jobs:
         browser: [chrome, firefox]
 
     steps:
-      - name: Git
-        run: git config --global url."https://github.com/".insteadOf git://github.com/
+      - uses: actions/checkout@v3
+      - run: |
+          git config --global url."https://github.com/".insteadOf git://github.com/
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,8 @@ jobs:
         browser: [chrome, firefox]
 
     steps:
-      - uses: actions/checkout@v3
-      - run: |
-          git config --global url."https://github.com/".insteadOf git://github.com/
-
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        run: |
+          git config --global url."https://github.com/".insteadOf git://github.com/
 
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - run: |
-          git config --global url."https://github.com/".insteadOf git://github.com/
+      - name: Checkout
+        uses: actions/checkout@v3
 
-      - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
           node-version: "14"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Git
+        run: git config --global url."https://github.com/".insteadOf git://github.com/
+
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        run: |
+      - uses: actions/checkout@v3
+      - run: |
           git config --global url."https://github.com/".insteadOf git://github.com/
 
       - uses: actions/setup-node@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Git
-        run: git config --global url."https://github.com/".insteadOf git://github.com/
+      - uses: actions/checkout@v3
+      - run: |
+          git config --global url."https://github.com/".insteadOf git://github.com/
 
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1


### PR DESCRIPTION
Fix workflow error in the [development branch](https://github.com/th8ta/ArConnect/runs/5829454232?check_suite_focus=true):

```
yarn install v1.22.18
[1/4] Resolving packages...
[2/4] Fetching packages...
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads git://github.com/JesseTheRobot/avsc
Directory: /home/runner/work/ArConnect/ArConnect
Output:
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
```