### PR TITLE
ARC-233 no pricing data on dashboard

### DIFF
--- a/src/components/popup/home/Balance.tsx
+++ b/src/components/popup/home/Balance.tsx
@@ -49,6 +49,11 @@ export default function Balance() {
   const [fiat, setFiat] = useState(0);
   const [currency] = useSetting<string>("currency");
 
+  const [StoredArPrice, setStoredArPrice] = useStorage<number>({
+    key: "ArPrice",
+    instance: ExtensionStorage
+  });
+
   useEffect(() => {
     (async () => {
       if (!currency) return;
@@ -56,8 +61,13 @@ export default function Balance() {
       // fetch price in currency
       const arPrice = await getArPrice(currency);
 
-      // calculate fiat balance
-      setFiat(arPrice * balance);
+      if (arPrice === 0 || !arPrice) {
+        setFiat(StoredArPrice * balance);
+      } else {
+        // calculate fiat balance
+        setFiat(arPrice * balance);
+        setStoredArPrice(arPrice);
+      }
     })();
   }, [balance, currency]);
 


### PR DESCRIPTION
- Added useStorage hook to persistently store the last known AR price.
- Modified useEffect in Balance.tsx to use the stored price as a fallback when the API fails to fetch the current price.
- Ensured the stored price is updated with each successful API response.
- This fix ensures continuous display of fiat balance, reducing dependency on API availability.