### PR TITLE
Fix expanded view url on first open

### DIFF
--- a/src/components/popup/WalletHeader.tsx
+++ b/src/components/popup/WalletHeader.tsx
@@ -84,7 +84,7 @@ export default function WalletHeader() {
 
   // expand view
   const expandView: MouseEventHandler = (e) => {
-    window.open(window.document.URL + "?expanded=true");
+    window.open(window.location.href.split("#")[0] + "?expanded=true");
   };
 
   // is the popup open in a tab


### PR DESCRIPTION
This PR fixes a small bug that only happens after first installing the extension and clicking expanded view first, where the url would contain a `#` that would not let the full page view render.