### PR TITLE
fix: Update old ao token with new

### DIFF
--- a/src/components/popup/Token.tsx
+++ b/src/components/popup/Token.tsx
@@ -31,6 +31,7 @@ import { abbreviateNumber } from "~utils/format";
 import Skeleton from "~components/Skeleton";
 import { TrashIcon, PlusIcon, SettingsIcon } from "@iconicicons/react";
 import JSConfetti from "js-confetti";
+import { AO_NATIVE_TOKEN } from "~utils/ao_import";
 
 export default function Token({ onClick, ...props }: Props) {
   const ref = useRef(null);
@@ -38,14 +39,6 @@ export default function Token({ onClick, ...props }: Props) {
   const [showTooltip, setShowTooltip] = useState(false);
   // display theme
   const theme = useTheme();
-
-  const [aoNativeToken] = useStorage(
-    {
-      key: "ao_native_token",
-      instance: ExtensionStorage
-    },
-    ""
-  );
 
   const [activeAddress] = useStorage({
     key: "active_address",
@@ -147,7 +140,7 @@ export default function Token({ onClick, ...props }: Props) {
       ref.current &&
       activeAddress &&
       !props.loading &&
-      aoNativeToken === props.id &&
+      AO_NATIVE_TOKEN === props.id &&
       !aoConfettiShown &&
       +props.balance > 0
     ) {
@@ -157,7 +150,6 @@ export default function Token({ onClick, ...props }: Props) {
     ref.current,
     aoConfettiShown,
     activeAddress,
-    aoNativeToken,
     props.balance,
     props.loading
   ]);
@@ -165,7 +157,7 @@ export default function Token({ onClick, ...props }: Props) {
   return (
     <Wrapper>
       {(!aoConfettiShown || ref.current) &&
-        aoNativeToken === props.id &&
+        AO_NATIVE_TOKEN === props.id &&
         +props.balance > 0 && <Canvas ref={ref} />}
       <InnerWrapper width={hasActionButton ? "86%" : "100%"} onClick={onClick}>
         <LogoAndDetails>

--- a/src/components/popup/home/AoBanner.tsx
+++ b/src/components/popup/home/AoBanner.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 import styled, { useTheme } from "styled-components";
 import browser from "webextension-polyfill";
 import { getTagValue, useAo, type Message } from "~tokens/aoTokens/ao";
+import { AO_NATIVE_TOKEN } from "~utils/ao_import";
 import { ExtensionStorage } from "~utils/storage";
 
 interface AoBannerProps {
@@ -17,11 +18,6 @@ export default function AoBanner({ activeAddress }: AoBannerProps) {
   const theme = useTheme();
   const [showBanner, setShowBanner] = useState(false);
 
-  const [aoNativeToken] = useStorage({
-    key: "ao_native_token",
-    instance: ExtensionStorage
-  });
-
   const [aoTokens] = useStorage(
     {
       key: "ao_tokens",
@@ -31,15 +27,15 @@ export default function AoBanner({ activeAddress }: AoBannerProps) {
   );
 
   const aoToken = useMemo<TokenInfo | undefined>(() => {
-    if (!aoNativeToken || aoTokens.length === 0) return undefined;
-    return aoTokens.find((token) => token.processId === aoNativeToken);
-  }, [aoTokens, aoNativeToken]);
+    if (aoTokens.length === 0) return undefined;
+    return aoTokens.find((token) => token.processId === AO_NATIVE_TOKEN);
+  }, [aoTokens]);
 
   async function getAoNativeTokenBalance() {
     const res = await ao.dryrun({
       Id: "0000000000000000000000000000000000000000001",
       Owner: activeAddress,
-      process: aoNativeToken,
+      process: AO_NATIVE_TOKEN,
       tags: [{ name: "Action", value: "Balance" }]
     });
 
@@ -63,12 +59,12 @@ export default function AoBanner({ activeAddress }: AoBannerProps) {
   }
 
   useEffect(() => {
-    if (activeAddress && aoNativeToken && aoToken && ao) {
+    if (activeAddress && aoToken && ao) {
       fetchAoNativeTokenBalance().catch(() => {});
     }
-  }, [activeAddress, aoNativeToken, aoToken, ao]);
+  }, [activeAddress, aoToken, ao]);
 
-  if (!activeAddress || !aoNativeToken || !aoToken || !showBanner) {
+  if (!activeAddress || !aoToken || !showBanner) {
     return null;
   }
 

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -34,7 +34,6 @@ import SubscriptionDetails from "~routes/popup/subscriptions/subscriptionDetails
 import SubscriptionPayment from "~routes/popup/subscriptions/subscriptionPayment";
 import SubscriptionManagement from "~routes/popup/subscriptions/subscriptionManagement";
 import Transactions from "~routes/popup/transaction/transactions";
-import { importAoNativeToken } from "~utils/ao_import";
 
 export default function Popup() {
   const theme = useTheme();
@@ -46,9 +45,6 @@ export default function Popup() {
   useEffect(() => {
     // sync ans labels
     syncLabels();
-
-    // import ao native token
-    importAoNativeToken();
 
     // check expanded view
     if (new URLSearchParams(window.location.search).get("expanded")) {

--- a/src/tokens/aoTokens/ao.ts
+++ b/src/tokens/aoTokens/ao.ts
@@ -13,6 +13,13 @@ export type AoInstance = ReturnType<typeof connect>;
 
 export const defaultAoTokens: TokenInfo[] = [
   {
+    Name: "AO",
+    Ticker: "AO",
+    Denomination: 12,
+    Logo: "UkS-mdoiG8hcAClhKK8ch4ZhEzla0mCPDOix9hpdSFE",
+    processId: "m3PaWzK4PTG9lAaqYQPaPdOcXdO8hYqi5Fe9NWqXd0w"
+  },
+  {
     Name: "TRUNK",
     Ticker: "TRUNK",
     Denomination: 3,
@@ -148,7 +155,7 @@ export function useAoTokens(): [TokenInfoWithBalance[], boolean] {
                     const balance = await aoToken.getBalance(activeAddress);
                     return balance;
                   })(),
-                  6000
+                  10000
                 )
               );
               return {
@@ -254,7 +261,7 @@ export function useAoTokensCache(): [TokenInfoWithBalance[], boolean] {
                     const balance = await aoToken.getBalance(activeAddress);
                     return balance;
                   })(),
-                  6000
+                  10000
                 )
               );
               return {

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -4,6 +4,7 @@ import { initializeARBalanceMonitor } from "./analytics";
 import { loadTokens } from "~tokens/token";
 import { getActiveAddress, getWallets } from "~wallets";
 import { ExtensionStorage } from "./storage";
+import { updateAoToken } from "./ao_import";
 
 export const isManifestv3 = () =>
   browser.runtime.getManifest().manifest_version === 3;
@@ -31,6 +32,9 @@ export async function onInstalled(details: Runtime.OnInstalledDetailsType) {
 
   // initialize tokens in wallet
   await loadTokens();
+
+  // update old ao token to new ao token
+  await updateAoToken();
 
   // wayfinder
   await scheduleGatewayUpdate();


### PR DESCRIPTION
## Summary

This PR removes the old ao token if found and adds the new ao token if not found. Also, it adds the new ao token to the default ao tokens list.

## How to Test
1. Add the old token if not added (If dry-run failed and unable to add the old token then add the new token and update the processId with the old token processId)
2. Run the dev mode and refresh the extension from settings to trigger `onInstalled` to update old ao token with new ao token.
3. You could also remove all the `ao_tokens` from storage and refresh the extension to see the updated defaultAoTokens added.