### PR TITLE
fix: Ensure transfer quantity is integer and make estimated network fee as USD

### DIFF
--- a/src/routes/popup/send/confirm.tsx
+++ b/src/routes/popup/send/confirm.tsx
@@ -182,7 +182,7 @@ export default function Confirm({ tokenID, qty }: Props) {
           quantity: "0"
         });
 
-        const qty = fractionedToBalance(Number(amount), token);
+        const qty = +fractionedToBalance(amount, token, "WARP");
 
         tx.addTag("App-Name", "SmartWeaveAction");
         tx.addTag("App-Version", "0.3.0");
@@ -201,9 +201,7 @@ export default function Confirm({ tokenID, qty }: Props) {
       } else {
         const tx = await arweave.createTransaction({
           target,
-          quantity: Math.floor(
-            fractionedToBalance(Number(amount), token)
-          ).toString(),
+          quantity: fractionedToBalance(amount, token, "AR"),
           data: message ? decodeURIComponent(message) : undefined
         });
 
@@ -338,7 +336,7 @@ export default function Confirm({ tokenID, qty }: Props) {
           ao,
           tokenID,
           recipient.address,
-          Math.floor(fractionedToBalance(Number(amount), token)).toString()
+          fractionedToBalance(amount, token, "AO")
         );
         if (res) {
           setToast({

--- a/src/routes/popup/send/confirm.tsx
+++ b/src/routes/popup/send/confirm.tsx
@@ -182,6 +182,8 @@ export default function Confirm({ tokenID, qty }: Props) {
           quantity: "0"
         });
 
+        const qty = fractionedToBalance(Number(amount), token);
+
         tx.addTag("App-Name", "SmartWeaveAction");
         tx.addTag("App-Version", "0.3.0");
         tx.addTag("Contract", tokenID);
@@ -190,7 +192,7 @@ export default function Confirm({ tokenID, qty }: Props) {
           JSON.stringify({
             function: "transfer",
             target: target,
-            qty: fractionedToBalance(Number(amount), token)
+            qty: uToken ? Math.floor(qty) : qty
           })
         );
         addTransferTags(tx);
@@ -336,7 +338,7 @@ export default function Confirm({ tokenID, qty }: Props) {
           ao,
           tokenID,
           recipient.address,
-          fractionedToBalance(Number(amount), token).toString()
+          Math.floor(fractionedToBalance(Number(amount), token)).toString()
         );
         if (res) {
           setToast({

--- a/src/routes/popup/send/confirm.tsx
+++ b/src/routes/popup/send/confirm.tsx
@@ -199,7 +199,9 @@ export default function Confirm({ tokenID, qty }: Props) {
       } else {
         const tx = await arweave.createTransaction({
           target,
-          quantity: fractionedToBalance(Number(amount), token).toString(),
+          quantity: Math.floor(
+            fractionedToBalance(Number(amount), token)
+          ).toString(),
           data: message ? decodeURIComponent(message) : undefined
         });
 

--- a/src/routes/popup/send/index.tsx
+++ b/src/routes/popup/send/index.tsx
@@ -378,11 +378,15 @@ export default function Send({ id }: Props) {
     // check qty
     if (invalidQty || qty === "" || Number(qty) === 0) return;
 
-    const finalQty = fractionedToBalance(Number(qty), {
-      id: token.id,
-      decimals: token.decimals,
-      divisibility: token.divisibility
-    });
+    const finalQty = fractionedToBalance(
+      qty,
+      {
+        id: token.id,
+        decimals: token.decimals,
+        divisibility: token.divisibility
+      },
+      token.id === "AR" ? "AR" : isAo ? "AO" : "WARP"
+    );
 
     await TempTransactionStorage.set("send", {
       networkFee,

--- a/src/tokens/currency.ts
+++ b/src/tokens/currency.ts
@@ -111,16 +111,43 @@ export function balanceToFractioned(
  * the units used by the contract.
  */
 export function fractionedToBalance(
-  balance: number,
-  cfg: DivisibilityOrDecimals
+  balance: string,
+  cfg: DivisibilityOrDecimals,
+  tokenType: "WARP" | "AO" | "AR"
 ) {
-  if (!balance) return 0;
+  if (!balance) return "0";
 
   // parse decimals
   const decimals = getDecimals(cfg);
 
-  // multiply fractioned balance using the decimals
-  return balance * Math.pow(10, decimals);
+  if (tokenType !== "WARP") {
+    // Convert balance to a string to avoid precision issues
+    const balanceStr = balance.toString();
+
+    // Split the balance into integer and fractional parts
+    const [integerPart, fractionalPart = ""] = balanceStr.split(".");
+
+    // Calculate the number of fractional digits
+    const fractionalDigits = fractionalPart.length;
+
+    let combined: string;
+    if (fractionalDigits > decimals) {
+      // Truncate the fractional part to fit the specified number of decimals
+      const truncatedFractionalPart = fractionalPart.slice(0, decimals);
+      combined = integerPart + truncatedFractionalPart;
+    } else {
+      // Combine integer and fractional parts into a single string
+      combined = integerPart + fractionalPart.padEnd(decimals, "0");
+    }
+
+    // Convert the combined string to a BigInt
+    const result = BigInt(combined);
+
+    // Return the result as a string to avoid exponential notation
+    return result.toString();
+  } else {
+    return (+balance * Math.pow(10, decimals)).toString();
+  }
 }
 
 export interface DivisibilityOrDecimals {


### PR DESCRIPTION
## Summary

This PR ensures that the AR transfer amount is always a integer value. Also, now we calculate the exact fees that is needed for the AR transfer with showing the estimated  network fees as USD.

**Questions:** 
- Was `dummyTarget` used so that we have some AR left after sending all the AR using `Max` ?
- The accepted transfer quantity can be a integer or float depending on the different tokens. When using the max or manual input sometimes the quantity can be a float value and can cause the transfer to fail when the token only accept the integer value. Any thoughts on how we can handle this ?