### PR TITLE
fix: Endless spinner issue when loading AR balance on dashboard

### DIFF
--- a/src/components/popup/home/Balance.tsx
+++ b/src/components/popup/home/Balance.tsx
@@ -124,7 +124,7 @@ export default function Balance() {
   }
 
   useEffect(() => {
-    if (!balance.isEqualTo(historicalBalance[0])) {
+    if (parseFloat(balance.toString()) !== historicalBalance[0]) {
       setLoading(true);
     } else {
       setLoading(false);


### PR DESCRIPTION
## Summary

This PR fixes the endless spinner issue when loading AR balance on dashboard by comparing the float balance value to historical balance as the historical balances are float value of balances.

## How to Test
- Test the balances of the current wallets.
- Test the balance of the wallet where the issue was occurring.