### PR TITLE
fix(archive integration): Fetch drives from all ArFS compatible transactions

### DIFF
--- a/src/views/Archive/App.tsx
+++ b/src/views/Archive/App.tsx
@@ -301,7 +301,6 @@ export default function App() {
             first: 100
             owners: [$addr]
             tags: [
-              { name: "App-Name", values: ["ArDrive-Desktop", "ArDrive-Web"] }
               { name: "Entity-Type", values: "drive" }
               { name: "Drive-Privacy", values: "public" } 
             ]


### PR DESCRIPTION
This PR removes the `"App-Name"` GQL tag filter which will enable the ArConnect extension to use the archive feature to any ArFS compatible drive, including the ArDrive-CLI and apps using ArDrive-Core.

The ArDrive apps use more `App-Name`s than just `"ArDrive-Web"` and `"ArDrive-Desktop"`. We currently also use `"ArDrive-CLI"`, `"ArDrive-Core"`, and `"ArDrive-Sync"`. But adding a query with this many tag values has proven to be intensive on the gateway. 

The ArFS spec is not really limited by App-Name. All MetaData Tx can be queried by `ArFS` with value `0.10` or `0.11`. But removing the App-Name tag filter altogether works just as well here and is more future proof