### PR TITLE
 feat: dashboard tabs

### DIFF
--- a/src/components/popup/Title.tsx
+++ b/src/components/popup/Title.tsx
@@ -20,7 +20,7 @@ export const ViewAll = styled(Title).attrs({
   align-items: center;
   font-size: 1rem;
   gap: 0.2rem;
-  color: rgb(${(props) => props.theme.secondaryText});
+  color: ${(props) => props.theme.secondaryTextv2};
   cursor: pointer;
   transition: all 0.23s ease-in-out;
 

--- a/src/components/popup/Title.tsx
+++ b/src/components/popup/Title.tsx
@@ -18,8 +18,8 @@ export const ViewAll = styled(Title).attrs({
 })`
   display: flex;
   align-items: center;
-  font-size: 1.25rem;
-  gap: 0.45rem;
+  font-size: 1rem;
+  gap: 0.2rem;
   color: rgb(${(props) => props.theme.secondaryText});
   cursor: pointer;
   transition: all 0.23s ease-in-out;
@@ -30,12 +30,10 @@ export const ViewAll = styled(Title).attrs({
 `;
 
 export const TokenCount = styled.span`
-  font-size: 0.7rem;
+  font-size: 1rem;
   font-weight: 500;
-  color: rgb(${(props) => props.theme.secondaryText});
-  background-color: rgb(${(props) => props.theme.secondaryText}, 0.3);
+  color: rgb(${(props) => props.theme.primaryText});
   border-radius: 5px;
-  padding: 0.1rem 0.3rem;
 `;
 
 export default Title;

--- a/src/components/popup/WalletHeader.tsx
+++ b/src/components/popup/WalletHeader.tsx
@@ -429,6 +429,13 @@ export default function WalletHeader() {
               })
           },
           {
+            icon: <CreditCard01 style={{ width: "18px", height: "17px" }} />,
+            title: "subscriptions",
+            route: () => {
+              push("/subscriptions");
+            }
+          },
+          {
             icon: <Settings01 style={{ width: "18px", height: "18px" }} />,
             title: "Settings",
             route: () =>
@@ -443,22 +450,6 @@ export default function WalletHeader() {
               window.open(
                 window.location.href.split("#")[0] + "?expanded=true"
               );
-            }
-          },
-          {
-            icon: <CreditCard01 style={{ width: "18px", height: "17px" }} />,
-            title: "subscriptions",
-            route: () => {
-              push("/subscriptions");
-            }
-          },
-          {
-            icon: (
-              <ArrowUpRightIcon style={{ width: "18px", height: "17px" }} />
-            ),
-            title: "transactions",
-            route: () => {
-              push("/transactions");
             }
           }
         ]}

--- a/src/components/popup/home/Collectibles.tsx
+++ b/src/components/popup/home/Collectibles.tsx
@@ -1,5 +1,5 @@
-import Title, { Heading, TokenCount, ViewAll } from "../Title";
-import { Section, Spacer, Text } from "@arconnect/components";
+import { Heading, TokenCount, ViewAll } from "../Title";
+import { Spacer, Text } from "@arconnect/components";
 import { useHistory } from "~utils/hash_router";
 import { useTokens } from "~tokens";
 import { useMemo } from "react";
@@ -21,9 +21,8 @@ export default function Collectibles() {
   const [push] = useHistory();
 
   return (
-    <Section>
+    <>
       <Heading>
-        <Title noMargin>{browser.i18n.getMessage("collectibles")}</Title>
         <ViewAll
           onClick={() => {
             if (collectibles.length === 0) return;
@@ -31,10 +30,10 @@ export default function Collectibles() {
           }}
         >
           {browser.i18n.getMessage("view_all")}
-          <TokenCount>{collectibles.length}</TokenCount>
+          <TokenCount>({collectibles.length})</TokenCount>
         </ViewAll>
       </Heading>
-      <Spacer y={0.8} />
+      <Spacer y={1} />
       {collectibles.length === 0 && (
         <NoAssets>{browser.i18n.getMessage("no_collectibles")}</NoAssets>
       )}
@@ -51,7 +50,7 @@ export default function Collectibles() {
           />
         ))}
       </CollectiblesList>
-    </Section>
+    </>
   );
 }
 

--- a/src/components/popup/home/Tabs.tsx
+++ b/src/components/popup/home/Tabs.tsx
@@ -76,11 +76,8 @@ const StyledTab = styled.div<{ active?: boolean; tabId: number }>`
   font-weight: 500;
   font-size: 18px;
   line-height: 25px;
-  // color: ${(props) => (props.active ? "#ffffff" : "#a3a3a3")};
   color: ${(props) =>
-    `rgb(${
-      props.active ? props.theme.primaryText : props.theme.secondaryText
-    })`};
+    props.active ? props.theme.primaryText : props.theme.secondaryTextv2};
   cursor: pointer;
 
   &::after {
@@ -88,7 +85,8 @@ const StyledTab = styled.div<{ active?: boolean; tabId: number }>`
     position: absolute;
     bottom: -2px;
     height: 2px;
-    background: ${(props) => (props.active ? "#8e7bea" : "#a3a3a3")};
+    background: ${(props) =>
+      props.active ? "#8e7bea" : props.theme.secondaryTextv2};
     transition: transform 0.3s ease-in-out;
     transform: scaleX(${(props) => (props.active ? 1 : 0)});
     ${(props) => props.tabId === 0 && "left: 0; right: -12px;"}
@@ -98,7 +96,7 @@ const StyledTab = styled.div<{ active?: boolean; tabId: number }>`
 `;
 
 const Underline = styled.div<{ active?: boolean }>`
-  border: 1px solid #a3a3a3;
+  border: 1px solid ${(props) => props.theme.secondaryTextv2};
   transition: border-color 0.3s ease-in-out;
 `;
 

