### PR TITLE
fix: Fetch token info to show readable ticker and amount

### DIFF
--- a/src/components/popup/home/Transactions.tsx
+++ b/src/components/popup/home/Transactions.tsx
@@ -2,7 +2,7 @@ import browser from "webextension-polyfill";
 import { useEffect, useState } from "react";
 import { ExtensionStorage } from "~utils/storage";
 import { useStorage } from "@plasmohq/storage/hook";
-import { Text } from "@arconnect/components";
+import { Loading, Text } from "@arconnect/components";
 
 import { gql } from "~gateways/api";
 import styled from "styled-components";
@@ -207,6 +207,11 @@ export default function Transactions() {
               {browser.i18n.getMessage("no_transactions")}
             </NoTransactions>
           ))}
+        {loading && (
+          <LoadingWrapper>
+            <Loading style={{ width: "20px", height: "20px" }} />
+          </LoadingWrapper>
+        )}
       </TransactionsWrapper>
     </>
   );
@@ -278,4 +283,11 @@ const NoTransactions = styled(Text).attrs({
   noMargin: true
 })`
   text-align: center;
+`;
+
+const LoadingWrapper = styled.div`
+  margin: auto;
+  display: flex;
+  justify-content: center;
+  align-items: top;
 `;

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -4,8 +4,11 @@ import type { RawTransaction } from "~notifications/api";
 import type { TokenInfo } from "~tokens/aoTokens/ao";
 import { formatAddress } from "~utils/format";
 import { ExtensionStorage } from "~utils/storage";
+import { getTokenInfo } from "~tokens/aoTokens/router";
+import type { Token } from "~tokens/token";
 
 let tokens: TokenInfo[] = null;
+export let tokenInfoMap = new Map<string, TokenInfo | Token>();
 
 export type ExtendedTransaction = RawTransaction & {
   cursor: string;
@@ -31,21 +34,45 @@ export function sortFn(a: ExtendedTransaction, b: ExtendedTransaction) {
   return timestampB - timestampA;
 }
 
+async function fetchTokenInfo(processId: string) {
+  try {
+    if (tokenInfoMap.has(processId)) {
+      return tokenInfoMap.get(processId) as TokenInfo;
+    }
+
+    const tokenInfo = await getTokenInfo(processId);
+    tokenInfoMap.set(processId, tokenInfo);
+    return tokenInfo;
+  } catch {
+    return null;
+  }
+}
+
 export const fetchTokenByProcessId = async (
   processId: string
-): Promise<TokenInfo> => {
-  if (!tokens) {
-    const aoTokens =
-      (await ExtensionStorage.get<TokenInfo[]>("ao_tokens")) || [];
-    const aoTokensCache =
-      (await ExtensionStorage.get<TokenInfo[]>("ao_tokens_cache")) || [];
-
-    tokens = [...aoTokens, ...aoTokensCache];
+): Promise<TokenInfo | null> => {
+  if (tokenInfoMap.has(processId)) {
+    return tokenInfoMap.get(processId) as TokenInfo;
   }
 
-  if (!tokens || !processId) return null;
+  if (!tokens) {
+    const [aoTokens, aoTokensCache] = await Promise.all([
+      ExtensionStorage.get<TokenInfo[]>("ao_tokens"),
+      ExtensionStorage.get<TokenInfo[]>("ao_tokens_cache")
+    ]);
 
-  return tokens.find((token) => token.processId === processId);
+    tokens = [...(aoTokens || []), ...(aoTokensCache || [])];
+  }
+
+  if (!processId) return null;
+
+  const tokenInfo = tokens.find((token) => token.processId === processId);
+  if (tokenInfo) {
+    tokenInfoMap.set(processId, tokenInfo);
+    return tokenInfo;
+  }
+
+  return fetchTokenInfo(processId);
 };
 
 const processTransaction = (transaction: GQLEdgeInterface, type: string) => ({

--- a/src/tokens/index.ts
+++ b/src/tokens/index.ts
@@ -2,7 +2,6 @@ import { DREContract, DRENode, NODES } from "@arconnect/warp-dre";
 import type { EvalStateResult } from "warp-contracts";
 import { useStorage } from "@plasmohq/storage/hook";
 import { ExtensionStorage } from "~utils/storage";
-import { type Gateway } from "~gateways/gateway";
 import { isTokenState } from "~utils/assertions";
 import { useEffect, useState } from "react";
 import { getActiveAddress } from "~wallets";
@@ -64,12 +63,7 @@ export async function getAoTokens() {
   return tokens || [];
 }
 
-/**
- * Add a token to the stored tokens
- *
- * @param id ID of the token contract
- */
-export async function addToken(id: string, type: TokenType, dre?: string) {
+export async function getToken(id: string, type: TokenType, dre?: string) {
   // dre
   if (!dre) dre = await getDreForToken(id);
   const contract = new DREContract(id, new DRENode(dre));
@@ -88,10 +82,7 @@ export async function addToken(id: string, type: TokenType, dre?: string) {
   // parse settings
   const settings = getSettings(state);
 
-  // get tokens
-  const tokens = await getTokens();
-
-  tokens.push({
+  return {
     id,
     name: state.name,
     ticker: state.ticker,
@@ -101,7 +92,21 @@ export async function addToken(id: string, type: TokenType, dre?: string) {
     decimals: state.decimals,
     defaultLogo: settings.get("communityLogo") as string,
     dre
-  });
+  } as Token;
+}
+
+/**
+ * Add a token to the stored tokens
+ *
+ * @param id ID of the token contract
+ */
+export async function addToken(id: string, type: TokenType, dre?: string) {
+  const token = await getToken(id, type, dre);
+
+  // get tokens
+  const tokens = await getTokens();
+
+  tokens.push(token);
   await ExtensionStorage.set("tokens", tokens);
 }
 


### PR DESCRIPTION
## Summary

This PR fetches token info for tokens not found in storage to ensure notifications and transaction history display the human readable ticker and amount.

## Optimization
Currently, tokens not found in storage are fetched and cached only for the duration of a session, meaning they are re-fetched each time a new popup is triggered. To enhance efficiency, should we consider caching this information in storage, or do you have any other suggestions for improving this process?