### PR TITLE
fix: Disabled allowance bug

### DIFF
--- a/src/api/modules/dispatch/allowance.ts
+++ b/src/api/modules/dispatch/allowance.ts
@@ -6,11 +6,14 @@ import type { JWKInterface } from "warp-contracts";
 import { allowanceAuth } from "../sign/allowance";
 import { signAuth } from "../sign/sign_auth";
 import Arweave from "arweave";
+import type { DataItem } from "arbundles";
+import type Transaction from "arweave/web/lib/transaction";
 
 /**
  * Ensure allowance for dispatch
  */
 export async function ensureAllowanceDispatch(
+  dataEntry: DataItem | Transaction,
   appData: ModuleAppData,
   allowance: Allowance,
   keyfile: JWKInterface,

--- a/src/api/modules/dispatch/dispatch.background.ts
+++ b/src/api/modules/dispatch/dispatch.background.ts
@@ -90,6 +90,7 @@ const background: ModuleFunction<ReturnType> = async (
     const price = await getPrice(dataEntry, await app.getBundler());
 
     await ensureAllowanceDispatch(
+      dataEntry,
       appData,
       allowance,
       decryptedWallet.keyfile,
@@ -127,6 +128,7 @@ const background: ModuleFunction<ReturnType> = async (
 
     // ensure allowance
     await ensureAllowanceDispatch(
+      transaction,
       appData,
       allowance,
       decryptedWallet.keyfile,

--- a/src/api/modules/sign/transaction_builder.ts
+++ b/src/api/modules/sign/transaction_builder.ts
@@ -71,6 +71,25 @@ export function deconstructTransaction(transaction: Transaction) {
 }
 
 /**
+ * Get Data size from transaction chunks
+ *
+ * @param chunks Chunks to reconstruct the transaction with
+ *
+ * @returns Data size
+ */
+export function getDataSize(chunks: Chunk[]): number {
+  let dataSize = 0;
+
+  for (const chunk of chunks) {
+    if (chunk.type === "data") {
+      dataSize += chunk.value?.length || 0;
+    }
+  }
+
+  return dataSize;
+}
+
+/**
  * Construct a transaction from a split transaction
  * and it's chunks
  *
@@ -93,9 +112,8 @@ export function constructTransaction(
   chunks.sort((a, b) => a.index - b.index);
 
   // create a Uint8Array to reconstruct the data to
-  const reconstructedData = new Uint8Array(
-    parseFloat(splitTransaction.data_size ?? "0")
-  );
+  const dataSize = getDataSize(chunks);
+  const reconstructedData = new Uint8Array(dataSize);
 
   // previous buffer length in bytes (gets updated
   // in the loop below)

--- a/src/routes/auth/sign.tsx
+++ b/src/routes/auth/sign.tsx
@@ -134,12 +134,10 @@ export default function Sign() {
 
   // transaction size
   const size = useMemo(() => {
-    if (!params?.transaction?.size) {
-      return 0;
-    }
+    if (!transaction) return 0;
 
-    return Number(params.transaction.size);
-  }, [params]);
+    return transaction.data.length;
+  }, [transaction]);
 
   // authorize
   async function authorize(data?: any) {


### PR DESCRIPTION
## Summary

This PR fixes the following issues:

- Eliminates continuous loading in AO transaction popup when allowance is disabled.
- Ensures dispatch transactions succeed even when allowance is disabled.
- Displays correct transaction size in the popup.

## How to Test

Disable allowance and test doing AO transactions and dispatch transactions on any Dapp using this PR branch built ArConnect and the ArConnect from ChromeStore. Also, check the transaction size on the popup.