### PR TITLE
Updated prettier options

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
Set [end of line](https://prettier.io/docs/en/options.html#end-of-line) option in order to use `yarn fmt` command on Windows and macOS