### PR TITLE
fix: disables ar balance to record on update, manually sets timer

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -163,6 +163,11 @@ export const trackBalance = async (alarmInfo?: Alarms.Alarm) => {
   );
   try {
     await trackDirect(EventType.BALANCE, { totalBalance });
+    const timer = setToNextMonth(new Date());
+    await ExtensionStorage.set(`balance_tracker`, timer.getTime());
+    browser.alarms.create("track-balance", {
+      when: timer.getTime()
+    });
   } catch (err) {
     console.log("err tracking", err);
   }
@@ -170,11 +175,31 @@ export const trackBalance = async (alarmInfo?: Alarms.Alarm) => {
 
 export const initializeARBalanceMonitor = async () => {
   // schedule monthly alarm
-  const oneMonthInMinutes = 30 * 24 * 60;
-  browser.alarms.create("track-balance", {
-    periodInMinutes: oneMonthInMinutes
-  });
+  const alarm = await ExtensionStorage.get(`balance_tracker`);
 
-  // trigger tracker
-  await trackBalance();
+  if (alarm) {
+    const time = new Date(alarm);
+    browser.alarms.create("track-balance", {
+      when: time.getTime()
+    });
+  } else {
+    const timer = setToNextMonth(new Date());
+
+    browser.alarms.create("track-balance", {
+      when: timer.getTime()
+    });
+    await ExtensionStorage.set(`balance_tracker`, timer.getTime());
+  }
+};
+
+const setToNextMonth = (currentDate: Date): Date => {
+  const newDate = new Date(currentDate.getTime());
+  const currentMonth = newDate.getMonth();
+  newDate.setMonth(currentMonth + 1);
+
+  if (newDate.getMonth() !== (currentMonth + 1) % 12) {
+    newDate.setDate(0);
+  }
+
+  return newDate;
 };


### PR DESCRIPTION
- Previously, we've triggered an analytics call upon installation/update
- Removed that `await trackBalance();` on installation
- Manually updating alarms in Chrome (updates don't persist alarm states) and using storage to keep track of the monthly calls