### PR TITLE
feat: Transaction History

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1809,5 +1809,9 @@
   "subscription_add_failure": {
     "message": "Failed to add subscription",
     "description": "Failed to add subscription error message"
+  },
+  "transaction_history_title": {
+    "message": "Transaction History",
+    "description": "Transaction History header"
   }
 }

--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1936,5 +1936,21 @@
   "Daily": {
     "message": "Daily",
     "description": "daily frequency"
+  },
+  "transactions": {
+    "message": "Transactions",
+    "descriptions": "Transactions title"
+  },
+  "no_transactions": {
+    "message": "No transactions found",
+    "description": "No transactions message"
+  },
+  "sent": {
+    "message": "Sent",
+    "description": "sent"
+  },
+  "received": {
+    "message": "Received",
+    "description": "received"
   }
 }

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -1882,6 +1882,10 @@
       "message": "添加订阅失败",
       "description": "Failed to add subscription error message"
   },
+  "transaction_history_title": {
+    "message": "交易历史",
+    "description": "Transaction History header"
+  },
   "subscription_application_address": {
     "message": "应用地址",
     "description": "付款地址"
@@ -1930,5 +1934,21 @@
   "Daily": {
     "message": "每天",
     "description": "daily frequency"
+  },
+  "transactions": {
+    "message": "交易",
+    "descriptions": "Transactions title"
+  },
+  "no_transactions": {
+    "message": "未找到交易",
+    "description": "No transactions message"
+  },
+  "sent": {
+    "message": "已发送",
+    "description": "sent"
+  },
+  "received": {
+    "message": "已收到",
+    "description": "received"
   }
 }

--- a/src/components/popup/WalletHeader.tsx
+++ b/src/components/popup/WalletHeader.tsx
@@ -456,7 +456,7 @@ export default function WalletHeader() {
             icon: (
               <ArrowUpRightIcon style={{ width: "18px", height: "17px" }} />
             ),
-            title: "Transactions",
+            title: "transactions",
             route: () => {
               push("/transactions");
             }

--- a/src/components/popup/WalletHeader.tsx
+++ b/src/components/popup/WalletHeader.tsx
@@ -21,6 +21,7 @@ import {
   TooltipV2
 } from "@arconnect/components";
 import {
+  ArrowUpRightIcon,
   CheckIcon,
   ChevronDownIcon,
   CopyIcon,
@@ -444,6 +445,15 @@ export default function WalletHeader() {
             title: "Subscriptions",
             route: () => {
               push("/subscriptions");
+            }
+          },
+          {
+            icon: (
+              <ArrowUpRightIcon style={{ width: "18px", height: "17px" }} />
+            ),
+            title: "Transactions",
+            route: () => {
+              push("/transactions");
             }
           }
         ]}

--- a/src/notifications/api.ts
+++ b/src/notifications/api.ts
@@ -15,7 +15,7 @@ import {
   processTransactions
 } from "./utils";
 
