### PR TITLE
Fix `addToken()` errors

### DIFF
--- a/src/tokens/token.ts
+++ b/src/tokens/token.ts
@@ -314,7 +314,14 @@ export async function loadTokenLogo(
  * Parse settings from token state
  */
 export function getSettings(state: TokenState) {
-  return new Map<string, any>(state?.settings || []);
+  let rawSettings = state?.settings || [];
+
+  // transform object setting structure
+  if (!Array.isArray(rawSettings)) {
+    rawSettings = Object.entries(rawSettings);
+  }
+
+  return new Map<string, any>(rawSettings);
 }
 
 /**

--- a/src/utils/assertions.ts
+++ b/src/utils/assertions.ts
@@ -281,7 +281,7 @@ export function isTokenState(input: unknown): asserts input is TokenState {
   isRecord(input.balances, "Invalid balances object: not a record.");
 
   for (const address in input.balances) {
-    isAddress(address);
+    isString(address);
     isValidBalance(input.balances[address]);
   }
 }


### PR DESCRIPTION
Fixed:
```ts
await arweaveWallet.addToken("bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U");
```

![image](https://github.com/arconnectio/ArConnect/assets/30638105/bcc05c5e-9901-4d98-b2ca-3c0abe2a3121)