--- a/src/components/popup/home/Tabs.tsx
+++ b/src/components/popup/home/Tabs.tsx
@@ -1,10 +1,32 @@
 import { Section } from "@arconnect/components";
-import { useState } from "react";
+import { useState, type Dispatch, type SetStateAction } from "react";
 import styled from "styled-components";
 import browser from "webextension-polyfill";
 import Tokens from "./Tokens";
 import Collectibles from "./Collectibles";
 import Transactions from "./Transactions";
+
+interface TabType {
+  id: number;
+  name: string;
+  component: () => JSX.Element;
+}
+
+interface TabProps {
+  tab: TabType;
+  active: boolean;
+  setActiveTab: Dispatch<SetStateAction<number>>;
+}
+
+const Tab = ({ tab, active, setActiveTab }: TabProps) => (
+  <StyledTab
+    active={active}
+    tabId={tab.id}
+    onClick={() => setActiveTab(tab.id)}
+  >
+    {browser.i18n.getMessage(tab.name)}
+  </StyledTab>
+);
 
 export default function Tabs() {
   const [activeTab, setActiveTab] = useState(0);
@@ -24,11 +46,10 @@ export default function Tabs() {
           {tabs.map((tab) => (
             <Tab
               key={tab.id}
+              tab={tab}
               active={tab.id === activeTab}
-              onClick={() => setActiveTab(tab.id)}
-            >
-              {browser.i18n.getMessage(tab.name)}
-            </Tab>
+              setActiveTab={setActiveTab}
+            />
           ))}
         </TabsWrapper>
         <Underline />
@@ -49,7 +70,7 @@ const TabsWrapper = styled.div`
   filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
 `;
 
-const Tab = styled.div<{ active?: boolean }>`
+const StyledTab = styled.div<{ active?: boolean; tabId: number }>`
   position: relative;
   height: 25px;
   font-weight: 500;
@@ -66,12 +87,13 @@ const Tab = styled.div<{ active?: boolean }>`
     content: "";
     position: absolute;
     bottom: -2px;
-    left: 0;
-    right: 0;
     height: 2px;
     background: ${(props) => (props.active ? "#8e7bea" : "#a3a3a3")};
     transition: transform 0.3s ease-in-out;
     transform: scaleX(${(props) => (props.active ? 1 : 0)});
+    ${(props) => props.tabId === 0 && "left: 0; right: -12px;"}
+    ${(props) => props.tabId === 1 && "left: -12px; right: -12px;"}
+    ${(props) => props.tabId === 2 && "left: -12px; right: 0;"}
   }
 `;
 

--- a/src/components/popup/home/Tabs.tsx
+++ b/src/components/popup/home/Tabs.tsx
@@ -1,0 +1,86 @@
+import { Section } from "@arconnect/components";
+import { useState } from "react";
+import styled from "styled-components";
+import browser from "webextension-polyfill";
+import Tokens from "./Tokens";
+import Collectibles from "./Collectibles";
+import Transactions from "./Transactions";
+
+export default function Tabs() {
+  const [activeTab, setActiveTab] = useState(0);
+
+  const tabs = [
+    { id: 0, name: "assets", component: Tokens },
+    { id: 1, name: "collectibles", component: Collectibles },
+    { id: 2, name: "transactions", component: Transactions }
+  ];
+
+  const ActiveComponent = tabs[activeTab].component;
+
+  return (
+    <>
+      <Section>
+        <TabsWrapper>
+          {tabs.map((tab) => (
+            <Tab
+              key={tab.id}
+              active={tab.id === activeTab}
+              onClick={() => setActiveTab(tab.id)}
+            >
+              {browser.i18n.getMessage(tab.name)}
+            </Tab>
+          ))}
+        </TabsWrapper>
+        <Underline />
+        <ContentWrapper>
+          <ActiveComponent />
+        </ContentWrapper>
+      </Section>
+    </>
+  );
+}
+
+const TabsWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 25px;
+  filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+`;
+
+const Tab = styled.div<{ active?: boolean }>`
+  position: relative;
+  height: 25px;
+  font-weight: 500;
+  font-size: 18px;
+  line-height: 25px;
+  // color: ${(props) => (props.active ? "#ffffff" : "#a3a3a3")};
+  color: ${(props) =>
+    `rgb(${
+      props.active ? props.theme.primaryText : props.theme.secondaryText
+    })`};
+  cursor: pointer;
+
+  &::after {
+    content: "";
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: ${(props) => (props.active ? "#8e7bea" : "#a3a3a3")};
+    transition: transform 0.3s ease-in-out;
+    transform: scaleX(${(props) => (props.active ? 1 : 0)});
+  }
+`;
+
+const Underline = styled.div<{ active?: boolean }>`
+  border: 1px solid #a3a3a3;
+  transition: border-color 0.3s ease-in-out;
+`;
+
+const ContentWrapper = styled.div`
+  margin-top: 16px;
+  width: 100%;
+`;

--- a/src/components/popup/home/Tokens.tsx
+++ b/src/components/popup/home/Tokens.tsx
@@ -1,5 +1,5 @@
-import Title, { Heading, TokenCount, ViewAll } from "../Title";
-import { Section, Spacer, Text } from "@arconnect/components";
+import { Heading, TokenCount, ViewAll } from "../Title";
+import { Spacer, Text } from "@arconnect/components";
 import { useHistory } from "~utils/hash_router";
 import { useTokens } from "~tokens";
 import { useMemo } from "react";
@@ -30,15 +30,14 @@ export default function Tokens() {
   }
 
   return (
-    <Section>
+    <>
       <Heading>
-        <Title noMargin>{browser.i18n.getMessage("assets")}</Title>
         <ViewAll onClick={() => push("/tokens")}>
           {browser.i18n.getMessage("view_all")}
-          <TokenCount>{assets.length + aoTokens.length}</TokenCount>
+          <TokenCount>({assets.length + aoTokens.length})</TokenCount>
         </ViewAll>
       </Heading>
-      <Spacer y={0.8} />
+      <Spacer y={1} />
       {assets.length === 0 && aoTokens.length === 0 && (
         <NoTokens>{browser.i18n.getMessage("no_assets")}</NoTokens>
       )}
@@ -66,7 +65,7 @@ export default function Tokens() {
           />
         ))}
       </TokensList>
-    </Section>
+    </>
   );
 }
 

--- a/src/components/popup/home/Transactions.tsx
+++ b/src/components/popup/home/Transactions.tsx
@@ -2,11 +2,11 @@ import browser from "webextension-polyfill";
 import { useEffect, useState } from "react";
 import { ExtensionStorage } from "~utils/storage";
 import { useStorage } from "@plasmohq/storage/hook";
+import { Text } from "@arconnect/components";
 
 import { gql } from "~gateways/api";
 import type { RawTransaction } from "~notifications/api";
 import styled from "styled-components";
-import { Empty, TitleMessage } from "~routes/popup/notifications";
 import { fetchTokenByProcessId } from "~utils/notifications";
 import { formatAddress } from "~utils/format";
 import { balanceToFractioned, formatFiatBalance } from "~tokens/currency";
@@ -261,7 +261,7 @@ export default function Transactions() {
         </ViewAll>
       </Heading>
       <Spacer y={1} />
-      <TransactionsWrapper>
+      <TransactionsWrapper showBorder={transactions.length > 0}>
         {!loading &&
           (transactions.length > 0 ? (
             transactions.map((transaction, index) => (
@@ -295,22 +295,21 @@ export default function Transactions() {
               </TransactionItem>
             ))
           ) : (
-            <Empty>
-              <TitleMessage>
-                {browser.i18n.getMessage("no_transactions")}
-              </TitleMessage>
-            </Empty>
+            <NoTransactions>
+              {browser.i18n.getMessage("no_transactions")}
+            </NoTransactions>
           ))}
       </TransactionsWrapper>
     </>
   );
 }
 
-const TransactionsWrapper = styled.div`
+const TransactionsWrapper = styled.div<{ showBorder: boolean }>`
   display: flex;
   flex-direction: column;
   border-radius: 10px;
-  border: 1px solid ${(props) => props.theme.backgroundSecondary};
+${(props) =>
+  props.showBorder && `border: 1px solid ${props.theme.backgroundSecondary}`}};
 `;
 
 const Main = styled.h4`
@@ -351,4 +350,10 @@ const TransactionItem = styled.div`
 const Underline = styled.div`
   height: 1px;
   background: ${(props) => props.theme.backgroundSecondary};
+`;
+
+const NoTransactions = styled(Text).attrs({
+  noMargin: true
+})`
+  text-align: center;
 `;

--- a/src/components/popup/home/Transactions.tsx
+++ b/src/components/popup/home/Transactions.tsx
@@ -60,7 +60,7 @@ export default function Transactions() {
             );
 
           const sent = await processTransactions(rawSent, "sent");
-          const received = await processTransactions(rawReceived, "sent");
+          const received = await processTransactions(rawReceived, "received");
           const aoSent = await processTransactions(rawAoSent, "aoSent", true);
           const aoReceived = await processTransactions(
             rawAoReceived,

--- a/src/components/popup/home/Transactions.tsx
+++ b/src/components/popup/home/Transactions.tsx
@@ -1,0 +1,354 @@
+import browser from "webextension-polyfill";
+import { useEffect, useState } from "react";
+import { ExtensionStorage } from "~utils/storage";
+import { useStorage } from "@plasmohq/storage/hook";
+
+import { gql } from "~gateways/api";
+import type { RawTransaction } from "~notifications/api";
+import styled from "styled-components";
+import { Empty, TitleMessage } from "~routes/popup/notifications";
+import { fetchTokenByProcessId } from "~utils/notifications";
+import { formatAddress } from "~utils/format";
+import { balanceToFractioned, formatFiatBalance } from "~tokens/currency";
+import {
+  AO_RECEIVER_QUERY,
+  AO_SENT_QUERY,
+  AR_RECEIVER_QUERY,
+  AR_SENT_QUERY
+} from "~notifications/utils";
+import { useHistory } from "~utils/hash_router";
+import { getArPrice } from "~lib/coingecko";
+import useSetting from "~settings/hook";
+import { suggestedGateways } from "~gateways/gateway";
+import { Spacer } from "@arconnect/components";
+import { Heading, ViewAll, TokenCount } from "../Title";
+
+type ExtendedTransaction = RawTransaction & {
+  month: number;
+  year: number;
+  transactionType: string;
+  date: string | null;
+  day: number;
+  aoInfo?: {
+    tickerName: string;
+    denomination?: number;
+    quantity: number;
+  };
+};
+
+export default function Transactions() {
+  const [transactions, setTransactions] = useState<ExtendedTransaction[]>([]);
+  const [arPrice, setArPrice] = useState(0);
+  const [push] = useHistory();
+  const [loading, setLoading] = useState(false);
+  const [currency] = useSetting<string>("currency");
+  const [activeAddress] = useStorage<string>({
+    key: "active_address",
+    instance: ExtensionStorage
+  });
+
+  useEffect(() => {
+    getArPrice(currency)
+      .then((res) => setArPrice(res))
+      .catch();
+  }, [currency]);
+
+  useEffect(() => {
+    const getNotifications = async () => {
+      setLoading(true);
+      try {
+        if (activeAddress) {
+          const [rawReceived, rawSent, rawAoSent, rawAoReceived] =
+            await Promise.all([
+              gql(
+                AR_RECEIVER_QUERY,
+                { address: activeAddress },
+                suggestedGateways[1]
+              ),
+              gql(
+                AR_SENT_QUERY,
+                { address: activeAddress },
+                suggestedGateways[1]
+              ),
+              gql(
+                AO_SENT_QUERY,
+                { address: activeAddress },
+                suggestedGateways[1]
+              ),
+              gql(
+                AO_RECEIVER_QUERY,
+                { address: activeAddress },
+                suggestedGateways[1]
+              )
+            ]);
+
+          const sent: ExtendedTransaction[] =
+            rawSent.data.transactions.edges.map((transaction) => ({
+              ...transaction,
+              transactionType: "sent",
+              day: 0,
+              month: 0,
+              year: 0,
+              date: ""
+            }));
+
+          const received: ExtendedTransaction[] =
+            rawReceived.data.transactions.edges.map((transaction) => ({
+              ...transaction,
+              transactionType: "received",
+              day: 0,
+              month: 0,
+              year: 0,
+              date: ""
+            }));
+
+          const aoSent: ExtendedTransaction[] = await Promise.all(
+            rawAoSent.data.transactions.edges.map(async (transaction) => {
+              const tokenData = await fetchTokenByProcessId(
+                transaction.node.recipient
+              );
+              const quantityTag = transaction.node.tags.find(
+                (tag) => tag.name === "Quantity"
+              );
+              return {
+                ...transaction,
+                transactionType: "aoSent",
+                day: 0,
+                month: 0,
+                year: 0,
+                date: "",
+                aoInfo: {
+                  quantity: quantityTag ? Number(quantityTag.value) : undefined,
+                  tickerName:
+                    tokenData?.Ticker ||
+                    formatAddress(transaction.node.recipient, 4),
+                  denomination: tokenData?.Denomination || 0
+                }
+              };
+            })
+          );
+
+          const aoReceived: ExtendedTransaction[] = await Promise.all(
+            rawAoReceived.data.transactions.edges.map(async (transaction) => {
+              const tokenData = await fetchTokenByProcessId(
+                transaction.node.recipient
+              );
+              const quantityTag = transaction.node.tags.find(
+                (tag) => tag.name === "Quantity"
+              );
+              return {
+                ...transaction,
+                transactionType: "aoReceived",
+                day: 0,
+                month: 0,
+                year: 0,
+                date: "",
+                aoInfo: {
+                  quantity: quantityTag ? Number(quantityTag.value) : undefined,
+                  tickerName:
+                    tokenData?.Ticker ||
+                    formatAddress(transaction.node.recipient, 4),
+                  denomination: tokenData?.Denomination || 1
+                }
+              };
+            })
+          );
+
+          let combinedTransactions: ExtendedTransaction[] = [
+            ...sent,
+            ...received,
+            ...aoReceived,
+            ...aoSent
+          ];
+          combinedTransactions.sort((a, b) => {
+            const timestampA =
+              a.node?.block?.timestamp || Number.MAX_SAFE_INTEGER;
+            const timestampB =
+              b.node?.block?.timestamp || Number.MAX_SAFE_INTEGER;
+            return timestampB - timestampA;
+          });
+
+          combinedTransactions = combinedTransactions.map((transaction) => {
+            if (transaction.node.block && transaction.node.block.timestamp) {
+              const date = new Date(transaction.node.block.timestamp * 1000);
+              const day = date.getDate();
+              const month = date.getMonth() + 1;
+              const year = date.getFullYear();
+              return {
+                ...transaction,
+                day,
+                month,
+                year,
+                date: date.toISOString()
+              };
+            } else {
+              const now = new Date();
+              return {
+                ...transaction,
+                day: now.getDate(),
+                month: now.getMonth() + 1,
+                year: now.getFullYear(),
+                date: null
+              };
+            }
+          });
+
+          setTransactions(combinedTransactions);
+        }
+      } catch (error) {
+        console.error("Error fetching transactions", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    getNotifications();
+  }, [activeAddress]);
+
+  const handleClick = (id: string) => {
+    push(`/transaction/${id}?back=${encodeURIComponent("/transactions")}`);
+  };
+
+  const getFormattedAmount = (transaction: ExtendedTransaction) => {
+    switch (transaction.transactionType) {
+      case "sent":
+      case "received":
+        return `${parseFloat(transaction.node.quantity.ar).toFixed(3)} AR`;
+      case "aoSent":
+      case "aoReceived":
+        if (transaction.aoInfo) {
+          return `${balanceToFractioned(transaction.aoInfo.quantity, {
+            divisibility: transaction.aoInfo.denomination
+          })} ${transaction.aoInfo.tickerName}`;
+        }
+        return "";
+      default:
+        return "";
+    }
+  };
+
+  const getTransactionDescription = (transaction: ExtendedTransaction) => {
+    switch (transaction.transactionType) {
+      case "sent":
+        return `${browser.i18n.getMessage("sent")} AR`;
+      case "received":
+        return `${browser.i18n.getMessage("received")} AR`;
+      case "aoSent":
+        return `${browser.i18n.getMessage("sent")} ${
+          transaction.aoInfo.tickerName
+        }`;
+      case "aoReceived":
+        return `${browser.i18n.getMessage("received")} ${
+          transaction.aoInfo.tickerName
+        }`;
+      default:
+        return "";
+    }
+  };
+
+  const getFullMonthName = (monthYear: string) => {
+    const [month, year] = monthYear.split("-").map(Number);
+    const date = new Date(year, month - 1);
+    return date.toLocaleString("default", { month: "long" });
+  };
+
+  return (
+    <>
+      <Heading>
+        <ViewAll onClick={() => push("/transactions")}>
+          {browser.i18n.getMessage("view_all")}
+          <TokenCount>({transactions.length})</TokenCount>
+        </ViewAll>
+      </Heading>
+      <Spacer y={1} />
+      <TransactionsWrapper>
+        {!loading &&
+          (transactions.length > 0 ? (
+            transactions.map((transaction, index) => (
+              <TransactionItem key={transaction.node.id}>
+                <Transaction
+                  key={transaction.node.id}
+                  onClick={() => handleClick(transaction.node.id)}
+                >
+                  <Section>
+                    <Main>{getTransactionDescription(transaction)}</Main>
+                    <Secondary>
+                      {transaction.date
+                        ? `${getFullMonthName(
+                            `${transaction.month}-${transaction.year}`
+                          )} ${transaction.day}`
+                        : "Pending"}
+                    </Secondary>
+                  </Section>
+                  <Section alignRight>
+                    <Main>{getFormattedAmount(transaction)}</Main>
+                    <Secondary>
+                      {transaction.node.quantity &&
+                        formatFiatBalance(
+                          transaction.node.quantity.ar,
+                          currency
+                        )}
+                    </Secondary>
+                  </Section>
+                </Transaction>
+                <Underline />
+              </TransactionItem>
+            ))
+          ) : (
+            <Empty>
+              <TitleMessage>
+                {browser.i18n.getMessage("no_transactions")}
+              </TitleMessage>
+            </Empty>
+          ))}
+      </TransactionsWrapper>
+    </>
+  );
+}
+
+const TransactionsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-radius: 10px;
+  border: 1px solid ${(props) => props.theme.backgroundSecondary};
+`;
+
+const Main = styled.h4`
+  font-weight: 500;
+  font-size: 14px;
+  margin: 0;
+`;
+
+const Secondary = styled.h6`
+  margin: 0;
+  font-weight: 500;
+  color: ${(props) => props.theme.secondaryTextv2};
+  font-size: 10px;
+`;
+
+const Transaction = styled.div`
+  display: flex;
+  cursor: pointer;
+  justify-content: space-between;
+  // border-bottom: 1px solid ${(props) => props.theme.backgroundSecondary};
+  padding: 8px 0;
+`;
+
+const Section = styled.div<{ alignRight?: boolean }>`
+  text-align: ${({ alignRight }) => (alignRight ? "right" : "left")};
+`;
+
+const TransactionItem = styled.div`
+  padding: 0 10px;
+  border-radius: 10px;
+
+  &:hover {
+    background: #36324d;
+    border-radius: 10px;
+  }
+`;
+
+const Underline = styled.div`
+  height: 1px;
+  background: ${(props) => props.theme.backgroundSecondary};
+`;

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -1,0 +1,84 @@
+import type GQLResultInterface from "ar-gql/dist/faces";
+import type { GQLEdgeInterface } from "ar-gql/dist/faces";
+import type { RawTransaction } from "~notifications/api";
+import { formatAddress } from "~utils/format";
+import { fetchTokenByProcessId } from "~utils/notifications";
+
+export type ExtendedTransaction = RawTransaction & {
+  cursor: string;
+  month: number;
+  year: number;
+  transactionType: string;
+  date: string | null;
+  day: number;
+  aoInfo?: {
+    tickerName: string;
+    denomination?: number;
+    quantity: number;
+  };
+};
+
+export type GroupedTransactions = {
+  [key: string]: ExtendedTransaction[];
+};
+
+export function sortFn(a: ExtendedTransaction, b: ExtendedTransaction) {
+  const timestampA = a.node?.block?.timestamp || Number.MAX_SAFE_INTEGER;
+  const timestampB = b.node?.block?.timestamp || Number.MAX_SAFE_INTEGER;
+  return timestampB - timestampA;
+}
+
+export const processTransaction = (
+  transaction: GQLEdgeInterface,
+  type: string
+) => ({
+  ...transaction,
+  transactionType: type,
+  day: 0,
+  month: 0,
+  year: 0,
+  date: ""
+});
+
+export const processAoTransaction = async (
+  transaction: GQLEdgeInterface,
+  type: string
+) => {
+  const tokenData = await fetchTokenByProcessId(transaction.node.recipient);
+  const quantityTag = transaction.node.tags.find(
+    (tag) => tag.name === "Quantity"
+  );
+  return {
+    ...transaction,
+    transactionType: type,
+    day: 0,
+    month: 0,
+    year: 0,
+    date: "",
+    aoInfo: {
+      quantity: quantityTag ? Number(quantityTag.value) : undefined,
+      tickerName:
+        tokenData?.Ticker || formatAddress(transaction.node.recipient, 4),
+      denomination: tokenData?.Denomination || 0
+    }
+  };
+};
+
+export const processTransactions = async (
+  rawData: PromiseSettledResult<GQLResultInterface>,
+  type: string,
+  isAo = false
+): Promise<ExtendedTransaction[]> => {
+  if (rawData.status === "fulfilled") {
+    const edges = rawData.value?.data?.transactions?.edges || [];
+    if (isAo) {
+      return Promise.all(
+        edges.map((transaction) => processAoTransaction(transaction, type))
+      );
+    } else {
+      return edges.map((transaction) => processTransaction(transaction, type));
+    }
+  } else {
+    return isAo ? Promise.resolve([]) : [];
+  }
+};

--- a/src/notifications/utils.ts
+++ b/src/notifications/utils.ts
@@ -137,6 +137,9 @@ export const ALL_AR_SENT_QUERY = `query ($address: String!) {
 export const AR_RECEIVER_QUERY_WITH_CURSOR = `
 query ($address: String!, $after: String) {
   transactions(first: 10, recipients: [$address], tags: [{ name: "Type", values: ["Transfer"] }], after: $after) {
+    pageInfo {
+      hasNextPage
+    }
     edges {
       cursor
       node {
@@ -158,6 +161,9 @@ query ($address: String!, $after: String) {
 export const AR_SENT_QUERY_WITH_CURSOR = `
 query ($address: String!, $after: String) {
   transactions(first: 10, owners: [$address], tags: [{ name: "Type", values: ["Transfer"] }], after: $after) {
+    pageInfo {
+      hasNextPage
+    }
     edges {
       cursor
       node {
@@ -187,6 +193,9 @@ query($address: String!, $after: String) {
     ],
     after: $after
   ) {
+    pageInfo {
+      hasNextPage
+    }
     edges {
       cursor
       node {
@@ -215,6 +224,9 @@ query($address: String!, $after: String) {
     ],
     after: $after
   ) {
+    pageInfo {
+      hasNextPage
+    }
     edges {
       cursor
       node {

--- a/src/routes/popup/index.tsx
+++ b/src/routes/popup/index.tsx
@@ -1,11 +1,9 @@
 import { useStorage } from "@plasmohq/storage/hook";
 import { ExtensionStorage } from "~utils/storage";
 import { useEffect, useMemo, useState } from "react";
-import Collectibles from "~components/popup/home/Collectibles";
 import WalletHeader from "~components/popup/WalletHeader";
 import NoBalance from "~components/popup/home/NoBalance";
 import Balance from "~components/popup/home/Balance";
-import Tokens from "~components/popup/home/Tokens";
 import { AnnouncementPopup } from "./announcement";
 import { getDecryptionKey, isExpired } from "~wallets/auth";
 import { useHistory } from "~utils/hash_router";
@@ -15,6 +13,7 @@ import { useTokens } from "~tokens";
 import { useAoTokens } from "~tokens/aoTokens/ao";
 import { useActiveWallet, useBalance } from "~wallets/hooks";
 import BuyButton from "~components/popup/home/BuyButton";
+import Tabs from "~components/popup/home/Tabs";
 
 export default function Home() {
   // get if the user has no balance
@@ -121,8 +120,7 @@ export default function Home() {
       {(!noBalance && (
         <>
           <BuyButton />
-          <Tokens />
-          <Collectibles />
+          <Tabs />
         </>
       )) || <NoBalance />}
     </HomeWrapper>

--- a/src/routes/popup/transaction/transactions.tsx
+++ b/src/routes/popup/transaction/transactions.tsx
@@ -1,222 +1,189 @@
 import HeadV2 from "~components/popup/HeadV2";
 import browser from "webextension-polyfill";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ExtensionStorage } from "~utils/storage";
 import { useStorage } from "@plasmohq/storage/hook";
 
 import { gql } from "~gateways/api";
-import type { RawTransaction } from "~notifications/api";
 import styled from "styled-components";
 import { Empty, TitleMessage } from "../notifications";
-import { fetchTokenByProcessId } from "~utils/notifications";
-import { formatAddress } from "~utils/format";
 import { balanceToFractioned, formatFiatBalance } from "~tokens/currency";
 import {
-  AO_RECEIVER_QUERY,
-  AO_SENT_QUERY,
-  AR_RECEIVER_QUERY,
-  AR_SENT_QUERY
+  AO_RECEIVER_QUERY_WITH_CURSOR,
+  AO_SENT_QUERY_WITH_CURSOR,
+  AR_RECEIVER_QUERY_WITH_CURSOR,
+  AR_SENT_QUERY_WITH_CURSOR
 } from "~notifications/utils";
 import { useHistory } from "~utils/hash_router";
 import { getArPrice } from "~lib/coingecko";
 import useSetting from "~settings/hook";
 import { suggestedGateways } from "~gateways/gateway";
+import { ButtonV2, Loading } from "@arconnect/components";
+import type GQLResultInterface from "ar-gql/dist/faces";
+import {
+  sortFn,
+  processTransactions,
+  type GroupedTransactions,
+  type ExtendedTransaction
+} from "~lib/transactions";
 
-type ExtendedTransaction = RawTransaction & {
-  month: number;
-  year: number;
-  transactionType: string;
-  date: string | null;
-  day: number;
-  aoInfo?: {
-    tickerName: string;
-    denomination?: number;
-    quantity: number;
-  };
-};
-
-type GroupedTransactions = {
-  [key: string]: ExtendedTransaction[];
-};
+const defaultCursors = ["", "", "", ""];
+const defaultHasNextPages = [true, true, true, true];
 
 export default function Transactions() {
-  const [transactions, setTransaction] = useState<GroupedTransactions>({});
+  const [cursors, setCursors] = useState(defaultCursors);
+  const [hasNextPages, setHasNextPages] = useState(defaultHasNextPages);
+  const [transactions, setTransactions] = useState<GroupedTransactions>({});
   const [arPrice, setArPrice] = useState(0);
   const [push] = useHistory();
   const [loading, setLoading] = useState(false);
   const [currency] = useSetting<string>("currency");
+
   const [activeAddress] = useStorage<string>({
     key: "active_address",
     instance: ExtensionStorage
   });
 
+  const hasNextPage = useMemo(
+    () => hasNextPages.some((v) => v === true),
+    [hasNextPages]
+  );
+
+  const fetchTransactions = async () => {
+    try {
+      if (!activeAddress) return;
+
+      setLoading(true);
+
+      const queries = [
+        AR_RECEIVER_QUERY_WITH_CURSOR,
+        AR_SENT_QUERY_WITH_CURSOR,
+        AO_SENT_QUERY_WITH_CURSOR,
+        AO_RECEIVER_QUERY_WITH_CURSOR
+      ];
+
+      const [rawReceived, rawSent, rawAoSent, rawAoReceived] =
+        await Promise.allSettled(
+          queries.map((query, idx) => {
+            return hasNextPages[idx]
+              ? gql(
+                  query,
+                  { address: activeAddress, after: cursors[idx] },
+                  suggestedGateways[1]
+                )
+              : ({
+                  data: {
+                    transactions: {
+                      pageInfo: { hasNextPage: false },
+                      edges: []
+                    }
+                  }
+                } as GQLResultInterface);
+          })
+        );
+
+      const sent = await processTransactions(rawSent, "sent");
+      const received = await processTransactions(rawReceived, "sent");
+      const aoSent = await processTransactions(rawAoSent, "aoSent", true);
+      const aoReceived = await processTransactions(
+        rawAoReceived,
+        "aoReceived",
+        true
+      );
+
+      setCursors((prev) =>
+        [received, sent, aoSent, aoReceived].map(
+          (data, idx) => data[data.length - 1]?.cursor ?? prev[idx]
+        )
+      );
+
+      setHasNextPages(
+        [rawReceived, rawSent, rawAoSent, rawAoReceived].map(
+          (result) =>
+            (result.status === "fulfilled" &&
+              result.value?.data?.transactions?.pageInfo?.hasNextPage) ??
+            true
+        )
+      );
+
+      let combinedTransactions: ExtendedTransaction[] = [
+        ...sent,
+        ...received,
+        ...aoReceived,
+        ...aoSent
+      ];
+
+      combinedTransactions = combinedTransactions.map((transaction) => {
+        if (transaction.node.block && transaction.node.block.timestamp) {
+          const date = new Date(transaction.node.block.timestamp * 1000);
+          const day = date.getDate();
+          const month = date.getMonth() + 1;
+          const year = date.getFullYear();
+          return {
+            ...transaction,
+            day,
+            month,
+            year,
+            date: date.toISOString()
+          };
+        } else {
+          const now = new Date();
+          return {
+            ...transaction,
+            day: now.getDate(),
+            month: now.getMonth() + 1,
+            year: now.getFullYear(),
+            date: null
+          };
+        }
+      });
+
+      const groupedTransactions = combinedTransactions.reduce(
+        (acc, transaction) => {
+          const monthYear = `${transaction.month}-${transaction.year}`;
+          if (!acc[monthYear]) {
+            acc[monthYear] = [];
+          }
+          if (!acc[monthYear].some((t) => t.node.id === transaction.node.id)) {
+            acc[monthYear].push(transaction);
+          }
+          return acc;
+        },
+        transactions
+      );
+
+      // Get the month-year keys and sort them in descending order
+      const sortedMonthYears = Object.keys(groupedTransactions).sort((a, b) => {
+        const [monthA, yearA] = a.split("-").map(Number);
+        const [monthB, yearB] = b.split("-").map(Number);
+
+        // Sort by year first, then by month
+        return yearB - yearA || monthB - monthA;
+      });
+
+      // Create a new object with sorted keys
+      const sortedGroupedTransactions: GroupedTransactions =
+        sortedMonthYears.reduce((acc, key) => {
+          acc[key] = groupedTransactions[key].sort(sortFn);
+          return acc;
+        }, {});
+
+      setTransactions(sortedGroupedTransactions);
+    } catch (error) {
+      console.error("Error fetching transactions", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   useEffect(() => {
-    getArPrice(currency)
-      .then((res) => setArPrice(res))
-      .catch();
+    getArPrice(currency).then(setArPrice).catch();
   }, [currency]);
 
   useEffect(() => {
-    const getNotifications = async () => {
-      setLoading(true);
-      try {
-        if (activeAddress) {
-          const [rawReceived, rawSent, rawAoSent, rawAoReceived] =
-            await Promise.all([
-              gql(
-                AR_RECEIVER_QUERY,
-                { address: activeAddress },
-                suggestedGateways[1]
-              ),
-              gql(
-                AR_SENT_QUERY,
-                { address: activeAddress },
-                suggestedGateways[1]
-              ),
-              gql(
-                AO_SENT_QUERY,
-                { address: activeAddress },
-                suggestedGateways[1]
-              ),
-              gql(
-                AO_RECEIVER_QUERY,
-                { address: activeAddress },
-                suggestedGateways[1]
-              )
-            ]);
-
-          const sent: ExtendedTransaction[] =
-            rawSent.data.transactions.edges.map((transaction) => ({
-              ...transaction,
-              transactionType: "sent",
-              day: 0,
-              month: 0,
-              year: 0,
-              date: ""
-            }));
-
-          const received: ExtendedTransaction[] =
-            rawReceived.data.transactions.edges.map((transaction) => ({
-              ...transaction,
-              transactionType: "received",
-              day: 0,
-              month: 0,
-              year: 0,
-              date: ""
-            }));
-
-          const aoSent: ExtendedTransaction[] = await Promise.all(
-            rawAoSent.data.transactions.edges.map(async (transaction) => {
-              const tokenData = await fetchTokenByProcessId(
-                transaction.node.recipient
-              );
-              const quantityTag = transaction.node.tags.find(
-                (tag) => tag.name === "Quantity"
-              );
-              return {
-                ...transaction,
-                transactionType: "aoSent",
-                day: 0,
-                month: 0,
-                year: 0,
-                date: "",
-                aoInfo: {
-                  quantity: quantityTag ? Number(quantityTag.value) : undefined,
-                  tickerName:
-                    tokenData?.Ticker ||
-                    formatAddress(transaction.node.recipient, 4),
-                  denomination: tokenData?.Denomination || 0
-                }
-              };
-            })
-          );
-
-          const aoReceived: ExtendedTransaction[] = await Promise.all(
-            rawAoReceived.data.transactions.edges.map(async (transaction) => {
-              const tokenData = await fetchTokenByProcessId(
-                transaction.node.recipient
-              );
-              const quantityTag = transaction.node.tags.find(
-                (tag) => tag.name === "Quantity"
-              );
-              return {
-                ...transaction,
-                transactionType: "aoReceived",
-                day: 0,
-                month: 0,
-                year: 0,
-                date: "",
-                aoInfo: {
-                  quantity: quantityTag ? Number(quantityTag.value) : undefined,
-                  tickerName:
-                    tokenData?.Ticker ||
-                    formatAddress(transaction.node.recipient, 4),
-                  denomination: tokenData?.Denomination || 1
-                }
-              };
-            })
-          );
-
-          let combinedTransactions: ExtendedTransaction[] = [
-            ...sent,
-            ...received,
-            ...aoReceived,
-            ...aoSent
-          ];
-          combinedTransactions.sort((a, b) => {
-            const timestampA =
-              a.node?.block?.timestamp || Number.MAX_SAFE_INTEGER;
-            const timestampB =
-              b.node?.block?.timestamp || Number.MAX_SAFE_INTEGER;
-            return timestampB - timestampA;
-          });
-
-          combinedTransactions = combinedTransactions.map((transaction) => {
-            if (transaction.node.block && transaction.node.block.timestamp) {
-              const date = new Date(transaction.node.block.timestamp * 1000);
-              const day = date.getDate();
-              const month = date.getMonth() + 1;
-              const year = date.getFullYear();
-              return {
-                ...transaction,
-                day,
-                month,
-                year,
-                date: date.toISOString()
-              };
-            } else {
-              const now = new Date();
-              return {
-                ...transaction,
-                day: now.getDate(),
-                month: now.getMonth() + 1,
-                year: now.getFullYear(),
-                date: null
-              };
-            }
-          });
-
-          const groupedTransactions = combinedTransactions.reduce(
-            (acc, transaction) => {
-              const monthYear = `${transaction.month}-${transaction.year}`;
-              if (!acc[monthYear]) {
-                acc[monthYear] = [];
-              }
-              acc[monthYear].push(transaction);
-              return acc;
-            },
-            {} as { [key: string]: ExtendedTransaction[] }
-          );
-          setTransaction(groupedTransactions);
-        }
-      } catch (error) {
-        console.error("Error fetching transactions", error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    getNotifications();
+    setCursors(defaultCursors);
+    setHasNextPages(defaultHasNextPages);
+    fetchTransactions();
   }, [activeAddress]);
 
   const handleClick = (id: string) => {
@@ -270,9 +237,8 @@ export default function Transactions() {
     <>
       <HeadV2 title={browser.i18n.getMessage("transaction_history_title")} />
       <TransactionsWrapper>
-        {!loading &&
-          (Object.keys(transactions).length > 0 ? (
-            Object.keys(transactions).map((monthYear) => (
+        {Object.keys(transactions).length > 0
+          ? Object.keys(transactions).map((monthYear) => (
               <div key={monthYear}>
                 <Month>{getFullMonthName(monthYear)}</Month>{" "}
                 <TransactionItem>
@@ -306,13 +272,28 @@ export default function Transactions() {
                 </TransactionItem>
               </div>
             ))
-          ) : (
-            <Empty>
-              <TitleMessage>
-                {browser.i18n.getMessage("no_transactions")}
-              </TitleMessage>
-            </Empty>
-          ))}
+          : !loading && (
+              <Empty>
+                <TitleMessage>
+                  {browser.i18n.getMessage("no_transactions")}
+                </TitleMessage>
+              </Empty>
+            )}
+        {hasNextPage && (
+          <ButtonV2
+            disabled={!hasNextPage || loading}
+            style={{ alignSelf: "center", marginTop: "5px" }}
+            onClick={fetchTransactions}
+          >
+            {loading ? (
+              <>
+                Loading <Loading style={{ margin: "0.18rem" }} />
+              </>
+            ) : (
+              "Load more..."
+            )}
+          </ButtonV2>
+        )}
       </TransactionsWrapper>
     </>
   );

--- a/src/routes/popup/transaction/transactions.tsx
+++ b/src/routes/popup/transaction/transactions.tsx
@@ -83,7 +83,7 @@ export default function Transactions() {
         );
 
       const sent = await processTransactions(rawSent, "sent");
-      const received = await processTransactions(rawReceived, "sent");
+      const received = await processTransactions(rawReceived, "received");
       const aoSent = await processTransactions(rawAoSent, "aoSent", true);
       const aoReceived = await processTransactions(
         rawAoReceived,


### PR DESCRIPTION
## Summary

This PR adds the dashboard tabs & `Load more...` button on the Transactions `View All` page to load more transactions.

<image src="https://github.com/arconnectio/ArConnect/assets/11836100/c05a5376-8cd6-4ad7-b915-16339c78f678" width="400px" />
<image src="https://github.com/arconnectio/ArConnect/assets/11836100/fd2d451f-00ac-4c05-9318-2bf1a42fcac1" width="400px" />

## Issue
I think when i am fetching more AO transactions, gateway fetch is timed out.

First fetch the 10 transactions with this query then use the cursor (last cursor from the transactions) to get more 10 transactions. Now, the second query is timed out. Do you have any idea on what might be wrong except gateway's own issue ?

```graphql
query {
  transactions(
    first: 10,
    owners: ["PykWdOZYg0DSmcHX4ts5zs-OJM71tjbR_YFaA-7Jn1k"], 
    tags: [
      {name: "Data-Protocol", values: ["ao"]}, 
      {name: "Action", values: ["Transfer"]}
    ],
    # after: ""
  ) {
    pageInfo {
      hasNextPage
    }
    edges {
      cursor
      node {
        id
        # recipient
        # owner { address }
        block { timestamp, height }
        # tags {
          # name
          # value
        # }
      }
    }
  }
}
```
