### PR TITLE
feat(keystone): support ao signing

### DIFF
--- a/src/api/modules/connect/auth.ts
+++ b/src/api/modules/connect/auth.ts
@@ -11,7 +11,7 @@ export type AuthType =
   | "token"
   | "sign"
   | "subscription"
-  | "signMessage"
+  | "signKeystone"
   | "signature"
   | "signDataItem";
 

--- a/src/api/modules/sign/chunks.ts
+++ b/src/api/modules/sign/chunks.ts
@@ -7,7 +7,7 @@ import { nanoid } from "nanoid";
  */
 export interface Chunk {
   collectionID: string; // unique ID for the collection, that is the parent of this chunk
-  type: "tag" | "data" | "start" | "end";
+  type: "tag" | "data" | "bytes" | "start" | "end";
   index: number; // index of the chunk, to make sure it is not in the wrong order
   value?: number[] | Tag; // Uint8Array converted to number array or a tag
 }

--- a/src/api/modules/sign/sign_auth.ts
+++ b/src/api/modules/sign/sign_auth.ts
@@ -1,8 +1,9 @@
 import { onMessage, sendMessage } from "@arconnect/webext-bridge";
-import { deconstructTransaction } from "./transaction_builder";
+import { bytesToChunks, deconstructTransaction } from "./transaction_builder";
 import type Transaction from "arweave/web/lib/transaction";
 import type { AuthResult } from "shim";
 import authenticate from "../connect/auth";
