### PR TITLE
fix: resolve settings page white screen

### DIFF
--- a/src/routes/dashboard/index.tsx
+++ b/src/routes/dashboard/index.tsx
@@ -112,7 +112,8 @@ export default function Settings({ params }: Props) {
         <MidSettingsTitle>
           {allSettings &&
             browser.i18n.getMessage(
-              allSettings.find((s) => s.name === activeSetting)?.displayName
+              allSettings.find((s) => s.name === activeSetting)?.displayName ||
+                ""
             )}
         </MidSettingsTitle>
         <Spacer y={0.85} />


### PR DESCRIPTION
## Summary

This PR resolves the settings page showing white screen issue when passed `undefined` to `getMessage`. This error seems to start from PR https://github.com/arconnectio/ArConnect/pull/363.

## How to Reproduce in development branch
- Click ArConnect icon and goto Settings to see the white screen only