### PR TITLE
fix: abbreviate large numbers

### DIFF
--- a/src/components/popup/Token.tsx
+++ b/src/components/popup/Token.tsx
@@ -92,11 +92,11 @@ export default function Token({ onClick, ...props }: Props) {
       </LogoAndDetails>
       <BalanceSection>
         {isMillion ? (
-          <TooltipV2 content={totalBalance} position="left">
-            <NativeBalance>
+          <BalanceTooltip content={totalBalance} position="topEnd">
+            <NativeBalance style={{}}>
               {balance} {props.ticker}
             </NativeBalance>
-          </TooltipV2>
+          </BalanceTooltip>
         ) : (
           <NativeBalance>
             {balance} {props.ticker}
@@ -128,6 +128,10 @@ const Wrapper = styled.div`
   &:active {
     transform: scale(0.98);
   }
+`;
+
+const BalanceTooltip = styled(TooltipV2)`
+  margin-right: 1rem;
 `;
 
 const Image = styled.img`

--- a/src/components/popup/Token.tsx
+++ b/src/components/popup/Token.tsx
@@ -22,6 +22,7 @@ import { defaultGateway } from "~gateways/gateway";
 import { useGateway } from "~gateways/wayfinder";
 import aoLogo from "url:/assets/ecosystem/ao-logo.svg";
 import { getUserAvatar } from "~lib/avatar";
+import { abbreviateNumber } from "~utils/format";
 
 export default function Token({ onClick, ...props }: Props) {
   // display theme
@@ -38,17 +39,18 @@ export default function Token({ onClick, ...props }: Props) {
     [props]
   );
 
-  const balance = useMemo(
-    () => formatTokenBalance(fractBalance),
-    [fractBalance]
-  );
+  const balance = useMemo(() => {
+    const formattedBalance = formatTokenBalance(fractBalance);
+    const numBalance = parseFloat(formattedBalance.replace(/,/g, ""));
+    return abbreviateNumber(numBalance);
+  }, [fractBalance]);
 
   // token price
   const { price, currency } = usePrice(props.ticker);
 
   // fiat balance
   const fiatBalance = useMemo(() => {
-    if (!price) return "--";
+    if (!price) return <div />;
 
     const estimate = fractBalance * price;
 
@@ -70,6 +72,10 @@ export default function Token({ onClick, ...props }: Props) {
       }
     })();
   }, [props, theme, logo]);
+
+  useEffect(() => {
+    console.log("balance:", balance);
+  }, [balance]);
 
   return (
     <Wrapper onClick={onClick}>

--- a/src/components/popup/Token.tsx
+++ b/src/components/popup/Token.tsx
@@ -8,7 +8,7 @@ import { hoverEffect, useTheme } from "~utils/theme";
 import { loadTokenLogo, type Token } from "~tokens/token";
 import { useStorage } from "@plasmohq/storage/hook";
 import { ExtensionStorage } from "~utils/storage";
-import { Text } from "@arconnect/components";
+import { Text, TooltipV2 } from "@arconnect/components";
 import { getArPrice } from "~lib/coingecko";
 import { usePrice } from "~lib/redstone";
 import arLogoLight from "url:/assets/ar/logo_light.png";
@@ -25,6 +25,7 @@ import { getUserAvatar } from "~lib/avatar";
 import { abbreviateNumber } from "~utils/format";
 
 export default function Token({ onClick, ...props }: Props) {
+  const [totalBalance, setTotalBalance] = useState("");
   // display theme
   const theme = useTheme();
 
@@ -41,6 +42,7 @@ export default function Token({ onClick, ...props }: Props) {
 
   const balance = useMemo(() => {
     const formattedBalance = formatTokenBalance(fractBalance);
+    setTotalBalance(formattedBalance);
     const numBalance = parseFloat(formattedBalance.replace(/,/g, ""));
     return abbreviateNumber(numBalance);
   }, [fractBalance]);
@@ -87,9 +89,11 @@ export default function Token({ onClick, ...props }: Props) {
         {props?.ao && <Image src={aoLogo} alt="ao logo" />}
       </LogoAndDetails>
       <BalanceSection>
-        <NativeBalance>
-          {balance} {props.ticker}
-        </NativeBalance>
+        <TooltipV2 content={`${totalBalance} ${props.ticker}`} position="left">
+          <NativeBalance>
+            {balance} {props.ticker}
+          </NativeBalance>
+        </TooltipV2>
         <FiatBalance>{fiatBalance}</FiatBalance>
       </BalanceSection>
     </Wrapper>

--- a/src/components/popup/Token.tsx
+++ b/src/components/popup/Token.tsx
@@ -26,6 +26,7 @@ import { abbreviateNumber } from "~utils/format";
 
 export default function Token({ onClick, ...props }: Props) {
   const [totalBalance, setTotalBalance] = useState("");
+  const [isMillion, setIsMillion] = useState(false);
   // display theme
   const theme = useTheme();
 
@@ -44,6 +45,7 @@ export default function Token({ onClick, ...props }: Props) {
     const formattedBalance = formatTokenBalance(fractBalance);
     setTotalBalance(formattedBalance);
     const numBalance = parseFloat(formattedBalance.replace(/,/g, ""));
+    setIsMillion(numBalance >= 1_000_000);
     return abbreviateNumber(numBalance);
   }, [fractBalance]);
 
@@ -89,11 +91,18 @@ export default function Token({ onClick, ...props }: Props) {
         {props?.ao && <Image src={aoLogo} alt="ao logo" />}
       </LogoAndDetails>
       <BalanceSection>
-        <TooltipV2 content={`${totalBalance} ${props.ticker}`} position="left">
+        {isMillion ? (
+          <TooltipV2 content={totalBalance} position="left">
+            <NativeBalance>
+              {balance} {props.ticker}
+            </NativeBalance>
+          </TooltipV2>
+        ) : (
           <NativeBalance>
             {balance} {props.ticker}
           </NativeBalance>
-        </TooltipV2>
+        )}
+
         <FiatBalance>{fiatBalance}</FiatBalance>
       </BalanceSection>
     </Wrapper>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -73,3 +73,34 @@ export const formatSettingName = (name: string) => {
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(" ");
 };
+
+/**
+ * Abbreviates large numbers into a more readable format, using M, B, and T for millions, billions, and trillions respectively.
+ *
+ * @param value The numeric value to abbreviate, as a number or string.
+ * @returns The abbreviated string representation of the number.
+ */
+export function abbreviateNumber(value: number): string {
+  let suffix = "";
+  let abbreviatedValue = value;
+
+  if (value >= 1e12) {
+    // Trillions
+    suffix = "T";
+    abbreviatedValue = value / 1e12;
+  } else if (value >= 1e9) {
+    // Billions
+    suffix = "B";
+    abbreviatedValue = value / 1e9;
+  } else if (value >= 1e6) {
+    // Millions
+    suffix = "M";
+    abbreviatedValue = value / 1e6;
+  }
+
+  if (abbreviatedValue % 1 === 0) {
+    return `${abbreviatedValue}${suffix}`;
+  } else {
+    return `${abbreviatedValue.toFixed(1)}${suffix}`;
+  }
+}


### PR DESCRIPTION
- adds M for millions, B for billions, T for trillions to tokens on homepage. 
- cleans up placeholder for no fiat value