### PR TITLE
fix: bip39 usage issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arconnect",
   "displayName": "ArConnect",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "__MSG_extensionDescription__",
   "author": "th8ta",
   "packageManager": "yarn@1.22.18",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arconnect",
   "displayName": "ArConnect",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "__MSG_extensionDescription__",
   "author": "th8ta",
   "packageManager": "yarn@1.22.18",

--- a/src/wallets/generator.ts
+++ b/src/wallets/generator.ts
@@ -1,8 +1,8 @@
-import { getKeyPairFromMnemonic } from "human-crypto-keys";
+import { getKeyPairFromSeed } from "human-crypto-keys";
 import type { JWKInterface } from "arweave/web/lib/wallet";
 import { passwordStrength } from "check-password-strength";
 import { isOneOf, isString } from "typed-assert";
-import { wordlists } from "bip39-web-crypto";
+import { wordlists, mnemonicToSeed } from "bip39-web-crypto";
 
 /**
  * Credits to arweave.app for the mnemonic wallet generation
@@ -18,8 +18,10 @@ import { wordlists } from "bip39-web-crypto";
  * @returns Wallet JWK
  */
 export async function jwkFromMnemonic(mnemonic: string) {
-  const { privateKey } = await getKeyPairFromMnemonic(
-    mnemonic,
+  let seedBuffer = await mnemonicToSeed(mnemonic);
+  let seed = Uint8Array.from(seedBuffer);
+  const { privateKey } = await getKeyPairFromSeed(
+    seed,
     {
       id: "rsa",
       modulusLength: 4096

--- a/src/wallets/generator.ts
+++ b/src/wallets/generator.ts
@@ -19,9 +19,9 @@ import { wordlists, mnemonicToSeed } from "bip39-web-crypto";
  */
 export async function jwkFromMnemonic(mnemonic: string) {
   let seedBuffer = await mnemonicToSeed(mnemonic);
-  let seed = Uint8Array.from(seedBuffer);
   const { privateKey } = await getKeyPairFromSeed(
-    seed,
+    //@ts-ignore
+    seedBuffer,
     {
       id: "rsa",
       modulusLength: 4096


### PR DESCRIPTION
The 'getKeyPairFromMnemonic' function from the 'human-crypto-keys' library (v0.1.4) has a bug that may lead to different results in Node.js compared to the browser. This fix ensures consistent results across environments and helps other developers avoid referencing faulty code.