### PR TITLE
fix: Resolve issue with fetching wallets balance

### DIFF
--- a/src/components/popup/WalletSwitcher.tsx
+++ b/src/components/popup/WalletSwitcher.tsx
@@ -107,7 +107,7 @@ export default function WalletSwitcher({
     (async () => {
       if (wallets.length === 0 || loadedBalances) return;
 
-      const gateway = await findGateway();
+      const gateway = await findGateway({});
       const arweave = new Arweave(gateway);
 
       await Promise.all(

--- a/src/gateways/wayfinder.ts
+++ b/src/gateways/wayfinder.ts
@@ -73,11 +73,11 @@ export async function findGateway(
         };
       }
     }
-
-    return defaultGateway;
   } catch (err) {
     console.log("err", err);
   }
+
+  return defaultGateway;
 }
 
 /**


### PR DESCRIPTION
This pull request resolves issue related to fetching wallets balance in wallet list.

As nothing was passed to a [findGateway](https://github.com/arconnectio/ArConnect/blob/65caa8b50374d812bdcf8c6079c2698982f6fd9c/src/components/popup/WalletSwitcher.tsx#L110) function and it’s `requirements` parameter doesn’t have a default value and its giving errors like `Cannot read properties of undefined (reading 'startBlock')` or `Cannot read properties of undefined (reading 'arns')`. The missing argument `requirements` is passed to `findGateway` function to solve this issue.

![image](https://github.com/arconnectio/ArConnect/assets/11836100/04d24508-d23f-4fbd-82af-b9c1b5134144)