### PR TITLE
ARC-225 retain quote data on back from confirm

### DIFF
--- a/src/components/InputMenu.tsx
+++ b/src/components/InputMenu.tsx
@@ -16,6 +16,7 @@ interface InputMenuProps {
   onPaymentMethodChange?: (methodId: string) => void;
   onFiatCurrencyChange?: (currency: string) => void;
   isPaymentMethod: boolean;
+  selectedPaymentMethod?: string;
   selectedFiatCurrency?: string;
 }
 
@@ -23,6 +24,7 @@ export default function InputMenu({
   onPaymentMethodChange,
   onFiatCurrencyChange,
   isPaymentMethod,
+  selectedPaymentMethod,
   selectedFiatCurrency = "eur"
 }: InputMenuProps) {
   const theme = useTheme();
@@ -75,6 +77,17 @@ export default function InputMenu({
       setChooseOption(true);
     }
   }, [isPaymentMethod, selectedFiatCurrency]);
+
+  useEffect(() => {
+    if (isPaymentMethod && onPaymentMethodChange) {
+      const selectedMethod = options.find(
+        (option) => option.id === selectedPaymentMethod
+      );
+      if (selectedMethod) {
+        setChosenOption(selectedMethod);
+      }
+    }
+  }, [onPaymentMethodChange, isPaymentMethod]);
 
   const OptionSelect = () => (
     <SelectInput displayTheme={theme} onClick={() => setChooseOption(true)}>

--- a/src/routes/popup/confirm.tsx
+++ b/src/routes/popup/confirm.tsx
@@ -54,7 +54,6 @@ export default function ConfirmPurchase() {
   useEffect(() => {
     async function fetchActiveQuote() {
       const quote = await getActiveQuote();
-      console.log(quote);
 
       setOnramp(quote.ramp);
       setSelectedFiat(quote.selectedFiat.toUpperCase());
@@ -81,8 +80,6 @@ export default function ConfirmPurchase() {
   }, []);
 
   const buyAR = async () => {
-    console.log("Confirmed purchase");
-
     try {
       const wallet = {
         address: activeWallet
@@ -103,8 +100,6 @@ export default function ConfirmPurchase() {
         requestBody.paymentMethod,
         requestBody.wallet
       );
-
-      console.log("Purchase pending:", response);
 
       if (
         response &&

--- a/src/routes/popup/confirm.tsx
+++ b/src/routes/popup/confirm.tsx
@@ -10,6 +10,7 @@ import type { DisplayTheme } from "@arconnect/components";
 import BuyButton from "~components/popup/home/BuyButton";
 import { getActiveWallet } from "~wallets";
 import { buyRequest } from "~lib/onramper";
+import { useStorage } from "@plasmohq/storage/hook";
 
 export default function ConfirmPurchase() {
   const [push] = useHistory();
@@ -27,6 +28,14 @@ export default function ConfirmPurchase() {
   const [fiatAmount, setFiatAmount] = useState(0);
   const [paymentMethod, setPaymentMethod] = useState("");
   const [paymentName, setPaymentName] = useState("");
+
+  const [isBackFromConfirm, setIsBackFromConfirm] = useStorage(
+    {
+      key: "isBackFromConfirm",
+      instance: ExtensionStorage
+    },
+    null
+  );
 
   useEffect(() => {
     async function fetchActiveWallet() {
@@ -107,6 +116,7 @@ export default function ConfirmPurchase() {
         browser.tabs.update({
           url: response.message.transactionInformation.url
         });
+        setIsBackFromConfirm(false);
         push("/purchase-pending");
       } else {
         console.error("Invalid response format or missing URL");
@@ -116,12 +126,17 @@ export default function ConfirmPurchase() {
     }
   };
 
+  const handleBack = () => {
+    setIsBackFromConfirm(true);
+    push("/purchase");
+  };
+
   return (
     <Wrapper>
       <div>
         <Header>
           <BackWrapper>
-            <ExitIcon onClick={() => push("/purchase")}>
+            <ExitIcon onClick={() => handleBack()}>
               {browser.i18n.getMessage("exit_buy_screen")}
             </ExitIcon>
           </BackWrapper>

--- a/src/routes/popup/purchase.tsx
+++ b/src/routes/popup/purchase.tsx
@@ -35,39 +35,33 @@ export default function Purchase() {
 
   const isInitialMount = useRef(true);
 
-  async function checkIsBackFromConfirm() {
-    const isBack = await ExtensionStorage.get("isBackFromConfirm");
-    console.log("is back:", isBack);
-
-    return isBack;
-  }
-
   async function getActiveQuote() {
     const activeQuote = await ExtensionStorage.get("quote");
     return activeQuote;
   }
 
-  useEffect(() => {
-    async function fetchActiveQuote() {
-      const backIsTrue = checkIsBackFromConfirm();
-      console.log("back is true:", backIsTrue);
-      if (backIsTrue) {
-        const quote = await getActiveQuote();
-        console.log("active quote from confirm:", quote);
+  async function checkIsBackFromConfirm() {
+    const isBack = await ExtensionStorage.get("isBackFromConfirm");
+    console.log("Back from confirm:", isBack);
 
-        setSelectedFiat(quote.selectedFiat);
-        setFiatAmount(quote.fiatAmount);
-        setReceivedAR(quote.payout);
-        setSelectedPaymentMethod(quote.selectedPaymentMethod);
+    if (isBack === true) {
+      const quote = await getActiveQuote();
+      console.log("active quote from confirm:", quote);
 
-        await ExtensionStorage.set("isBackFromConfirm", false);
-      }
+      setSelectedFiat(quote.selectedFiat);
+      setFiatAmount(quote.fiatAmount);
+      setReceivedAR(quote.payout);
+      setSelectedPaymentMethod(quote.selectedPaymentMethod);
+
+      await ExtensionStorage.set("isBackFromConfirm", false);
+    } else {
+      return false;
     }
+  }
 
-    fetchActiveQuote();
+  useEffect(() => {
+    checkIsBackFromConfirm();
   }, [isInitialMount]);
-
-  // ------------------------------------------------------------
 
   const [quote, setQuote] = useStorage<Object>(
     {

--- a/src/routes/popup/purchase.tsx
+++ b/src/routes/popup/purchase.tsx
@@ -35,6 +35,40 @@ export default function Purchase() {
 
   const isInitialMount = useRef(true);
 
+  async function checkIsBackFromConfirm() {
+    const isBack = await ExtensionStorage.get("isBackFromConfirm");
+    console.log("is back:", isBack);
+
+    return isBack;
+  }
+
+  async function getActiveQuote() {
+    const activeQuote = await ExtensionStorage.get("quote");
+    return activeQuote;
+  }
+
+  useEffect(() => {
+    async function fetchActiveQuote() {
+      const backIsTrue = checkIsBackFromConfirm();
+      console.log("back is true:", backIsTrue);
+      if (backIsTrue) {
+        const quote = await getActiveQuote();
+        console.log("active quote from confirm:", quote);
+
+        setSelectedFiat(quote.selectedFiat);
+        setFiatAmount(quote.fiatAmount);
+        setReceivedAR(quote.payout);
+        setSelectedPaymentMethod(quote.selectedPaymentMethod);
+
+        await ExtensionStorage.set("isBackFromConfirm", false);
+      }
+    }
+
+    fetchActiveQuote();
+  }, [isInitialMount]);
+
+  // ------------------------------------------------------------
+
   const [quote, setQuote] = useStorage<Object>(
     {
       key: "quote",

--- a/src/routes/popup/purchase.tsx
+++ b/src/routes/popup/purchase.tsx
@@ -51,7 +51,7 @@ export default function Purchase() {
       setSelectedFiat(quote.selectedFiat);
       setFiatAmount(quote.fiatAmount);
       setReceivedAR(quote.payout);
-      setSelectedPaymentMethod(quote.selectedPaymentMethod);
+      handlePaymentMethodChange(quote.selectedPaymentMethod);
 
       await ExtensionStorage.set("isBackFromConfirm", false);
     } else {
@@ -88,8 +88,17 @@ export default function Purchase() {
   };
 
   function handlePaymentMethodChange(methodId: string) {
+    console.log("handlePaymentMethodChange called with:", methodId);
+    console.log(
+      "Selected payment method before update:",
+      selectedPaymentMethod
+    );
     setSelectedPaymentMethod(methodId);
   }
+
+  useEffect(() => {
+    console.log("Selected payment method after update:", selectedPaymentMethod);
+  }, [selectedPaymentMethod]);
 
   useEffect(() => {
     setShowOptions(fiatSwitchOpen);
@@ -231,6 +240,7 @@ export default function Purchase() {
           </PaymentLabel>
           <InputMenu
             onPaymentMethodChange={handlePaymentMethodChange}
+            selectedPaymentMethod={selectedPaymentMethod}
             isPaymentMethod={true}
           />
         </MainSwap>

--- a/src/routes/popup/purchase.tsx
+++ b/src/routes/popup/purchase.tsx
@@ -42,11 +42,9 @@ export default function Purchase() {
 
   async function checkIsBackFromConfirm() {
     const isBack = await ExtensionStorage.get("isBackFromConfirm");
-    console.log("Back from confirm:", isBack);
 
     if (isBack === true) {
       const quote = await getActiveQuote();
-      console.log("active quote from confirm:", quote);
 
       setSelectedFiat(quote.selectedFiat);
       setFiatAmount(quote.fiatAmount);
@@ -75,30 +73,19 @@ export default function Purchase() {
     try {
       // Set the quote data in the state
       await setQuote(quoteData);
-      console.log("Quote data saved:", quoteData);
     } catch (error) {
       console.error("Error saving quote data:", error);
     }
   };
 
   const handleFiat = (currency: string) => {
-    console.log("updated currency:", currency);
     setSelectedFiat(currency); // Update the selected fiat currency
     setFiatSwitchOpen(!fiatSwitchOpen); // Close the dropdown
   };
 
   function handlePaymentMethodChange(methodId: string) {
-    console.log("handlePaymentMethodChange called with:", methodId);
-    console.log(
-      "Selected payment method before update:",
-      selectedPaymentMethod
-    );
     setSelectedPaymentMethod(methodId);
   }
-
-  useEffect(() => {
-    console.log("Selected payment method after update:", selectedPaymentMethod);
-  }, [selectedPaymentMethod]);
 
   useEffect(() => {
     setShowOptions(fiatSwitchOpen);


### PR DESCRIPTION
This PR adds a new variable to local storage to handle if the user has gone back on confirming their purchase. It retains the existing data so that the user does not have to input their previous data. The logic takes place when component mounts. 