### PR TITLE
arc-394:  Adds Token Info Fetching 

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1127,6 +1127,10 @@
     "message": "Remove token",
     "description": "Remove token button text"
   },
+  "refresh_token": {
+    "message": "Refresh token",
+    "description": "Refresh token button text"
+  },
   "your_balance": {
     "message": "Your balance",
     "description": "Balance label for tokens"

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -1123,6 +1123,10 @@
       "message": "移除代币",
       "description": "Remove token button text"
   },
+  "refresh_token": {
+    "message": "刷新令牌",
+    "description": "Refresh token button text"
+  },
   "your_balance": {
       "message": "您的余额",
       "description": "Balance label for tokens"

--- a/shim.d.ts
+++ b/shim.d.ts
@@ -51,6 +51,7 @@ declare module "styled-components" {
     backgroundSecondary: string;
     inputField: string;
     primary: string;
+    backgroundv2;
     cardBorder: string;
     fail: string;
     secondaryDelete: string;

--- a/src/background.ts
+++ b/src/background.ts
@@ -15,6 +15,7 @@ import browser from "webextension-polyfill";
 import { syncLabels } from "~wallets";
 import { trackBalance } from "~utils/analytics";
 import { subscriptionsHandler } from "~subscriptions/api";
+import { aoTokensCacheHandler } from "~tokens/aoTokens/ao";
 
 // watch for API calls
 onMessage("api_call", handleApiCalls);
@@ -36,6 +37,9 @@ browser.alarms.onAlarm.addListener(notificationsHandler);
 browser.alarms.onAlarm.addListener(subscriptionsHandler);
 
 browser.alarms.onAlarm.addListener(trackBalance);
+
+// handle ao tokens info cache update
+browser.alarms.onAlarm.addListener(aoTokensCacheHandler);
 
 // handle alarm for updating gateways
 browser.alarms.onAlarm.addListener(handleGatewayUpdate);

--- a/src/components/dashboard/Tokens.tsx
+++ b/src/components/dashboard/Tokens.tsx
@@ -125,14 +125,6 @@ export default function Tokens() {
           values={tokens}
           style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}
         >
-          {tokens.map((token) => (
-            <TokenListItem
-              token={token}
-              active={activeTokenSetting === token.id}
-              key={token.id}
-            />
-          ))}
-          <Spacer y={2} />
           {enhancedAoTokens.length > 0 && aoSettingsState && (
             <>
               <Label style={{ paddingLeft: "4px", margin: "0" }}>
@@ -150,7 +142,17 @@ export default function Tokens() {
               ))}
             </>
           )}
+          <Spacer y={1} />
+          <Label style={{ paddingLeft: "4px", margin: "0" }}>warp tokens</Label>
+          {tokens.map((token) => (
+            <TokenListItem
+              token={token}
+              active={activeTokenSetting === token.id}
+              key={token.id}
+            />
+          ))}
         </Reorder.Group>
+        <Spacer y={1} />
       </div>
       <ButtonV2 fullWidth onClick={addToken}>
         {browser.i18n.getMessage("import_token")}

--- a/src/components/popup/home/AoBanner.tsx
+++ b/src/components/popup/home/AoBanner.tsx
@@ -4,7 +4,7 @@ import { Quantity } from "ao-tokens";
 import { useEffect, useState } from "react";
 import styled, { useTheme } from "styled-components";
 import browser from "webextension-polyfill";
-import { useAo } from "~tokens/aoTokens/ao";
+import { Id, useAo } from "~tokens/aoTokens/ao";
 import { AO_NATIVE_TOKEN_BALANCE_MIRROR } from "~utils/ao_import";
 import { ExtensionStorage } from "~utils/storage";
 
