### PR TITLE
fix: Patch issue with Worker to fix connecting keystone

### DIFF
--- a/src/components/hardware/KeystoneButton.tsx
+++ b/src/components/hardware/KeystoneButton.tsx
@@ -3,6 +3,7 @@ import {
   type KeystoneAccount
 } from "~wallets/hardware/keystone";
 import { addHardwareWallet } from "~wallets/hardware";
+import { usePatchWorker } from "~wallets/hardware/hooks";
 import { useScanner } from "@arconnect/keystone-sdk";
 import {
   Alert,
@@ -81,6 +82,9 @@ export default function KeystoneButton({ onSuccess }: Props) {
 
     cancel();
   });
+
+  // Patch Worker
+  usePatchWorker();
 
   return (
     <>

--- a/src/wallets/hardware/hooks.ts
+++ b/src/wallets/hardware/hooks.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from "react";
+
+export function usePatchWorker() {
+  const initialWorkerRef = useRef<typeof Worker | null>(window.Worker);
+
+  useEffect(() => {
+    if (window.Worker && !initialWorkerRef.current) {
+      initialWorkerRef.current = window.Worker;
+    }
+
+    if (!window.Worker && initialWorkerRef.current) {
+      window.Worker = initialWorkerRef.current;
+    }
+  }, [window.Worker]);
+}


### PR DESCRIPTION
## Summary

This PR fixes issue with Worker being undefined while connecting keystone in Add wallet page.

`Worker` changes from `ƒ Worker() { [native code] }` to `undefined` to `ƒ Worker() { [native code] }` so Worker is `undefined` while clicking the Connect Keystone button immediately.

![image](https://github.com/arconnectio/ArConnect/assets/11836100/f0285a04-57b2-445e-a43b-df6e1cd3ab18)

@nicholaswma Please check if connecting Keystone works fine with this approach.