### PR TITLE
replace docs link with correct url

### DIFF
--- a/src/views/Popup/routes/Settings.tsx
+++ b/src/views/Popup/routes/Settings.tsx
@@ -1047,7 +1047,9 @@ export default function Settings({
                   </p>
                   <p
                     onClick={() =>
-                      browser.tabs.create({ url: "https://arconnect.io/docs" })
+                      browser.tabs.create({
+                        url: "https://docs.th8ta.org/arconnect"
+                      })
                     }
                     style={{ color: theme.palette.success }}
                   >


### PR DESCRIPTION
The current docs link is pointed at `https://www.arconnect.io/docs` which is a 404. This PR replaces it with the most recent docs at `https://docs.th8ta.org/arconnect`