### PR TITLE
fix(onboarding): Add password expiration after wallet generation

### DIFF
--- a/src/routes/welcome/generate/done.tsx
+++ b/src/routes/welcome/generate/done.tsx
@@ -12,6 +12,7 @@ import { ExtensionStorage } from "~utils/storage";
 import { useStorage } from "@plasmohq/storage/hook";
 import JSConfetti from "js-confetti";
 import { useLocation } from "wouter";
+import { addExpiration } from "~wallets/auth";
 
 export default function Done() {
   // wallet context
@@ -47,6 +48,9 @@ export default function Done() {
       nickname ? { nickname, wallet: wallet.jwk } : wallet.jwk,
       password
     );
+
+    // add password expiration
+    addExpiration();
 
     // log user onboarded
     await trackEvent(EventType.ONBOARDED, {});

--- a/src/routes/welcome/generate/done.tsx
+++ b/src/routes/welcome/generate/done.tsx
@@ -50,7 +50,7 @@ export default function Done() {
     );
 
     // add password expiration
-    addExpiration();
+    await addExpiration();
 
     // log user onboarded
     await trackEvent(EventType.ONBOARDED, {});


### PR DESCRIPTION
## Summary
This PR addresses an issue where users were prompted to reset their password upon reopening the wallet after completing the onboarding process.

## How to Test
- Ensure to follow these steps to test both the development and this PR branch:
  1. ⚠️ Reset the storage of this Arconnect extension, loaded from either this PR or the development branch, using the storage explorer.
  2. Complete the onboarding process.
  3. In this PR build, clicking the extension icon should not prompt for a password reset. However, in the development branch build, you should encounter the password prompt.