### PR TITLE
fix: Prevent popup freeze by sending keep-alive alarm to background

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -54,6 +54,13 @@ browser.alarms.onAlarm.addListener(keyRemoveAlarmListener);
 // handle importing ao tokens
 browser.alarms.onAlarm.addListener(importAoTokens);
 
+// handle keep alive alarm
+browser.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === "keep-alive") {
+    console.log("keep alive alarm");
+  }
+});
+
 // handle window close
 browser.windows.onRemoved.addListener(onWindowClose);
 

--- a/src/utils/mutex.ts
+++ b/src/utils/mutex.ts
@@ -1,0 +1,14 @@
+export class Mutex {
+  private mutex = Promise.resolve();
+
+  lock(): Promise<() => void> {
+    let unlockNext: () => void;
+    const willLock = new Promise<void>((resolve) => (unlockNext = resolve));
+    // To release the lock
+    const unlock = () => unlockNext();
+
+    const currentLock = this.mutex.then(() => unlock);
+    this.mutex = this.mutex.then(() => willLock);
+    return currentLock;
+  }
+}


### PR DESCRIPTION
## Summary

This PR sends keep-alive alarm to background every 20s to keep service worker alive so that the popup doesn't freeze when kept open for long time.

## How to Test
- Test both this PR (test with build not dev) and the production/beta extension with ao.link and send an AO message with write tab for a process [HERE](https://www.ao.link/#/entity/txvY5I2PDnBCW6vHpVxPN3m-SKP-ylJu0w7D_priUhs?tab=write). Keep the popup for long time (> 10 minutes or maybe longer) then approve or cancel the popup to see if it works or not.