### PR TITLE
refactor: Remove token ticker beside token balance in token listing

### DIFF
--- a/src/components/popup/Token.tsx
+++ b/src/components/popup/Token.tsx
@@ -108,12 +108,12 @@ export default function Token({ onClick, ...props }: Props) {
             {isMillion ? (
               <BalanceTooltip content={totalBalance} position="topEnd">
                 <NativeBalance>
-                  {props.ao ? props.balance : balance} {props.ticker}
+                  {props.ao ? props.balance : balance}
                 </NativeBalance>
               </BalanceTooltip>
             ) : (
               <NativeBalance>
-                {props.ao ? props.balance : balance} {props.ticker}
+                {props.ao ? props.balance : balance}
               </NativeBalance>
             )}
           </>


### PR DESCRIPTION
## Summary

This PR removes the token ticker beside token balance from the token listing in `Dashboard`, `View all` and `Currency selection` in Send page.

<img src="https://github.com/arconnectio/ArConnect/assets/11836100/cabb25cb-68ed-4f97-a5b9-1676348cdde4" width="400">
<img src="https://github.com/arconnectio/ArConnect/assets/11836100/35770e8c-3ca6-44db-bc9e-59a4fd3764a4" width="400">