### PR TITLE
fix: Make sure wallet selector stays on top of currency selector

### DIFF
--- a/src/components/popup/HeadV2.tsx
+++ b/src/components/popup/HeadV2.tsx
@@ -150,7 +150,7 @@ const HeadWrapper = styled(Section)<{
   top: 0;
   left: 0;
   right: 0;
-  z-index: 11;
+  z-index: 21;
   display: flex;
   flex-direction: row;
   width: full;


### PR DESCRIPTION
## Summary

This PR fixes an issue where the currency selector overlaps the wallet selector.