### PR TITLE
fix: re-enable u-token transfer

### DIFF
--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -47,7 +47,11 @@ export default function Popup() {
               <Route path="/send/transfer/:id?">
                 {(params: { id?: string }) => <Send id={params?.id} />}
               </Route>
-              <Route path="/send/auth" component={SendAuth} />
+              <Route path="/send/auth/:tokenID?">
+                {(params: { tokenID: string }) => (
+                  <SendAuth tokenID={params?.tokenID} />
+                )}
+              </Route>
               <Route path="/explore" component={Explore} />
               <Route path="/unlock" component={Unlock} />
               <Route path="/tokens" component={Tokens} />

--- a/src/routes/popup/send/auth.tsx
+++ b/src/routes/popup/send/auth.tsx
@@ -286,10 +286,10 @@ export default function SendAuth({ tokenID }: Props) {
           duration: 2000
         });
         uToken
-          ? push(
+          ? push("/")
+          : push(
               `/transaction/${transaction.id}?back=${encodeURIComponent("/")}`
-            )
-          : push("/");
+            );
       } catch (e) {
         console.log(e);
         setToast({

--- a/src/routes/popup/send/index.tsx
+++ b/src/routes/popup/send/index.tsx
@@ -392,27 +392,15 @@ export default function Send({ id }: Props) {
             <ChevronRightIcon />
           </TokenSelectorRightSide>
         </TokenSelector>
-        <Tooltip
-          content={
-            token.id === "KTzTXT_ANmF84fWEKHzWURD1LWd9QaFR9yfYUwH2Lxw"
-              ? browser.i18n.getMessage("u_token_disabled")
-              : ""
-          }
+
+        <Button
+          disabled={invalidQty || parseFloat(qty) === 0 || qty === ""}
+          fullWidth
+          onClick={send}
         >
-          <Button
-            disabled={
-              invalidQty ||
-              parseFloat(qty) === 0 ||
-              qty === "" ||
-              token.id === "KTzTXT_ANmF84fWEKHzWURD1LWd9QaFR9yfYUwH2Lxw"
-            }
-            fullWidth
-            onClick={send}
-          >
-            {browser.i18n.getMessage("send")}
-            <ArrowUpRightIcon />
-          </Button>
-        </Tooltip>
+          {browser.i18n.getMessage("send")}
+          <ArrowUpRightIcon />
+        </Button>
       </BottomActions>
       <AnimatePresence>
         {showTokenSelector && (

--- a/src/routes/popup/send/index.tsx
+++ b/src/routes/popup/send/index.tsx
@@ -53,6 +53,7 @@ import Collectible from "~components/popup/Collectible";
 import { findGateway } from "~gateways/wayfinder";
 import { useHistory } from "~utils/hash_router";
 import { DREContract, DRENode } from "@arconnect/warp-dre";
+import { isUToken } from "~utils/send";
 
 // default size for the qty text
 const defaulQtytSize = 3.7;
@@ -266,6 +267,8 @@ export default function Send({ id }: Props) {
     setShownTokenSelector(false);
   }
 
+  const uToken = isUToken(tokenID);
+
   // qty text size
   const qtySize = useMemo(() => {
     const maxLengthDef = 7;
@@ -353,14 +356,16 @@ export default function Send({ id }: Props) {
           <Max onClick={() => setQty(max.toString())}>Max</Max>
         </QuantitySection>
         <Spacer y={1} />
-        <Message>
-          <Input
-            {...message.bindings}
-            type="text"
-            placeholder={browser.i18n.getMessage("send_message_optional")}
-            fullWidth
-          />
-        </Message>
+        {!uToken && (
+          <Message>
+            <Input
+              {...message.bindings}
+              type="text"
+              placeholder={browser.i18n.getMessage("send_message_optional")}
+              fullWidth
+            />
+          </Message>
+        )}
         <Spacer y={1} />
         <Datas>
           {!!price && (

--- a/src/routes/popup/send/recipient.tsx
+++ b/src/routes/popup/send/recipient.tsx
@@ -144,7 +144,7 @@ export default function Recipient({ tokenID, qty, message }: Props) {
       await TempTransactionStorage.set(TRANSFER_TX_STORAGE, storedTx);
 
       // push to auth & signature
-      push(`/send/auth`);
+      push(`/send/auth/${tokenID}`);
     } catch {
       return setToast({
         type: "error",

--- a/src/utils/send.ts
+++ b/src/utils/send.ts
@@ -1,0 +1,44 @@
+/**
+ * Checks if the provided token ID is a Test U-Token or U-Token.
+ *
+ * @param {string} tokenID - The token ID to check.
+ * @returns {boolean} Returns `true` if the token ID is a U-Token, otherwise `false`.
+ */
+
+export const isUToken = (tokenID: string) => {
+  return (
+    // Test U-TOKEN
+    tokenID === "FYJOKdtNKl18QgblxgLEZUfJMFUv6tZTQqGTtY-D6jQ" ||
+    // U-TOKEN
+    tokenID === "KTzTXT_ANmF84fWEKHzWURD1LWd9QaFR9yfYUwH2Lxw"
+  );
+};
+
+/**
+ * Sends an HTTP request for L2 token Transfers
+ *
+ * @param {RequestInit & { url: string }} config - The configuration for the Fetch request.
+ *                                                It should include the URL, method, headers, and any other relevant options.
+ * @returns {Promise<Response>} - A Promise that resolves to the response object.
+ */
+
+export const sendRequest = async (
+  config: RequestInit & { url: string }
+): Promise<Response> => {
+  try {
+    const response = await fetch(config.url, config);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    if (data !== undefined) {
+      return data;
+    } else {
+      throw new Error(`${config.url}: null response`);
+    }
+  } catch (error) {
+    throw new Error("Unknown error occurred");
+  }
+};


### PR DESCRIPTION
This PR re-enables U-Token Transfer, using `sendRequest` to send an HTTP request directly to warp 

- Message field is currently hidden on u-token transfer 
- Post-transaction, users are redirected to the home page of the wallet rather than the post-transaction screen, this is due to having to use a different endpoint to fetch tx (WIP)