### PR TITLE
fix: Throw error on ao token negative & zero amount quantity

### DIFF
--- a/src/lib/ao.ts
+++ b/src/lib/ao.ts
@@ -66,9 +66,12 @@ export class AOProcess {
     this.processId = processId;
     this.ao = connect({
       GRAPHQL_URL:
-        connectionConfig?.GATEWAY_URL ??
-        joinUrl({ url: defaultConfig.GATEWAY_URL, path: "graphql" }),
-      CU_URL: connectionConfig?.GATEWAY_URL ?? defaultConfig.CU_URL,
+        connectionConfig?.GRAPHQL_URL ??
+        joinUrl({
+          url: connectionConfig?.GATEWAY_URL ?? defaultConfig.GATEWAY_URL,
+          path: "graphql"
+        }),
+      CU_URL: connectionConfig?.CU_URL ?? defaultConfig.CU_URL,
       MU_URL: connectionConfig?.MU_URL ?? defaultConfig.MU_URL,
       GATEWAY_URL: connectionConfig?.GATEWAY_URL ?? defaultConfig.GATEWAY_URL
     });

--- a/src/routes/popup/transaction/[id].tsx
+++ b/src/routes/popup/transaction/[id].tsx
@@ -46,9 +46,7 @@ import { TempTransactionStorage } from "~utils/storage";
 import { useContact } from "~contacts/hooks";
 import { EventType, PageType, trackEvent, trackPage } from "~utils/analytics";
 import BigNumber from "bignumber.js";
-import { Token } from "ao-tokens";
 import { fetchTokenByProcessId } from "~lib/transactions";
-import type { TokenInfo } from "~tokens/aoTokens/ao";
 
 // pull contacts and check if to address is in contacts
 
@@ -161,11 +159,9 @@ export default function Transaction({ id: rawId, gw, message }: Props) {
           );
 
           if (aoQuantity) {
-            let tokenInfo;
-            tokenInfo = await fetchTokenByProcessId(data.transaction.recipient);
-            if (!tokenInfo) {
-              tokenInfo = (await Token(data.transaction.recipient)).info;
-            }
+            const tokenInfo = await fetchTokenByProcessId(
+              data.transaction.recipient
+            );
             if (tokenInfo) {
               const amount = balanceToFractioned(aoQuantity.value, {
                 id: data.transaction.recipient,


### PR DESCRIPTION
## Summary

This PR fixes the ArConnect popup crash by throwing error when AO token quantity is negative, non-number or zero.

## How to Test
1. Goto [AO Link](https://www.ao.link/#/entity/agYcCFJtrMG6cqMuZfskIkFTGvUPddICmtQSBIoPdiA?tab=write), scroll down and connect the wallet and send the following message pasting on the Query.

  ```json
  {
    "process": "agYcCFJtrMG6cqMuZfskIkFTGvUPddICmtQSBIoPdiA",
    "data": "",
    "tags": [
      {
        "name": "Action",
        "value": "Transfer"
      },
        {
        "name": "Recipient",
        "value": "7waR8v4STuwPnTck1zFVkQqJh5K9q9Zik4Y5-5dV7nk"
      },
        {
        "name": "Quantity",
        "value": "-1"
      }
    ]
  }
  ```
  2. Repeat 1. for both this PR and development branch.