### PR TITLE
Buy Buttons - Dashboard (w/ balance & w/ no balance)

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1333,9 +1333,9 @@
       }
     }
   },
-  "home_add_balance": {
-    "message": "Add",
-    "description": "Add balance button text"
+  "home_transfer_balance": {
+    "message": "Transfer AR",
+    "description": "Transfer balance button text"
   },
   "close_tab_generate_wallet_message": {
     "message": "Are you sure you want to exit? Your new wallet is still being generated and will be lost.",

--- a/src/components/popup/home/BuyButton.tsx
+++ b/src/components/popup/home/BuyButton.tsx
@@ -3,9 +3,13 @@ import browser from "webextension-polyfill";
 import styled from "styled-components";
 import arLogoDark from "url:/assets/ar/logo_dark.png";
 
-export default function BuyButton() {
+interface ButtonWrapperProps {
+  padding?: boolean;
+}
+
+export default function BuyButton({ padding }: ButtonWrapperProps) {
   return (
-    <ButtonWrapper>
+    <ButtonWrapper padding={padding}>
       <CustomButton className="normal-font-weight" small fullWidth>
         {browser.i18n.getMessage("buy_ar_button")}
         <ARLogo src={arLogoDark} alt={"AR"} draggable={false} />
@@ -14,9 +18,9 @@ export default function BuyButton() {
   );
 }
 
-const ButtonWrapper = styled.div`
-  padding: 0px 12px;
+const ButtonWrapper = styled.div<ButtonWrapperProps>`
   height: 55px;
+  padding: ${(props) => (props.padding ? "0px 12px" : "0")};
 `;
 
 const CustomButton = styled(Button)`

--- a/src/components/popup/home/BuyButton.tsx
+++ b/src/components/popup/home/BuyButton.tsx
@@ -23,7 +23,6 @@ const CustomButton = styled(Button)`
   &.normal-font-weight {
     font-weight: normal;
   }
-  border-radius: 40px;
   margin-top: 10px;
 `;
 

--- a/src/components/popup/home/NoBalance.tsx
+++ b/src/components/popup/home/NoBalance.tsx
@@ -4,6 +4,7 @@ import { useHistory } from "~utils/hash_router";
 import noBalanceArt from "url:/assets/ar/no_funds.png";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
+import BuyButton from "./BuyButton";
 
 export default function NoBalance() {
   const [push] = useHistory();
@@ -14,10 +15,19 @@ export default function NoBalance() {
       <NoBalanceText>
         {browser.i18n.getMessage("home_no_balance", "$AR")}
       </NoBalanceText>
-      <Button onClick={() => push("/receive")} small>
-        {browser.i18n.getMessage("home_add_balance")}
-        <ArrowRightIcon />
-      </Button>
+      <ButtonWrapper>
+        <BuyButton padding={false} />
+        <Container>
+          <CustomButton
+            onClick={() => push("/receive")}
+            small
+            fullWidth
+            className="normal-font-weight"
+          >
+            {browser.i18n.getMessage("home_add_balance")}
+          </CustomButton>
+        </Container>
+      </ButtonWrapper>
     </Wrapper>
   );
 }
@@ -42,4 +52,20 @@ const Art = styled.img.attrs({
 })`
   user-select: none;
   width: 184px;
+`;
+
+const ButtonWrapper = styled.div`
+  width: 100%;
+`;
+
+const Container = styled.div`
+  height: 55px;
+`;
+
+const CustomButton = styled(Button)`
+  &.normal-font-weight {
+    font-weight: normal;
+  }
+  background-color: black;
+  border: 3px solid #ab9aff;
 `;

--- a/src/components/popup/home/NoBalance.tsx
+++ b/src/components/popup/home/NoBalance.tsx
@@ -24,7 +24,8 @@ export default function NoBalance() {
             fullWidth
             className="normal-font-weight"
           >
-            {browser.i18n.getMessage("home_add_balance")}
+            {browser.i18n.getMessage("home_transfer_balance")}
+            <ArrowRightIcon />
           </CustomButton>
         </Container>
       </ButtonWrapper>

--- a/src/components/popup/home/NoBalance.tsx
+++ b/src/components/popup/home/NoBalance.tsx
@@ -25,7 +25,7 @@ export default function NoBalance() {
             className="normal-font-weight"
           >
             {browser.i18n.getMessage("home_transfer_balance")}
-            <ArrowRightIcon />
+            <ArrowRight />
           </CustomButton>
         </Container>
       </ButtonWrapper>
@@ -69,4 +69,9 @@ const CustomButton = styled(Button)`
   }
   background-color: black;
   border: 3px solid #ab9aff;
+`;
+
+const ArrowRight = styled(ArrowRightIcon)`
+  width: 16px;
+  height: 16px;
 `;

--- a/src/routes/popup/index.tsx
+++ b/src/routes/popup/index.tsx
@@ -59,7 +59,7 @@ export default function Home() {
       <Balance />
       {(!noBalance && (
         <>
-          <BuyButton />
+          <BuyButton padding={true} />
           <Tokens />
           <Collectibles />
         </>


### PR DESCRIPTION
This PR encompasses both ARC-208 & ARC-209 including the new Buy AR buttons. On the no balance dashboard it also includes the newly updated design with the new Transfer AR button beneath the Buy AR button. The Buy AR button is a new, reusable component. 