+import { nanoid } from "nanoid";
 
 /**
  * Request a manual signature for the transaction.
@@ -73,15 +74,57 @@ export const signAuth = (
     }
   );
 
-export const signAuthMessage = (dataToSign: Uint8Array) =>
+export type AuthKeystoneType = "Message" | "DataItem";
+
+export interface AuthKeystoneData {
+  type: AuthKeystoneType;
+  data: Uint8Array;
+}
+
+export const signAuthKeystone = (dataToSign: AuthKeystoneData) =>
   new Promise<AuthResult<{ id: string; signature: string } | undefined>>(
     (resolve, reject) => {
       // start auth
+      const collectionID = nanoid();
       authenticate({
-        type: "signMessage",
-        data: Buffer.from(dataToSign).toString("base64")
+        type: "signKeystone",
+        keystoneSignType: dataToSign.type,
+        collectionID
       })
         .then((res) => resolve(res))
         .catch((err) => reject(err));
+      const dataChunks = bytesToChunks(dataToSign.data, collectionID, 0);
+
+      // send tx in chunks to sign if requested
+      onMessage("auth_listening", async ({ sender }) => {
+        if (sender.context !== "web_accessible") return;
+
+        // send data chunks
+        for (const chunk of dataChunks) {
+          try {
+            await sendMessage(
+              "auth_chunk",
+              chunk,
+              `web_accessible@${sender.tabId}`
+            );
+          } catch (e) {
+            // chunk fail
+            return reject(
+              `Error while sending a data chunk of collection "${collectionID}": \n${e}`
+            );
+          }
+        }
+
+        // end chunk
+        await sendMessage(
+          "auth_chunk",
+          {
+            collectionID,
+            type: "end",
+            index: dataChunks.length
+          },
+          `web_accessible@${sender.tabId}`
+        );
+      });
     }
   );

--- a/src/api/modules/sign_message/sign_message.background.ts
+++ b/src/api/modules/sign_message/sign_message.background.ts
@@ -8,7 +8,7 @@ import {
   isNumberArray,
   isSignMessageOptions
 } from "~utils/assertions";
-import { signAuthMessage } from "../sign/sign_auth";
+import { signAuthKeystone, type AuthKeystoneData } from "../sign/sign_auth";
 import Arweave from "arweave";
 
 const background: ModuleFunction<number[]> = async (
@@ -66,7 +66,11 @@ const background: ModuleFunction<number[]> = async (
 
     return Array.from(new Uint8Array(signature));
   } else {
-    const res = await signAuthMessage(dataToSign);
+    const data: AuthKeystoneData = {
+      type: "Message",
+      data: dataToSign
+    };
+    const res = await signAuthKeystone(data);
     const sig = Arweave.utils.b64UrlToBuffer(res.data.signature);
     return Array.from(sig);
   }

--- a/src/routes/popup/send/confirm.tsx
+++ b/src/routes/popup/send/confirm.tsx
@@ -520,11 +520,12 @@ export default function Confirm({ tokenID, qty, subscription }: Props) {
   const keystoneInteraction = useMemo(() => {
     const keystoneInteraction: KeystoneInteraction = {
       display(data) {
+        setIsLoading(false);
         setTransactionUR(data);
       }
     };
     return keystoneInteraction;
-  }, []);
+  }, [setIsLoading]);
 
   const keystoneSigner = useMemo(() => {
     if (wallet?.type !== "hardware") return null;
@@ -539,6 +540,7 @@ export default function Confirm({ tokenID, qty, subscription }: Props) {
 
   useEffect(() => {
     (async () => {
+      setIsLoading(true);
       if (!recipient?.address) return;
 
       // get the tx from storage
@@ -587,6 +589,7 @@ export default function Confirm({ tokenID, qty, subscription }: Props) {
 
       // get tx UR
       try {
+        setIsLoading(false);
         setTransactionUR(
           await transactionToUR(
             convertedTransaction,
@@ -604,7 +607,7 @@ export default function Confirm({ tokenID, qty, subscription }: Props) {
         push("/send/transfer");
       }
     })();
-  }, [wallet, recipient, keystoneSigner]);
+  }, [wallet, recipient, keystoneSigner, setIsLoading]);
 
   // current hardware wallet operation
   const [hardwareStatus, setHardwareStatus] = useState<"play" | "scan">();

--- a/src/routes/popup/send/confirm.tsx
+++ b/src/routes/popup/send/confirm.tsx
@@ -45,16 +45,26 @@ import {
 import { fractionedToBalance } from "~tokens/currency";
 import { type Token } from "~tokens/token";
 import { useContact } from "~contacts/hooks";
-import { sendAoTransfer, useAo } from "~tokens/aoTokens/ao";
+import {
+  sendAoTransfer,
+  sendAoTransferKeystone,
+  useAo
+} from "~tokens/aoTokens/ao";
 import { useActiveWallet } from "~wallets/hooks";
 import { UR } from "@ngraveio/bc-ur";
-import { decodeSignature, transactionToUR } from "~wallets/hardware/keystone";
+import {
+  KeystoneSigner,
+  decodeSignature,
+  transactionToUR,
+  type KeystoneInteraction
+} from "~wallets/hardware/keystone";
 import { useScanner } from "@arconnect/keystone-sdk";
 import Progress from "~components/Progress";
 import { updateSubscription } from "~subscriptions";
 import { SubscriptionStatus } from "~subscriptions/subscription";
 import { checkPassword } from "~wallets/auth";
 import BigNumber from "bignumber.js";
+import { SignType } from "@keystonehq/bc-ur-registry-arweave";
 
 interface Props {
   tokenID: string;
@@ -507,6 +517,26 @@ export default function Confirm({ tokenID, qty, subscription }: Props) {
   const [transactionUR, setTransactionUR] = useState<UR>();
   const [preparedTx, setPreparedTx] = useState<Partial<RawStoredTransfer>>();
 
+  const keystoneInteraction = useMemo(() => {
+    const keystoneInteraction: KeystoneInteraction = {
+      display(data) {
+        setTransactionUR(data);
+      }
+    };
+    return keystoneInteraction;
+  }, []);
+
+  const keystoneSigner = useMemo(() => {
+    if (wallet?.type !== "hardware") return null;
+    const keystoneSigner = new KeystoneSigner(
+      Buffer.from(Arweave.utils.b64UrlToBuffer(wallet.publicKey)),
+      wallet.xfp,
+      isAo ? SignType.DataItem : SignType.Transaction,
+      keystoneInteraction
+    );
+    return keystoneSigner;
+  }, [wallet, isAo, keystoneInteraction]);
+
   useEffect(() => {
     (async () => {
       if (!recipient?.address) return;
@@ -523,6 +553,32 @@ export default function Confirm({ tokenID, qty, subscription }: Props) {
       // check if the current wallet
       // is a hardware wallet
       if (wallet?.type !== "hardware") return;
+
+      if (isAo) {
+        try {
+          setPreparedTx(prepared);
+          const res = await sendAoTransferKeystone(
+            ao,
+            tokenID,
+            recipient.address,
+            fractionedToBalance(amount, token, "AO"),
+            keystoneSigner
+          );
+          if (res) {
+            setToast({
+              type: "success",
+              content: browser.i18n.getMessage("sent_tx"),
+              duration: 2000
+            });
+            push(`/transaction/${res}`);
+            setIsLoading(false);
+          }
+          return res;
+        } catch (err) {
+          console.log("err in ao", err);
+          throw err;
+        }
+      }
 
       const arweave = new Arweave(prepared.gateway);
       const convertedTransaction = arweave.transactions.fromRaw(
@@ -548,7 +604,7 @@ export default function Confirm({ tokenID, qty, subscription }: Props) {
         push("/send/transfer");
       }
     })();
-  }, [wallet, recipient]);
+  }, [wallet, recipient, keystoneSigner]);
 
   // current hardware wallet operation
   const [hardwareStatus, setHardwareStatus] = useState<"play" | "scan">();
@@ -581,6 +637,11 @@ export default function Confirm({ tokenID, qty, subscription }: Props) {
 
         // decode signature
         const { id, signature } = await decodeSignature(res);
+
+        if (isAo) {
+          keystoneSigner.submitSignature(signature);
+          return;
+        }
 
         // set signature
         transaction.setSignature({

--- a/src/routes/popup/send/index.tsx
+++ b/src/routes/popup/send/index.tsx
@@ -138,9 +138,6 @@ export default function Send({ id }: Props) {
     "token"
   );
 
-  const wallet = useActiveWallet();
-  const keystoneError = wallet?.type === "hardware" && isAo;
-
   // tokens
   const tokens = useTokens();
 
@@ -428,32 +425,21 @@ export default function Send({ id }: Props) {
       {AO_NATIVE_TOKEN === tokenID && (
         <AnnouncementPopup isOpen={isOpen} setOpen={setOpen} />
       )}
-      <Wrapper showOverlay={showSlider || degraded || keystoneError}>
+      <Wrapper showOverlay={showSlider || degraded}>
         <SendForm>
           {/* TOP INPUT */}
