### PR TITLE
fix: Initialize storage values with defaults to prevent errors

### DIFF
--- a/src/tokens/aoTokens/ao.ts
+++ b/src/tokens/aoTokens/ao.ts
@@ -98,10 +98,13 @@ export function useAoTokens(): [TokenInfoWithBalance[], boolean] {
     instance: ExtensionStorage
   });
 
-  const [aoTokens] = useStorage<any[]>({
-    key: "ao_tokens",
-    instance: ExtensionStorage
-  });
+  const [aoTokens] = useStorage<any[]>(
+    {
+      key: "ao_tokens",
+      instance: ExtensionStorage
+    },
+    []
+  );
 
   // fetch token infos
   useEffect(() => {
@@ -183,10 +186,13 @@ export function useAoTokensCache(): [TokenInfoWithBalance[], boolean] {
     instance: ExtensionStorage
   });
 
-  const [aoTokens] = useStorage<(TokenInfo & { processId: string })[]>({
-    key: "ao_tokens",
-    instance: ExtensionStorage
-  });
+  const [aoTokens] = useStorage<(TokenInfo & { processId: string })[]>(
+    {
+      key: "ao_tokens",
+      instance: ExtensionStorage
+    },
+    []
+  );
 
   const [aoTokensCache] = useStorage<(TokenInfo & { processId: string })[]>(
     { key: "ao_tokens_cache", instance: ExtensionStorage },

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -3,6 +3,7 @@ import browser, { type Runtime, type Storage } from "webextension-polyfill";
 import { initializeARBalanceMonitor } from "./analytics";
 import { loadTokens } from "~tokens/token";
 import { getActiveAddress, getWallets } from "~wallets";
+import { ExtensionStorage } from "./storage";
 
 export const isManifestv3 = () =>
   browser.runtime.getManifest().manifest_version === 3;


### PR DESCRIPTION
## Summary

This PR fixes issue with `View all` page when `ao_tokens` storage value might be `undefined` and cause issues with UI.

## How To Test
- Test it on development branch first to see the error. Clear `ao_tokens`, `ao_tokens_cache` and `ao_tokens_ids` first and goto view all page to see the issue.
- Then do the same for this branch PR by clearing the storage values.