@@ -19,7 +19,7 @@ export default function AoBanner({ activeAddress }: AoBannerProps) {
 
   async function getAoNativeTokenBalance() {
     const res = await ao.dryrun({
-      Id: "0000000000000000000000000000000000000000001",
+      Id,
       Owner: activeAddress,
       process: AO_NATIVE_TOKEN_BALANCE_MIRROR,
       tags: [{ name: "Action", value: "Balance" }]

--- a/src/routes/auth/signDataItem.tsx
+++ b/src/routes/auth/signDataItem.tsx
@@ -166,7 +166,7 @@ export default function SignDataItem() {
   // get ao token info
   useEffect(() => {
     const fetchTokenInfo = async () => {
-      if (!process) return;
+      if (!process || !transfer) return;
       let tokenInfo: TokenInfo;
       try {
         setLoading(true);

--- a/src/routes/popup/send/index.tsx
+++ b/src/routes/popup/send/index.tsx
@@ -123,7 +123,7 @@ export default function Send({ id }: Props) {
   const [currency] = useSetting<string>("currency");
 
   // aoTokens
-  const [aoTokens, loading] = useAoTokens();
+  const [aoTokens, loading] = useAoTokens(true);
 
   // set ao for following page
   const [isAo, setIsAo] = useState<boolean>(false);

--- a/src/routes/popup/transaction/[id].tsx
+++ b/src/routes/popup/transaction/[id].tsx
@@ -161,7 +161,7 @@ export default function Transaction({ id: rawId, gw, message }: Props) {
           );
 
           if (aoQuantity) {
-            let tokenInfo: TokenInfo;
+            let tokenInfo;
             tokenInfo = await fetchTokenByProcessId(data.transaction.recipient);
             if (!tokenInfo) {
               tokenInfo = (await Token(data.transaction.recipient)).info;

--- a/src/tokens/aoTokens/ao.ts
+++ b/src/tokens/aoTokens/ao.ts
@@ -492,7 +492,7 @@ export interface TokenInfo {
   Name?: string;
   Ticker?: string;
   Logo?: string;
-  Denomination: number;
+  Denomination: number | BigInt;
   processId?: string;
   lastUpdated?: string | null;
 }

--- a/src/tokens/aoTokens/ao.ts
+++ b/src/tokens/aoTokens/ao.ts
@@ -95,7 +95,9 @@ export function useAo() {
   return ao;
 }
 
-export function useAoTokens(): [TokenInfoWithBalance[], boolean] {
+export function useAoTokens(
+  refresh?: boolean
+): [TokenInfoWithBalance[], boolean] {
   const [tokens, setTokens] = useState<TokenInfoWithBalance[]>([]);
   const [balances, setBalances] = useState<{ id: string; balance: number }[]>(
     []
@@ -181,10 +183,13 @@ export function useAoTokens(): [TokenInfoWithBalance[], boolean] {
                       // default return
                       return new Quantity(0, BigInt(12));
                     } else {
-                      const balance = await getAoTokenBalance(
-                        activeAddress,
-                        id
-                      );
+                      let balance: Quantity;
+                      if (refresh) {
+                        const aoToken = await Token(id);
+                        balance = await aoToken.getBalance(activeAddress);
+                      } else {
+                        balance = await getAoTokenBalance(activeAddress, id);
+                      }
                       if (balance) {
                         return balance;
                       } else {
@@ -216,7 +221,10 @@ export function useAoTokens(): [TokenInfoWithBalance[], boolean] {
   return [tokensWithBalances, loading];
 }
 
-export async function getAoTokenBalance(address: string, process: string) {
+export async function getAoTokenBalance(
+  address: string,
+  process: string
+): Promise<Quantity> {
   const aoTokens = (await ExtensionStorage.get<TokenInfo[]>("ao_tokens")) || [];
 
   const aoToken = aoTokens.find((token) => token.processId === process);

--- a/src/tokens/aoTokens/ao.ts
+++ b/src/tokens/aoTokens/ao.ts
@@ -387,7 +387,9 @@ export interface TokenInfo {
   Logo?: string;
   Denomination: number;
   processId?: string;
+  lastUpdated?: string | null;
 }
+
 export interface TokenInfoWithBalance extends TokenInfo {
   id: string;
   balance: number;

--- a/src/tokens/aoTokens/ao.ts
+++ b/src/tokens/aoTokens/ao.ts
@@ -166,47 +166,45 @@ export function useAoTokens(
         const balances = await Promise.all(
           tokens.map(async ({ id }) => {
             try {
-              const balance = Number(
-                await timeoutPromise(
-                  (async () => {
-                    if (id === AO_NATIVE_TOKEN) {
-                      const res = await dryrun({
-                        Id,
-                        Owner: activeAddress,
-                        process: AO_NATIVE_TOKEN_BALANCE_MIRROR,
-                        tags: [{ name: "Action", value: "Balance" }]
-                      });
-                      const balance = res.Messages[0].Data;
-                      if (balance) {
-                        return new Quantity(
-                          BigInt(balance),
-                          BigInt(12)
-                        ).toString();
-                      }
+              const balance = await timeoutPromise(
+                (async () => {
+                  if (id === AO_NATIVE_TOKEN) {
+                    const res = await dryrun({
+                      Id,
+                      Owner: activeAddress,
+                      process: AO_NATIVE_TOKEN_BALANCE_MIRROR,
+                      tags: [{ name: "Action", value: "Balance" }]
+                    });
+                    const balance = res.Messages[0].Data;
+                    if (balance) {
+                      return new Quantity(
+                        BigInt(balance),
+                        BigInt(12)
+                      ).toString();
+                    }
+                    // default return
+                    return new Quantity(0, BigInt(12)).toString();
+                  } else {
+                    let balance: string;
+                    if (refresh) {
+                      const aoToken = await Token(id);
+                      balance = (
+                        await aoToken.getBalance(activeAddress)
+                      ).toString();
+                    } else {
+                      balance = (await getAoTokenBalance(activeAddress, id))
+                        .toString()
+                        .toString();
+                    }
+                    if (balance) {
+                      return balance;
+                    } else {
                       // default return
                       return new Quantity(0, BigInt(12)).toString();
-                    } else {
-                      let balance: string;
-                      if (refresh) {
-                        const aoToken = await Token(id);
-                        balance = (
-                          await aoToken.getBalance(activeAddress)
-                        ).toString();
-                      } else {
-                        balance = (await getAoTokenBalance(activeAddress, id))
-                          .toString()
-                          .toString();
-                      }
-                      if (balance) {
-                        return balance;
-                      } else {
-                        // default return
-                        return new Quantity(0, BigInt(12)).toString();
-                      }
                     }
-                  })(),
-                  10000
-                )
+                  }
+                })(),
+                10000
               );
 
               return {

--- a/src/tokens/aoTokens/ao.ts
+++ b/src/tokens/aoTokens/ao.ts
@@ -492,7 +492,7 @@ export interface TokenInfo {
   Name?: string;
   Ticker?: string;
   Logo?: string;
-  Denomination: number | BigInt;
+  Denomination: number;
   processId?: string;
   lastUpdated?: string | null;
 }

--- a/src/tokens/aoTokens/sync.ts
+++ b/src/tokens/aoTokens/sync.ts
@@ -7,7 +7,9 @@ import {
   getTagValue,
   timeoutPromise,
   type Message,
-  type TokenInfo
+  type TokenInfo,
+  Id,
+  Owner
 } from "./ao";
 
 /** Tokens storage name */
@@ -54,9 +56,9 @@ async function withRetry<T>(
 
 async function getTokenInfo(id: string): Promise<TokenInfo> {
   const body = {
-    Id: "0000000000000000000000000000000000000000001",
+    Id,
     Target: id,
-    Owner: "0000000000000000000000000000000000000000002",
+    Owner,
     Anchor: "0",
     Data: "1234",
     Tags: [

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -30,6 +30,11 @@ export async function onInstalled(details: Runtime.OnInstalledDetailsType) {
   // reset notifications
   // await ExtensionStorage.set("show_announcement", true);
 
+  // initialize alarm to update tokens once a week
+  browser.alarms.create("update_ao_tokens", {
+    periodInMinutes: 10080
+  });
+
   // initialize tokens in wallet
   await loadTokens();
 


### PR DESCRIPTION
- Balances on dashboard are directly queried rather than querying for token info first
- Token Info are queried once a week with manual refreshing able to be called in the Token Settings page
- Balance will call token info if users are on Send page for accuracy 
- signDataItem auth screen will only query for Token Information if it's a `Transfer` (tighter params can be added)