### PR TITLE
fix: pw expiration for hardware wallets

### DIFF
--- a/src/routes/welcome/load/wallets.tsx
+++ b/src/routes/welcome/load/wallets.tsx
@@ -22,6 +22,7 @@ import SeedInput from "~components/SeedInput";
 import Paragraph from "~components/Paragraph";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
+import { addExpiration } from "~wallets/auth";
 
 export default function Wallets() {
   // password context
@@ -132,6 +133,7 @@ export default function Wallets() {
 
         // add wallet
         await addWallet(jwk, password);
+        await addExpiration();
       } else if (existingWallets.length < 1) {
         // the user has not migrated, so they need to add a wallet
         return finishUp();
@@ -157,6 +159,7 @@ export default function Wallets() {
     // we need this because we don't
     // have any other wallets added yet
     await setActiveWallet(account.address);
+    await addExpiration();
 
     // redirect
     setLocation(`/${params.setup}/${Number(params.page) + 1}`);

--- a/src/wallets/index.ts
+++ b/src/wallets/index.ts
@@ -266,9 +266,6 @@ export async function addWallet(
   if (freshInstall) {
     await ExtensionStorage.set("active_address", wallets[0].address);
   }
-
-  // add expiration date if needed
-  await addExpiration();
 }
 
 /**


### PR DESCRIPTION
- Small bug where adding a keystone wallet first doesn't trigger an expiration and users are then forced to change their pw after onboarding