### PR TITLE
refactor: Show all AR transactions in TX history & notifications

### DIFF
--- a/src/components/popup/home/Balance.tsx
+++ b/src/components/popup/home/Balance.tsx
@@ -204,7 +204,7 @@ async function balanceHistory(address: string, gateway: Gateway) {
     await gql(
       `
       query($recipient: String!) {
-        transactions(recipients: [$recipient], first: 100) {
+        transactions(recipients: [$recipient], first: 100, bundledIn: null) {
           edges {
             node {
               owner {
@@ -231,7 +231,7 @@ async function balanceHistory(address: string, gateway: Gateway) {
     await gql(
       `
       query($owner: String!) {
-        transactions(owners: [$owner], first: 100) {
+        transactions(owners: [$owner], first: 100, bundledIn: null) {
           edges {
             node {
               owner {

--- a/src/components/popup/home/Transactions.tsx
+++ b/src/components/popup/home/Transactions.tsx
@@ -27,6 +27,7 @@ import {
   sortFn,
   type ExtendedTransaction
 } from "~lib/transactions";
+import BigNumber from "bignumber.js";
 
 export default function Transactions() {
   const [transactions, fetchTransactions] = useState<ExtendedTransaction[]>([]);
@@ -62,8 +63,12 @@ export default function Transactions() {
               )
             );
 
-          const sent = await processTransactions(rawSent, "sent");
-          const received = await processTransactions(rawReceived, "received");
+          let sent = await processTransactions(rawSent, "sent");
+          sent = sent.filter((tx) => BigNumber(tx.node.quantity.ar).gt(0));
+          let received = await processTransactions(rawReceived, "received");
+          received = received.filter((tx) =>
+            BigNumber(tx.node.quantity.ar).gt(0)
+          );
           const aoSent = await processTransactions(rawAoSent, "aoSent", true);
           const aoReceived = await processTransactions(
             rawAoReceived,

--- a/src/notifications/utils.ts
+++ b/src/notifications/utils.ts
@@ -2,8 +2,7 @@
 
 export const AR_RECEIVER_QUERY = `
 query ($address: String!) {
-  transactions(first: 10, recipients: [$address], tags: [{ name: "Type", values: ["Transfer"] }]) {
-
+  transactions(first: 10, recipients: [$address], bundledIn: null) {
     edges {
       cursor
       node {
@@ -23,7 +22,7 @@ query ($address: String!) {
 `;
 
 export const AR_SENT_QUERY = `query ($address: String!) {
-  transactions(first: 10, owners: [$address], tags: [{ name: "Type", values: ["Transfer"] }]) {
+  transactions(first: 10, owners: [$address], bundledIn: null) {
     edges {
       cursor
       node {
@@ -136,7 +135,7 @@ export const ALL_AR_SENT_QUERY = `query ($address: String!) {
 
 export const AR_RECEIVER_QUERY_WITH_CURSOR = `
 query ($address: String!, $after: String) {
-  transactions(first: 10, recipients: [$address], tags: [{ name: "Type", values: ["Transfer"] }], after: $after) {
+  transactions(first: 10, recipients: [$address], bundledIn: null, after: $after) {
     pageInfo {
       hasNextPage
     }
@@ -160,7 +159,7 @@ query ($address: String!, $after: String) {
 
 export const AR_SENT_QUERY_WITH_CURSOR = `
 query ($address: String!, $after: String) {
-  transactions(first: 10, owners: [$address], tags: [{ name: "Type", values: ["Transfer"] }], after: $after) {
+  transactions(first: 10, owners: [$address], bundledIn: null, after: $after) {
     pageInfo {
       hasNextPage
     }

--- a/src/routes/popup/transaction/transactions.tsx
+++ b/src/routes/popup/transaction/transactions.tsx
@@ -29,6 +29,7 @@ import {
   getFullMonthName,
   getTransactionDescription
 } from "~lib/transactions";
+import BigNumber from "bignumber.js";
 
 const defaultCursors = ["", "", "", ""];
 const defaultHasNextPages = [true, true, true, true];
@@ -85,8 +86,8 @@ export default function Transactions() {
           })
         );
 
-      const sent = await processTransactions(rawSent, "sent");
-      const received = await processTransactions(rawReceived, "received");
+      let sent = await processTransactions(rawSent, "sent");
+      let received = await processTransactions(rawReceived, "received");
       const aoSent = await processTransactions(rawAoSent, "aoSent", true);
       const aoReceived = await processTransactions(
         rawAoReceived,
@@ -99,6 +100,9 @@ export default function Transactions() {
           (data, idx) => data[data.length - 1]?.cursor ?? prev[idx]
         )
       );
+
+      sent = sent.filter((tx) => BigNumber(tx.node.quantity.ar).gt(0));
+      received = received.filter((tx) => BigNumber(tx.node.quantity.ar).gt(0));
 
       setHasNextPages(
         [rawReceived, rawSent, rawAoSent, rawAoReceived].map(


### PR DESCRIPTION
## Summary

This PR makes sure we show all AR transactions in TX history and notifications and show the balance chart for last 30 days.

## How to Test
- Try to mimic the address in this [TX](https://viewblock.io/arweave/tx/EhjG7DPvoRVHjvoAuDLzIvkWeKAQ498BrMx_BApuP3g) and see if you can see this transaction in your notifications and TX history.
- Balance chart is shown for the last 30 days only. Make sure the chart is correct.
- Also, review the code to see if everything looks good and working.