-export type Transaction = {
+export type RawTransaction = {
   node: {
     id: string;
     recipient: string;
@@ -34,6 +34,9 @@ export type Transaction = {
       value: string;
     }>;
   };
+};
+
+export type Transaction = RawTransaction & {
   transactionType: string;
   quantity: string;
   isAo?: boolean;

--- a/src/notifications/utils.ts
+++ b/src/notifications/utils.ts
@@ -5,6 +5,7 @@ query ($address: String!) {
   transactions(first: 10, recipients: [$address], tags: [{ name: "Type", values: ["Transfer"] }]) {
 
     edges {
+      cursor
       node {
         id
         recipient
@@ -24,6 +25,7 @@ query ($address: String!) {
 export const AR_SENT_QUERY = `query ($address: String!) {
   transactions(first: 10, owners: [$address], tags: [{ name: "Type", values: ["Transfer"] }]) {
     edges {
+      cursor
       node {
         id
         recipient
@@ -52,6 +54,7 @@ query($address: String!) {
     ]
   ) {
     edges {
+      cursor
       node {
         recipient
         id
@@ -78,6 +81,7 @@ query($address: String!) {
     ]
   ) {
     edges {
+      cursor
       node {
         id
         recipient
@@ -129,6 +133,104 @@ export const ALL_AR_SENT_QUERY = `query ($address: String!) {
     }
   }
 }`;
+
+export const AR_RECEIVER_QUERY_WITH_CURSOR = `
+query ($address: String!, $after: String) {
+  transactions(first: 10, recipients: [$address], tags: [{ name: "Type", values: ["Transfer"] }], after: $after) {
+    edges {
+      cursor
+      node {
+        id
+        recipient
+        owner { address }
+        quantity { ar }
+        block { timestamp, height }
+        tags {
+          name
+          value
+        }
+      }
+    }
+  }
+}
+`;
+
+export const AR_SENT_QUERY_WITH_CURSOR = `
+query ($address: String!, $after: String) {
+  transactions(first: 10, owners: [$address], tags: [{ name: "Type", values: ["Transfer"] }], after: $after) {
+    edges {
+      cursor
+      node {
+        id
+        recipient
+        owner { address }
+        quantity { ar }
+        block { timestamp, height }
+        tags {
+          name
+          value
+        }
+      }
+    }
+  }
+}
+`;
+
+export const AO_RECEIVER_QUERY_WITH_CURSOR = `
+query($address: String!, $after: String) {
+  transactions(
+    first: 10, 
+    tags: [
+      {name: "Data-Protocol", values: ["ao"]}, 
+      {name: "Action", values: ["Transfer"]},
+      {name: "Recipient", values: [$address]}
+    ],
+    after: $after
+  ) {
+    edges {
+      cursor
+      node {
+        recipient
+        id
+        owner { address }
+        block { timestamp, height }
+        tags {
+          name
+          value
+        }
+      }
+    }
+  }
+}
+`;
+
+export const AO_SENT_QUERY_WITH_CURSOR = `
+query($address: String!, $after: String) {
+  transactions(
+    first: 10, 
+    owners: [$address], 
+    tags: [
+      {name: "Data-Protocol", values: ["ao"]}, 
+      {name: "Action", values: ["Transfer"]}
+    ],
+    after: $after
+  ) {
+    edges {
+      cursor
+      node {
+        id
+        recipient
+        owner { address }
+        block { timestamp, height }
+        tags {
+          name
+          value
+        }
+      }
+    }
+  }
+}
+`;
 
 export const combineAndSortTransactions = (responses: any[]) => {
   const combinedTransactions = responses.reduce((acc, response) => {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -33,6 +33,7 @@ import MessageNotification from "~routes/popup/notification/[id]";
 import SubscriptionDetails from "~routes/popup/subscriptions/subscriptionDetails";
 import SubscriptionPayment from "~routes/popup/subscriptions/subscriptionPayment";
 import SubscriptionManagement from "~routes/popup/subscriptions/subscriptionManagement";
+import Transactions from "~routes/popup/transaction/transactions";
 
 export default function Popup() {
   const theme = useTheme();
@@ -95,6 +96,7 @@ export default function Popup() {
                     <SubscriptionPayment id={params?.id} />
                   )}
                 </Route>
+                <Route path="/transactions" component={Transactions} />
                 <Route path="/notifications" component={Notifications} />
                 <Route path="/notification/:id">
                   {(params: { id: string }) => (

--- a/src/routes/popup/notifications.tsx
+++ b/src/routes/popup/notifications.tsx
@@ -240,7 +240,7 @@ export default function Notifications() {
   );
 }
 
-const Empty = styled.div`
+export const Empty = styled.div`
   width: calc(100% - 30px);
   height: calc(100% - 64.59px);
   margin-top: 50%;
@@ -272,7 +272,7 @@ const Link = styled.a`
   cursor: pointer;
 `;
 
-const TitleMessage = styled.div`
+export const TitleMessage = styled.div`
   color: ${(props) => props.theme.primaryTextv2};
   font-size: 14px;
 `;

--- a/src/routes/popup/transaction/[id].tsx
+++ b/src/routes/popup/transaction/[id].tsx
@@ -132,8 +132,10 @@ export default function Transaction({ id: rawId, gw, message }: Props) {
       } else {
         timeoutID = undefined;
 
-        const sdkTag = data.transaction.tags.find((tag) => tag.name === "SDK");
-        if (sdkTag && sdkTag.value === "aoconnect") {
+        const dataProtocolTag = data.transaction.tags.find(
+          (tag) => tag.name === "Data-Protocol"
+        );
+        if (dataProtocolTag && dataProtocolTag.value === "ao") {
           setAo({ isAo: true, tokenId: data.transaction.recipient });
           const aoRecipient = data.transaction.tags.find(
             (tag) => tag.name === "Recipient"

--- a/src/routes/popup/transaction/[id].tsx
+++ b/src/routes/popup/transaction/[id].tsx
@@ -1,4 +1,9 @@
-import { formatFiatBalance, formatTokenBalance } from "~tokens/currency";
+import {
+  balanceToFractioned,
+  formatFiatBalance,
+  formatTokenBalance,
+  fractionedToBalance
+} from "~tokens/currency";
 import { AnimatePresence, type Variants, motion } from "framer-motion";
 import { Section, Spacer, Text } from "@arconnect/components";
 import type { GQLNodeInterface } from "ar-gql/dist/faces";
@@ -34,6 +39,7 @@ import {
 import { TempTransactionStorage } from "~utils/storage";
 import { useContact } from "~contacts/hooks";
 import { EventType, PageType, trackEvent, trackPage } from "~utils/analytics";
+import { Token } from "ao-tokens";
 
 // pull contacts and check if to address is in contacts
 
@@ -55,6 +61,8 @@ export default function Transaction({ id: rawId, gw, message }: Props) {
   const contact = useContact(transaction?.recipient);
 
   const [ao, setAo] = useState<ao>({ isAo: false });
+
+  const [ticker, setTicker] = useState<string | null>(null);
 
   const [showTags, setShowTags] = useState<boolean>(false);
 
@@ -133,8 +141,17 @@ export default function Transaction({ id: rawId, gw, message }: Props) {
           const aoQuantity = data.transaction.tags.find(
             (tag) => tag.name === "Quantity"
           );
-          data.transaction.quantity = { ar: aoQuantity.value, winston: "" };
-          data.transaction.recipient = aoRecipient.value;
+
+          if (aoQuantity) {
+            const tokenInfo = (await Token(data.transaction.recipient)).info;
+            const amount = balanceToFractioned(Number(aoQuantity.value), {
+              id: data.transaction.recipient,
+              decimals: Number(tokenInfo.Denomination)
+            });
+            setTicker(tokenInfo.Ticker);
+            data.transaction.quantity = { ar: amount.toString(), winston: "" };
+            data.transaction.recipient = aoRecipient.value;
+          }
         }
 
         setTransaction(data.transaction);
@@ -267,7 +284,7 @@ export default function Transaction({ id: rawId, gw, message }: Props) {
         <HeadV2
           title={message ? "Message" : "Transaction Complete"}
           back={() => {
-            if (backPath === "/notifications") {
+            if (backPath === "/notifications" || backPath === "/transactions") {
               back();
             } else {
               push("/");
@@ -282,9 +299,9 @@ export default function Transaction({ id: rawId, gw, message }: Props) {
                   <AmountTitle>
                     {!ao.isAo
                       ? formatTokenBalance(Number(transaction.quantity.ar))
-                      : 0}
+                      : transaction.quantity.ar}
                     {/* NEEDS TO BE DYNAMIC */}
-                    {!ao.isAo && <span>AR</span>}
+                    <span>{ticker ? ticker : "AR"}</span>
                   </AmountTitle>
                   <FiatAmount>
                     {ao.isAo ? "$-.--" : formatFiatBalance(fiatPrice, currency)}
@@ -527,13 +544,13 @@ export default function Transaction({ id: rawId, gw, message }: Props) {
                 fullWidth
                 onClick={() => {
                   const url = ao.isAo
-                    ? `https://ao_marton.g8way.io/#/process/${ao.tokenId}/${id}`
+                    ? `https://www.ao.link/message/${id}`
                     : `https://viewblock.io/arweave/tx/${id}`;
 
                   browser.tabs.create({ url });
                 }}
               >
-                {ao.isAo ? "ao Scanner" : "Viewblock"}
+                {ao.isAo ? "AOLink" : "Viewblock"}
                 <ShareIcon style={{ marginLeft: "5px" }} />
               </SendButton>
             </Section>

--- a/src/routes/popup/transaction/transactions.tsx
+++ b/src/routes/popup/transaction/transactions.tsx
@@ -1,0 +1,351 @@
+import HeadV2 from "~components/popup/HeadV2";
+import browser from "webextension-polyfill";
+import { useEffect, useState } from "react";
+import { ExtensionStorage } from "~utils/storage";
+import { useStorage } from "@plasmohq/storage/hook";
+
+import { gql } from "~gateways/api";
+import type { RawTransaction } from "~notifications/api";
+import styled from "styled-components";
+import { Empty, TitleMessage } from "../notifications";
+import { fetchTokenByProcessId } from "~utils/notifications";
+import { formatAddress } from "~utils/format";
+import { balanceToFractioned, formatFiatBalance } from "~tokens/currency";
+import {
+  AO_RECEIVER_QUERY,
+  AO_SENT_QUERY,
+  AR_RECEIVER_QUERY,
+  AR_SENT_QUERY
+} from "~notifications/utils";
+import { useHistory } from "~utils/hash_router";
+import { getArPrice } from "~lib/coingecko";
+import useSetting from "~settings/hook";
+
+type ExtendedTransaction = RawTransaction & {
+  month: number;
+  year: number;
+  transactionType: string;
+  date: string | null;
+  day: number;
+  aoInfo?: {
+    tickerName: string;
+    denomination?: number;
+    quantity: number;
+  };
+};
+
+type GroupedTransactions = {
+  [key: string]: ExtendedTransaction[];
+};
+
+export default function Transactions() {
+  const [transactions, setTransaction] = useState<GroupedTransactions>({});
+  const [arPrice, setArPrice] = useState(0);
+  const [push] = useHistory();
+  const [loading, setLoading] = useState(false);
+  const [currency] = useSetting<string>("currency");
+  const [activeAddress] = useStorage<string>({
+    key: "active_address",
+    instance: ExtensionStorage
+  });
+
+  useEffect(() => {
+    getArPrice(currency)
+      .then((res) => setArPrice(res))
+      .catch();
+  }, [currency]);
+
+  useEffect(() => {
+    const getNotifications = async () => {
+      setLoading(true);
+      try {
+        if (activeAddress) {
+          const [rawReceived, rawSent, rawAoSent, rawAoReceived] =
+            await Promise.all([
+              gql(AR_RECEIVER_QUERY, { address: activeAddress }),
+              gql(AR_SENT_QUERY, { address: activeAddress }),
+              gql(AO_SENT_QUERY, { address: activeAddress }),
+              gql(AO_RECEIVER_QUERY, { address: activeAddress })
+            ]);
+
+          const sent: ExtendedTransaction[] =
+            rawSent.data.transactions.edges.map((transaction) => ({
+              ...transaction,
+              transactionType: "sent",
+              day: 0,
+              month: 0,
+              year: 0,
+              date: ""
+            }));
+
+          const received: ExtendedTransaction[] =
+            rawReceived.data.transactions.edges.map((transaction) => ({
+              ...transaction,
+              transactionType: "received",
+              day: 0,
+              month: 0,
+              year: 0,
+              date: ""
+            }));
+
+          const aoSent: ExtendedTransaction[] = await Promise.all(
+            rawAoSent.data.transactions.edges.map(async (transaction) => {
+              const tokenData = await fetchTokenByProcessId(
+                transaction.node.recipient
+              );
+              const quantityTag = transaction.node.tags.find(
+                (tag) => tag.name === "Quantity"
+              );
+              return {
+                ...transaction,
+                transactionType: "aoSent",
+                day: 0,
+                month: 0,
+                year: 0,
+                date: "",
+                aoInfo: {
+                  quantity: quantityTag ? Number(quantityTag.value) : undefined,
+                  tickerName:
+                    tokenData?.Ticker ||
+                    formatAddress(transaction.node.recipient, 4),
+                  denomination: tokenData?.Denomination || 0
+                }
+              };
+            })
+          );
+
+          const aoReceived: ExtendedTransaction[] = await Promise.all(
+            rawAoReceived.data.transactions.edges.map(async (transaction) => {
+              const tokenData = await fetchTokenByProcessId(
+                transaction.node.recipient
+              );
+              const quantityTag = transaction.node.tags.find(
+                (tag) => tag.name === "Quantity"
+              );
+              return {
+                ...transaction,
+                transactionType: "aoReceived",
+                day: 0,
+                month: 0,
+                year: 0,
+                date: "",
+                aoInfo: {
+                  quantity: quantityTag ? Number(quantityTag.value) : undefined,
+                  tickerName:
+                    tokenData?.Ticker ||
+                    formatAddress(transaction.node.recipient, 4),
+                  denomination: tokenData?.Denomination || 1
+                }
+              };
+            })
+          );
+
+          let combinedTransactions: ExtendedTransaction[] = [
+            ...sent,
+            ...received,
+            ...aoReceived,
+            ...aoSent
+          ];
+          combinedTransactions.sort((a, b) => {
+            const timestampA =
+              a.node?.block?.timestamp || Number.MAX_SAFE_INTEGER;
+            const timestampB =
+              b.node?.block?.timestamp || Number.MAX_SAFE_INTEGER;
+            return timestampB - timestampA;
+          });
+
+          combinedTransactions = combinedTransactions.map((transaction) => {
+            if (transaction.node.block && transaction.node.block.timestamp) {
+              const date = new Date(transaction.node.block.timestamp * 1000);
+              const day = date.getDate();
+              const month = date.getMonth() + 1;
+              const year = date.getFullYear();
+              return {
+                ...transaction,
+                day,
+                month,
+                year,
+                date: date.toISOString()
+              };
+            } else {
+              const now = new Date();
+              return {
+                ...transaction,
+                day: now.getDate(),
+                month: now.getMonth() + 1,
+                year: now.getFullYear(),
+                date: null
+              };
+            }
+          });
+
+          const groupedTransactions = combinedTransactions.reduce(
+            (acc, transaction) => {
+              const monthYear = `${transaction.month}-${transaction.year}`;
+              if (!acc[monthYear]) {
+                acc[monthYear] = [];
+              }
+              acc[monthYear].push(transaction);
+              return acc;
+            },
+            {} as { [key: string]: ExtendedTransaction[] }
+          );
+          setTransaction(groupedTransactions);
+        }
+      } catch (error) {
+        console.error("Error fetching transactions", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    getNotifications();
+  }, [activeAddress]);
+
+  const handleClick = (id: string) => {
+    push(`/transaction/${id}?back=${encodeURIComponent("/transactions")}`);
+  };
+
+  const getFormattedAmount = (transaction: ExtendedTransaction) => {
+    switch (transaction.transactionType) {
+      case "sent":
+      case "received":
+        return `${parseFloat(transaction.node.quantity.ar).toFixed(3)} AR`;
+      case "aoSent":
+      case "aoReceived":
+        if (transaction.aoInfo) {
+          return `${balanceToFractioned(transaction.aoInfo.quantity, {
+            divisibility: transaction.aoInfo.denomination
+          })} ${transaction.aoInfo.tickerName}`;
+        }
+        return "";
+      default:
+        return "";
+    }
+  };
+
+  const getTransactionDescription = (transaction: ExtendedTransaction) => {
+    switch (transaction.transactionType) {
+      case "sent":
+        return "Sent AR";
+      case "received":
+        return "Received AR";
+      case "aoSent":
+        return `Sent ${transaction.aoInfo.tickerName}`;
+      case "aoReceived":
+        return `Received ${transaction.aoInfo.tickerName}`;
+      default:
+        return "";
+    }
+  };
+
+  const getFullMonthName = (monthYear: string) => {
+    const [month, year] = monthYear.split("-").map(Number);
+    const date = new Date(year, month - 1);
+    return date.toLocaleString("default", { month: "long" });
+  };
+
+  return (
+    <>
+      <HeadV2 title={browser.i18n.getMessage("transaction_history_title")} />
+      <TransactionsWrapper>
+        {!loading &&
+          (Object.keys(transactions).length > 0 ? (
+            Object.keys(transactions).map((monthYear) => (
+              <div key={monthYear}>
+                <Month>{getFullMonthName(monthYear)}</Month>{" "}
+                <TransactionItem>
+                  {transactions[monthYear].map((transaction) => (
+                    <Transaction
+                      key={transaction.node.id}
+                      onClick={() => handleClick(transaction.node.id)}
+                    >
+                      <Section>
+                        <Main>{getTransactionDescription(transaction)}</Main>
+                        <Secondary>
+                          {transaction.date
+                            ? `${getFullMonthName(monthYear)} ${
+                                transaction.day
+                              }`
+                            : "Pending"}
+                        </Secondary>
+                      </Section>
+                      <Section alignRight>
+                        <Main>{getFormattedAmount(transaction)}</Main>
+                        <Secondary>
+                          {transaction.node.quantity &&
+                            formatFiatBalance(
+                              transaction.node.quantity.ar,
+                              currency
+                            )}
+                        </Secondary>
+                      </Section>
+                    </Transaction>
+                  ))}
+                </TransactionItem>
+              </div>
+            ))
+          ) : (
+            <Empty>
+              <TitleMessage>No Transactions Found</TitleMessage>
+            </Empty>
+          ))}
+      </TransactionsWrapper>
+    </>
+  );
+}
+
+const Selector = styled.span<{ active?: string }>``;
+
+const Month = styled.p`
+  margin: 0;
+  padding-bottom: 12px;
+  font-size: 10px;
+  font-weight: 500;
+`;
+
+const TransactionsWrapper = styled.div`
+  padding: 0 15px 15px 15px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const Main = styled.h4`
+  font-weight: 500;
+  font-size: 14px;
+  margin: 0;
+`;
+
+const Secondary = styled.h6`
+  margin: 0;
+  font-weight: 500;
+  color: ${(props) => props.theme.secondaryTextv2};
+  font-size: 10px;
+`;
+
+const Transaction = styled.div`
+  display: flex;
+  cursor: pointer;
+  justify-content: space-between;
+  border-bottom: 1px solid ${(props) => props.theme.backgroundSecondary};
+  padding-bottom: 8px;
+
+  &:last-child {
+    padding-bottom: 0;
+    border-bottom: none;
+  }
+`;
+
+const Section = styled.div<{ alignRight?: boolean }>`
+  text-align: ${({ alignRight }) => (alignRight ? "right" : "left")};
+`;
+
+const TransactionItem = styled.div`
+  border: 1px solid ${(props) => props.theme.backgroundSecondary};
+  gap: 8px;
+  display: flex;
+  flex-direction: column;
+  padding: 8px 10px;
+  border-radius: 10px;
+`;

--- a/src/routes/popup/transaction/transactions.tsx
+++ b/src/routes/popup/transaction/transactions.tsx
@@ -227,13 +227,17 @@ export default function Transactions() {
   const getTransactionDescription = (transaction: ExtendedTransaction) => {
     switch (transaction.transactionType) {
       case "sent":
-        return "Sent AR";
+        return `${browser.i18n.getMessage("sent")} AR`;
       case "received":
-        return "Received AR";
+        return `${browser.i18n.getMessage("received")} AR`;
       case "aoSent":
-        return `Sent ${transaction.aoInfo.tickerName}`;
+        return `${browser.i18n.getMessage("sent")} ${
+          transaction.aoInfo.tickerName
+        }`;
       case "aoReceived":
-        return `Received ${transaction.aoInfo.tickerName}`;
+        return `${browser.i18n.getMessage("received")} ${
+          transaction.aoInfo.tickerName
+        }`;
       default:
         return "";
     }
@@ -287,7 +291,9 @@ export default function Transactions() {
             ))
           ) : (
             <Empty>
-              <TitleMessage>No Transactions Found</TitleMessage>
+              <TitleMessage>
+                {browser.i18n.getMessage("no_transactions")}
+              </TitleMessage>
             </Empty>
           ))}
       </TransactionsWrapper>

--- a/src/routes/popup/transaction/transactions.tsx
+++ b/src/routes/popup/transaction/transactions.tsx
@@ -20,6 +20,7 @@ import {
 import { useHistory } from "~utils/hash_router";
 import { getArPrice } from "~lib/coingecko";
 import useSetting from "~settings/hook";
+import { suggestedGateways } from "~gateways/gateway";
 
 type ExtendedTransaction = RawTransaction & {
   month: number;
@@ -62,10 +63,26 @@ export default function Transactions() {
         if (activeAddress) {
           const [rawReceived, rawSent, rawAoSent, rawAoReceived] =
             await Promise.all([
-              gql(AR_RECEIVER_QUERY, { address: activeAddress }),
-              gql(AR_SENT_QUERY, { address: activeAddress }),
-              gql(AO_SENT_QUERY, { address: activeAddress }),
-              gql(AO_RECEIVER_QUERY, { address: activeAddress })
+              gql(
+                AR_RECEIVER_QUERY,
+                { address: activeAddress },
+                suggestedGateways[1]
+              ),
+              gql(
+                AR_SENT_QUERY,
+                { address: activeAddress },
+                suggestedGateways[1]
+              ),
+              gql(
+                AO_SENT_QUERY,
+                { address: activeAddress },
+                suggestedGateways[1]
+              ),
+              gql(
+                AO_RECEIVER_QUERY,
+                { address: activeAddress },
+                suggestedGateways[1]
+              )
             ]);
 
           const sent: ExtendedTransaction[] =


### PR DESCRIPTION
- Creates a new section tab for "transactions"
- Combines ao and AR sent/receive notifications (40 total max transactions, but we can make this in a way where more transactions can be loaded)
- Transaction details are viewable