### PR TITLE
ARC-226 make confirm password on send optional

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -391,6 +391,10 @@
     "message": "Sign notification",
     "description": "Sign notification settings title"
   },
+  "setting_sign_settings": {
+    "message": "Sign settings",
+    "description": "Sign settings title"
+  },
   "setting_display_theme": {
     "message": "Theme",
     "description": "Theme settings title"
@@ -1492,5 +1496,9 @@
   "receive_AR_button": {
     "message": "Receive AR", 
     "description": "Button text for the receive AR button"
+  },
+  "password_allowance": {
+    "message": "Password required allowance",
+    "description": "Input title for the password allowance label"
   }
 }

--- a/src/api/modules/sign/utils.ts
+++ b/src/api/modules/sign/utils.ts
@@ -2,6 +2,7 @@ import { getSetting } from "~settings";
 import { nanoid } from "nanoid";
 import type Transaction from "arweave/web/lib/transaction";
 import Application from "~applications/application";
+import { ExtensionStorage } from "~utils/storage";
 import iconUrl from "url:/assets/icon512.png";
 import browser from "webextension-polyfill";
 import Arweave from "arweave";
@@ -70,10 +71,13 @@ export async function signNotification(
   appURL: string,
   type: "sign" | "dispatch" = "sign"
 ) {
+  async function getNotificationSetting() {
+    return await ExtensionStorage.get("setting_sign_notification");
+  }
   // fetch if notification is enabled
-  const notificationSetting = getSetting("sign_notification");
+  const notificationSetting = await getNotificationSetting();
 
-  if (!(await notificationSetting.getValue())) return;
+  if (notificationSetting === "false" || !notificationSetting) return;
 
   // get gateway config
   const app = new Application(appURL);

--- a/src/components/dashboard/SignSettings.tsx
+++ b/src/components/dashboard/SignSettings.tsx
@@ -1,0 +1,72 @@
+import { useState, useEffect } from "react";
+import PermissionCheckbox from "~components/auth/PermissionCheckbox";
+import { Input, Spacer, Text } from "@arconnect/components";
+import browser from "webextension-polyfill";
+import styled from "styled-components";
+import { ExtensionStorage } from "~utils/storage";
+import { useStorage } from "@plasmohq/storage/hook";
+
+export default function SignSettings() {
+  const [signSettingsState, setSignSettingsState] = useState(false);
+
+  const [signatureAllowance, setSignatureAllowance] = useStorage(
+    {
+      key: "signatureAllowance",
+      instance: ExtensionStorage
+    },
+    () => 10
+  );
+
+  useEffect(() => {
+    async function fetchSignSettings() {
+      const currentSetting = await ExtensionStorage.get(
+        "setting_sign_notification"
+      );
+      setSignSettingsState(currentSetting !== "false");
+    }
+
+    fetchSignSettings();
+  }, []);
+
+  const toggleSignSettings = async () => {
+    const newSetting = !signSettingsState;
+    setSignSettingsState(newSetting);
+    await ExtensionStorage.set("setting_sign_notification", newSetting);
+  };
+
+  const handleAllowanceChange = (e) => {
+    const newAllowance = Number(e.target.value);
+    setSignatureAllowance(newAllowance);
+  };
+
+  return (
+    <>
+      <Wrapper>
+        <PermissionCheckbox
+          checked={signSettingsState}
+          onChange={toggleSignSettings}
+        >
+          {browser.i18n.getMessage(
+            !!signSettingsState ? "enabled" : "disabled"
+          )}
+          <br />
+          <Text noMargin>
+            {browser.i18n.getMessage("setting_sign_notification_description")}
+          </Text>
+        </PermissionCheckbox>
+        <Spacer y={1.7} />
+        <Input
+          label={browser.i18n.getMessage("password_allowance")}
+          type="number"
+          value={signatureAllowance}
+          onChange={handleAllowanceChange}
+          fullWidth
+        />
+      </Wrapper>
+    </>
+  );
+}
+
+const Wrapper = styled.div`
+  position: relative;
+`;

--- a/src/components/dashboard/SignSettings.tsx
+++ b/src/components/dashboard/SignSettings.tsx
@@ -9,13 +9,10 @@ import { useStorage } from "@plasmohq/storage/hook";
 export default function SignSettings() {
   const [signSettingsState, setSignSettingsState] = useState(false);
 
-  const [signatureAllowance, setSignatureAllowance] = useStorage(
-    {
-      key: "signatureAllowance",
-      instance: ExtensionStorage
-    },
-    () => 10
-  );
+  const [signatureAllowance, setSignatureAllowance] = useStorage({
+    key: "signatureAllowance",
+    instance: ExtensionStorage
+  });
 
   useEffect(() => {
     async function fetchSignSettings() {
@@ -34,9 +31,12 @@ export default function SignSettings() {
     await ExtensionStorage.set("setting_sign_notification", newSetting);
   };
 
-  const handleAllowanceChange = (e) => {
+  const handleAllowanceChange = async (e) => {
     const newAllowance = Number(e.target.value);
     setSignatureAllowance(newAllowance);
+
+    // Save the updated allowance to the extension storage
+    await ExtensionStorage.set("signatureAllowance", newAllowance);
   };
 
   return (

--- a/src/components/dashboard/SignSettings.tsx
+++ b/src/components/dashboard/SignSettings.tsx
@@ -15,14 +15,20 @@ export default function SignSettings() {
   });
 
   useEffect(() => {
-    async function fetchSignSettings() {
+    async function initializeSettings() {
       const currentSetting = await ExtensionStorage.get(
         "setting_sign_notification"
       );
       setSignSettingsState(currentSetting !== "false");
+
+      // Check if signatureAllowance is set, if not, initialize to 10
+      let allowance = await ExtensionStorage.get("signatureAllowance");
+      if (allowance === undefined || allowance === null) {
+        await ExtensionStorage.set("signatureAllowance", 10);
+      }
     }
 
-    fetchSignSettings();
+    initializeSettings();
   }, []);
 
   const toggleSignSettings = async () => {

--- a/src/routes/dashboard/index.tsx
+++ b/src/routes/dashboard/index.tsx
@@ -13,7 +13,8 @@ import {
   GridIcon,
   InformationIcon,
   TrashIcon,
-  WalletIcon
+  WalletIcon,
+  BellIcon
 } from "@iconicicons/react";
 import WalletSettings from "~components/dashboard/subsettings/WalletSettings";
 import TokenSettings from "~components/dashboard/subsettings/TokenSettings";
@@ -30,6 +31,7 @@ import browser from "webextension-polyfill";
 import styled from "styled-components";
 import settings from "~settings";
 import { PageType, trackPage } from "~utils/analytics";
+import SignSettings from "~components/dashboard/SignSettings";
 
 export default function Settings({ params }: Props) {
   // router location
@@ -242,6 +244,13 @@ const allSettings: Omit<Setting, "active">[] = [
     description: "setting_tokens_description",
     icon: TicketIcon,
     component: Tokens
+  },
+  {
+    name: "sign_notification",
+    displayName: "setting_sign_settings",
+    description: "setting_sign_notification_description",
+    icon: BellIcon,
+    component: SignSettings
   },
   ...settings.map((setting) => ({
     name: setting.name,

--- a/src/routes/popup/send/auth.tsx
+++ b/src/routes/popup/send/auth.tsx
@@ -178,20 +178,24 @@ export default function SendAuth({ tokenID }: Props) {
   async function sendLocal() {
     setLoading(true);
 
-    // Retrieve latest transaction details from localStorage
-    const latestTxJSON = localStorage.getItem("latest_tx");
-    if (!latestTxJSON) {
+    // Retrieve latest tx amount details from localStorage
+    const latestTxQty = await ExtensionStorage.get("last_send_qty");
+    if (!latestTxQty) {
       setLoading(false);
       return setToast({
         type: "error",
-        content: "No transaction found",
+        content: "No send quantity found",
         duration: 2000
       });
     }
-    const latestTx = JSON.parse(latestTxJSON);
 
-    // Parse the transaction quantity
-    const transactionAmount = latestTx.quantity.ar;
+    console.log(typeof latestTxQty);
+
+    console.log(latestTxQty);
+
+    const transactionAmount = Number(latestTxQty);
+
+    console.log(transactionAmount);
 
     // get tx and gateway
     let { type, gateway, transaction } = await getTransaction();
@@ -199,6 +203,14 @@ export default function SendAuth({ tokenID }: Props) {
 
     const decryptedWallet = await getActiveKeyfile();
     isLocalWallet(decryptedWallet);
+
+    console.log(
+      "transaction amount:",
+      transactionAmount,
+      "vs.",
+      "sign allowance:",
+      signAllowance
+    );
 
     // Check if the transaction amount is less than the signature allowance
     if (transactionAmount <= signAllowance) {

--- a/src/routes/popup/send/auth.tsx
+++ b/src/routes/popup/send/auth.tsx
@@ -1,7 +1,8 @@
 import {
   type RawStoredTransfer,
   TempTransactionStorage,
-  TRANSFER_TX_STORAGE
+  TRANSFER_TX_STORAGE,
+  ExtensionStorage
 } from "~utils/storage";
 import { concatGatewayURL } from "~gateways/utils";
 import { decodeSignature, transactionToUR } from "~wallets/hardware/keystone";
@@ -13,7 +14,7 @@ import { useScanner } from "@arconnect/keystone-sdk";
 import { useActiveWallet } from "~wallets/hooks";
 import { useHistory } from "~utils/hash_router";
 import { useEffect, useState } from "react";
-import { getActiveWallet } from "~wallets";
+import { getActiveKeyfile, getActiveWallet } from "~wallets";
 import type { UR } from "@ngraveio/bc-ur";
 import {
   Button,
@@ -39,6 +40,7 @@ import {
   type Gateway
 } from "~gateways/gateway";
 import { isUToken, sendRequest } from "~utils/send";
+import { isLocalWallet } from "~utils/assertions";
 import { EventType, trackEvent } from "~utils/analytics";
 interface Props {
   tokenID?: string;
@@ -46,6 +48,16 @@ interface Props {
 export default function SendAuth({ tokenID }: Props) {
   // loading
   const [loading, setLoading] = useState(false);
+
+  const [signAllowance, setSignAllowance] = useState<number>(10);
+
+  useEffect(() => {
+    const fetchSignAllowance = async () => {
+      const allowance = await ExtensionStorage.get("signatureAllowance");
+      setSignAllowance(Number(allowance));
+    };
+    fetchSignAllowance();
+  }, []);
 
   // password input
   const passwordInput = useInput();
@@ -166,73 +178,124 @@ export default function SendAuth({ tokenID }: Props) {
   async function sendLocal() {
     setLoading(true);
 
+    // Retrieve latest transaction details from localStorage
+    const latestTxJSON = localStorage.getItem("latest_tx");
+    if (!latestTxJSON) {
+      setLoading(false);
+      return setToast({
+        type: "error",
+        content: "No transaction found",
+        duration: 2000
+      });
+    }
+    const latestTx = JSON.parse(latestTxJSON);
+
+    // Parse the transaction quantity
+    const transactionAmount = latestTx.quantity.ar;
+
     // get tx and gateway
     let { type, gateway, transaction } = await getTransaction();
     const arweave = new Arweave(gateway);
 
-    // decrypt wallet
-    const activeWallet = await getActiveWallet();
+    const decryptedWallet = await getActiveKeyfile();
+    isLocalWallet(decryptedWallet);
 
-    if (activeWallet.type === "hardware") {
-      return setLoading(false);
-    }
-
-    let keyfile: JWKInterface;
-
-    try {
-      keyfile = await decryptWallet(activeWallet.keyfile, passwordInput.state);
-    } catch {
-      setLoading(false);
-      return setToast({
-        type: "error",
-        content: browser.i18n.getMessage("invalidPassword"),
-        duration: 2000
-      });
-    }
-
-    // set owner
-    transaction.setOwner(keyfile.n);
-
-    try {
-      // sign
-      await arweave.transactions.sign(transaction, keyfile);
-
-      // post tx
+    // Check if the transaction amount is less than the signature allowance
+    if (transactionAmount <= signAllowance) {
+      // Process transaction without user signing
       try {
-        await submitTx(transaction, arweave, type);
-      } catch (e) {
-        if (!uToken) {
-          // FALLBACK IF ISP BLOCKS ARWEAVE.NET OR IF WAYFINDER FAILS
-          gateway = fallbackGateway;
-          const fallbackArweave = new Arweave(gateway);
-          await fallbackArweave.transactions.sign(transaction, keyfile);
-          await submitTx(transaction, fallbackArweave, type);
-          await trackEvent(EventType.FALLBACK, {});
-        }
-      }
-      setToast({
-        type: "success",
-        content: browser.i18n.getMessage("sent_tx"),
-        duration: 2000
-      });
-      uToken
-        ? push("/")
-        : push(
-            `/transaction/${transaction.id}/${encodeURIComponent(
-              concatGatewayURL(gateway)
-            )}?back=${encodeURIComponent("/")}`
-          );
-    } catch (e) {
-      console.error(e);
-      setToast({
-        type: "error",
-        content: browser.i18n.getMessage("failed_tx"),
-        duration: 2000
-      });
-    }
+        // Decrypt wallet without user input
+        const keyfile = decryptedWallet.keyfile;
 
-    // remove wallet from memory
-    freeDecryptedWallet(keyfile);
+        // Set owner
+        transaction.setOwner(keyfile.n);
+
+        // Sign the transaction
+        await arweave.transactions.sign(transaction, keyfile);
+
+        // Post the transaction
+        await submitTx(transaction, arweave, type);
+
+        // Success toast
+        setToast({
+          type: "success",
+          content: browser.i18n.getMessage("sent_tx"),
+          duration: 2000
+        });
+
+        // Redirect
+        uToken
+          ? push("/")
+          : push(
+              `/transaction/${transaction.id}?back=${encodeURIComponent("/")}`
+            );
+
+        // remove wallet from memory
+        freeDecryptedWallet(keyfile);
+      } catch (e) {
+        console.log(e);
+        setToast({
+          type: "error",
+          content: browser.i18n.getMessage("failed_tx"),
+          duration: 2000
+        });
+      }
+    } else {
+      // decrypt wallet
+      const activeWallet = await getActiveWallet();
+
+      if (activeWallet.type === "hardware") {
+        return setLoading(false);
+      }
+
+      let keyfile: JWKInterface;
+
+      try {
+        keyfile = await decryptWallet(
+          activeWallet.keyfile,
+          passwordInput.state
+        );
+      } catch {
+        setLoading(false);
+        return setToast({
+          type: "error",
+          content: browser.i18n.getMessage("invalidPassword"),
+          duration: 2000
+        });
+      }
+
+      // set owner
+      transaction.setOwner(keyfile.n);
+
+      try {
+        // sign
+        await arweave.transactions.sign(transaction, keyfile);
+
+        // post tx
+        await submitTx(transaction, arweave, type);
+
+        setToast({
+          type: "success",
+          content: browser.i18n.getMessage("sent_tx"),
+          duration: 2000
+        });
+        uToken
+          ? push("/")
+          : push(
+              `/transaction/${transaction.id}?back=${encodeURIComponent("/")}`
+            );
+
+        // remove wallet from memory
+        freeDecryptedWallet(keyfile);
+      } catch (e) {
+        console.log(e);
+        setToast({
+          type: "error",
+          content: browser.i18n.getMessage("failed_tx"),
+          duration: 2000
+        });
+      }
+    }
 
     setLoading(false);
   }

--- a/src/routes/popup/send/auth.tsx
+++ b/src/routes/popup/send/auth.tsx
@@ -219,8 +219,19 @@ export default function SendAuth({ tokenID }: Props) {
         // Sign the transaction
         await arweave.transactions.sign(transaction, keyfile);
 
-        // Post the transaction
-        await submitTx(transaction, arweave, type);
+        try {
+          // Post the transaction
+          await submitTx(transaction, arweave, type);
+        } catch (e) {
+          if (!uToken) {
+            // FALLBACK IF ISP BLOCKS ARWEAVE.NET OR IF WAYFINDER FAILS
+            gateway = fallbackGateway;
+            const fallbackArweave = new Arweave(gateway);
+            await fallbackArweave.transactions.sign(transaction, keyfile);
+            await submitTx(transaction, fallbackArweave, type);
+            await trackEvent(EventType.FALLBACK, {});
+          }
+        }
 
         // Success toast
         setToast({
@@ -277,8 +288,19 @@ export default function SendAuth({ tokenID }: Props) {
         // sign
         await arweave.transactions.sign(transaction, keyfile);
 
-        // post tx
-        await submitTx(transaction, arweave, type);
+        try {
+          // post tx
+          await submitTx(transaction, arweave, type);
+        } catch (e) {
+          if (!uToken) {
+            // FALLBACK IF ISP BLOCKS ARWEAVE.NET OR IF WAYFINDER FAILS
+            gateway = fallbackGateway;
+            const fallbackArweave = new Arweave(gateway);
+            await fallbackArweave.transactions.sign(transaction, keyfile);
+            await submitTx(transaction, fallbackArweave, type);
+            await trackEvent(EventType.FALLBACK, {});
+          }
+        }
 
         setToast({
           type: "success",

--- a/src/routes/popup/send/auth.tsx
+++ b/src/routes/popup/send/auth.tsx
@@ -189,13 +189,7 @@ export default function SendAuth({ tokenID }: Props) {
       });
     }
 
-    console.log(typeof latestTxQty);
-
-    console.log(latestTxQty);
-
     const transactionAmount = Number(latestTxQty);
-
-    console.log(transactionAmount);
 
     // get tx and gateway
     let { type, gateway, transaction } = await getTransaction();

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -51,14 +51,14 @@ const settings: Setting[] = [
     type: "number",
     defaultValue: 60
   }),*/
-  new Setting({
-    name: "sign_notification",
-    displayName: "setting_sign_notification",
-    icon: BellIcon,
-    description: "setting_sign_notification_description",
-    type: "boolean",
-    defaultValue: true
-  }),
+  // new Setting({
+  //   name: "sign_notification",
+  //   displayName: "setting_sign_notification",
+  //   icon: BellIcon,
+  //   description: "setting_sign_notification_description",
+  //   type: "boolean",
+  //   defaultValue: true
+  // }),
   new Setting({
     name: "display_theme",
     displayName: "setting_display_theme",


### PR DESCRIPTION
Updates:
- Created a new setting called Sign settings
- Existing Notify when signing a transaction setting functions as before
- New sub-setting called Password Required Allowance has been created with an initial value of 10
- The user can update the value, and that value will persist

Current UX:
- The user can click the Send button without having to input their password if the transaction amount is below the signature allowance.
- The user is required to input their password if the transaction amount is at or above the signature allowance.

UX Development to be continued:
- Send Screen 2 - Confirm transaction screen by @nicholaswma 
- Incorporates new UI to include the password input or not depending on the transaction amount vs. signature allowance amount.