### PR TITLE
refactor: Add retries & toast error when quote fetch failed

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -2179,5 +2179,9 @@
   "mismatch_warning": {
     "message": "Your wallet has a mismatched bit length. You can proceed, but may encounter errors. Transactions could fail or behave unexpectedly.",
     "description": "warning for mismatch wallet"
+  },
+  "transak_unavailable": {
+    "message": "Transak is unavailable at the moment. Please try again later.",
+    "description": "Transak unavailable error message"
   }
 }

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -2165,5 +2165,9 @@
   "mismatch_warning": {
     "message": "您的钱包存在不匹配的位长度。您可以继续操作，但可能会遇到错误。交易可能会失败或表现异常。",
     "description": "warning for mismatch wallet"
+  },
+  "transak_unavailable": {
+    "message": "Transak 目前不可用。请稍后再试。",
+    "description": "Transak unavailable error message"
   }
 }

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,32 @@
+/**
+ * Retries a given function up to a maximum number of attempts.
+ * @param fn - The asynchronous function to retry, which should return a Promise.
+ * @param maxAttempts - The maximum number of attempts to make.
+ * @param delay - The delay between attempts in milliseconds.
+ * @return A Promise that resolves with the result of the function or rejects after all attempts fail.
+ */
+export async function retryWithDelay<T>(
+  fn: () => Promise<T>,
+  maxAttempts: number = 3,
+  delay: number = 1000
+): Promise<T> {
+  let attempts = 0;
+
+  const attempt = async (): Promise<T> => {
+    try {
+      return await fn();
+    } catch (error) {
+      attempts += 1;
+      if (attempts < maxAttempts) {
+        // console.log(`Attempt ${attempts} failed, retrying...`)
+        return new Promise<T>((resolve) =>
+          setTimeout(() => resolve(attempt()), delay)
+        );
+      } else {
+        throw error;
+      }
+    }
+  };
+
+  return attempt();
+}


### PR DESCRIPTION
## Summary

This PR adds the following:
- Retries to fetching Transak quote
- Show error toast when Transak quote fetch failed like due to:
  - api error (server not responding)
  - client error (showing error on minimum amount required or payment not supported)