### PR TITLE
fix: temp disables u-token on send page

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -287,6 +287,10 @@
     "message": "Disabled",
     "description": "Disabled label"
   },
+  "u_token_disabled": {
+    "message": "Transfering of U-Token is currently disabled",
+    "description": "U-token Disabled label"
+  },
   "spent": {
     "message": "Spent",
     "description": "Spent text"

--- a/src/routes/popup/send/index.tsx
+++ b/src/routes/popup/send/index.tsx
@@ -7,6 +7,7 @@ import {
   Section,
   Spacer,
   Text,
+  Tooltip,
   useInput
 } from "@arconnect/components";
 import browser from "webextension-polyfill";
@@ -391,13 +392,27 @@ export default function Send({ id }: Props) {
             <ChevronRightIcon />
           </TokenSelectorRightSide>
         </TokenSelector>
-        <Button
-          disabled={invalidQty || parseFloat(qty) === 0 || qty === ""}
-          onClick={send}
+        <Tooltip
+          content={
+            token.id === "KTzTXT_ANmF84fWEKHzWURD1LWd9QaFR9yfYUwH2Lxw"
+              ? browser.i18n.getMessage("u_token_disabled")
+              : ""
+          }
         >
-          {browser.i18n.getMessage("send")}
-          <ArrowUpRightIcon />
-        </Button>
+          <Button
+            disabled={
+              invalidQty ||
+              parseFloat(qty) === 0 ||
+              qty === "" ||
+              token.id === "KTzTXT_ANmF84fWEKHzWURD1LWd9QaFR9yfYUwH2Lxw"
+            }
+            fullWidth
+            onClick={send}
+          >
+            {browser.i18n.getMessage("send")}
+            <ArrowUpRightIcon />
+          </Button>
+        </Tooltip>
       </BottomActions>
       <AnimatePresence>
         {showTokenSelector && (


### PR DESCRIPTION
Temporarily disables U-token on send page due to transfer bug

<img width="346" alt="image" src="https://github.com/arconnectio/ArConnect/assets/23609833/9856146a-d21e-4e9c-b6fe-e9465ef53168">