-          {(keystoneError || degraded) && (
+          {degraded && (
             <Degraded>
               <WarningWrapper>
                 <WarningIcon color={theme === "dark" ? "#fff" : "#000"} />
               </WarningWrapper>
               <div>
-                {keystoneError ? (
-                  <>
-                    <h4>{browser.i18n.getMessage("keystone_ao_title")}</h4>
-                    <span>
-                      {browser.i18n.getMessage("keystone_ao_description")}
-                    </span>
-                  </>
-                ) : (
-                  <>
-                    <h4>{browser.i18n.getMessage("ao_degraded")}</h4>
-                    <span>
-                      {browser.i18n
-                        .getMessage("ao_degraded_description")
-                        .replace("<br/>", "")}
-                    </span>
-                  </>
-                )}
+                <h4>{browser.i18n.getMessage("ao_degraded")}</h4>
+                <span>
+                  {browser.i18n
+                    .getMessage("ao_degraded_description")
+                    .replace("<br/>", "")}
+                </span>
               </div>
             </Degraded>
           )}

--- a/src/tabs/auth.tsx
+++ b/src/tabs/auth.tsx
@@ -16,7 +16,7 @@ import SignDataItem from "~routes/auth/signDataItem";
 import Token from "~routes/auth/token";
 import Sign from "~routes/auth/sign";
 import Subscription from "~routes/auth/subscription";
-import SignMessage from "~routes/auth/signMessage";
+import SignKeystone from "~routes/auth/signKeystone";
 
 export default function Auth() {
   const theme = useTheme();
@@ -36,7 +36,7 @@ export default function Auth() {
             <Route path="/unlock" component={Unlock} />
             <Route path="/token" component={Token} />
             <Route path="/sign" component={Sign} />
-            <Route path="/signMessage" component={SignMessage} />
+            <Route path="/signKeystone" component={SignKeystone} />
             <Route path="/signature" component={Signature} />
             <Route path="/subscription" component={Subscription} />
             <Route path="/signDataItem" component={SignDataItem} />

--- a/src/tokens/aoTokens/ao.ts
+++ b/src/tokens/aoTokens/ao.ts
@@ -14,6 +14,7 @@ import {
   AO_NATIVE_TOKEN_BALANCE_MIRROR
 } from "~utils/ao_import";
 import type { Alarms } from "webextension-polyfill";
+import type { KeystoneSigner } from "~wallets/hardware/keystone";
 
 export type AoInstance = ReturnType<typeof connect>;
 
@@ -484,6 +485,54 @@ export const aoTokensCacheHandler = async (alarmInfo?: Alarms.Alarm) => {
     }
   }
   await ExtensionStorage.set("ao_tokens", updatedTokens);
+}
+
+export const sendAoTransferKeystone = async (
+  ao: AoInstance,
+  process: string,
+  recipient: string,
+  amount: string,
+  keystoneSigner: KeystoneSigner
+) => {
+  try {
+    const dataItemSigner = async ({
+      data,
+      tags = [],
+      target,
+      anchor
+    }: {
+      data: any;
+      tags?: { name: string; value: string }[];
+      target?: string;
+      anchor?: string;
+    }): Promise<{ id: string; raw: ArrayBuffer }> => {
+      const signer = keystoneSigner;
+      const dataItem = createData(data, signer, { tags, target, anchor });
+      const serial = dataItem.getRaw();
+      const signature = await signer.sign(serial);
+      dataItem.setSignature(Buffer.from(signature));
+
+      return {
+        id: dataItem.id,
+        raw: dataItem.getRaw()
+      };
+    };
+    const transferID = await ao.message({
+      process,
+      signer: dataItemSigner,
+      tags: [
+        { name: "Action", value: "Transfer" },
+        {
+          name: "Recipient",
+          value: recipient
+        },
+        { name: "Quantity", value: amount }
+      ]
+    });
+    return transferID;
+  } catch (err) {
+    console.log("err", err);
+  }
 };
 
 export interface TokenInfo {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -8,11 +8,14 @@ import type { AuthResult } from "shim";
  * Hook to parse auth params from the url
  */
 export function useAuthParams<T = {}>() {
+  console.log("useAuthParams");
   const [params, setParams] = useState<AuthDataWithID & T>();
 
   // fetch params
   useEffect(() => {
+    console.log("here", window.location.href);
     const urlParams = window.location.href.split("?");
+    console.log("here", urlParams);
     const params = objectFromUrlParams<AuthDataWithID & T>(
       urlParams[urlParams.length - 1].replace(window.location.hash, "")
     );

--- a/src/utils/data_item.ts
+++ b/src/utils/data_item.ts
@@ -1,0 +1,39 @@
+import {
+  ArweaveSigner,
+  DataItem,
+  Signer,
+  createData,
+  type DataItemCreateOptions
+} from "arbundles";
+
+export interface SignerConfig {
+  signatureType: number;
+  signatureLength: number;
+  ownerLength: number;
+  publicKey: Buffer;
+}
+
+class DummySigner implements Signer {
+  publicKey: Buffer;
+  signatureType: number;
+  signatureLength: number;
+  ownerLength: number;
+  pem?: string | Buffer;
+  constructor(signerConfig: SignerConfig) {
+    this.publicKey = signerConfig.publicKey;
+    this.signatureLength = signerConfig.signatureLength;
+    this.signatureType = signerConfig.signatureType;
+    this.ownerLength = signerConfig.ownerLength;
+  }
+  sign(message: Uint8Array, _opts?: any): Uint8Array | Promise<Uint8Array> {
+    throw new Error("Method not implemented.");
+  }
+}
+
+export const createDataItem = (
+  binary: Uint8Array,
+  signerConfig: SignerConfig,
+  options: DataItemCreateOptions
+): DataItem => {
+  return createData(binary, new DummySigner(signerConfig), options);
+};

--- a/src/wallets/hardware/keystone.ts
+++ b/src/wallets/hardware/keystone.ts
@@ -143,6 +143,24 @@ export async function messageToUR(
   return signRequest.toUR();
 }
 
+export async function dataItemToUR(
+  data: Uint8Array,
+  xfp: string,
+  options: SignatureOptions = { saltLength: 32 }
+) {
+  const messageBuff = Buffer.from(data);
+
+  // construct request
+  const signRequest = ArweaveSignRequest.constructArweaveRequest(
+    messageBuff,
+    xfp,
+    SignType.DataItem,
+    options.saltLength
+  );
+
+  return signRequest.toUR();
+}
+
 /**
  * Decode cbor result from a keystone QR code
  * with an Arweave transaction


### PR DESCRIPTION
This PR adds support for AO transfer with Keystone 3 Pro. 
Changes: 
1. Add class `KeystoneSigner` to fit the API for signing AO messages.
2. Change transaction sending process by adding a new logic branch to prepare AO transaction for Keystone and get signature from Keystone. 
3. Change the SignMessage component to SignKeystone for signing DataItem with Keystone