### PR TITLE
Support archiving/printing entire websites to Arweave

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
       "contextMenus",
       "tabs",
       "webNavigation",
-      "notifications"
+      "notifications",
+      "printerProvider"
     ],
     "web_accessible_resources": [
       {

--- a/src/background.ts
+++ b/src/background.ts
@@ -86,6 +86,7 @@ browser.webNavigation.onBeforeNavigate.addListener(protocolHandler);
 
 // print to the permaweb (only on chrome)
 if (typeof chrome !== "undefined") {
+  // @ts-expect-error
   chrome.printerProvider.onGetCapabilityRequested.addListener(getCapabilities);
   chrome.printerProvider.onGetPrintersRequested.addListener(getPrinters);
   chrome.printerProvider.onPrintRequested.addListener(handlePrintRequest);

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,7 +1,7 @@
+import { getCapabilities, getPrinters, handlePrintRequest } from "~lib/printer";
 import { addressChangeListener, walletsChangeListener } from "~wallets/event";
 import { keyRemoveAlarmListener, onWindowClose } from "~wallets/auth";
 import { appConfigChangeListener } from "~applications/events";
-import { getCapabilities, getPrinters } from "~lib/printer";
 import { handleApiCalls, handleChunkCalls } from "~api";
 import { handleGatewayUpdate } from "~gateways/cache";
 import { onMessage } from "@arconnect/webext-bridge";
@@ -88,6 +88,7 @@ browser.webNavigation.onBeforeNavigate.addListener(protocolHandler);
 if (typeof chrome !== "undefined") {
   chrome.printerProvider.onGetCapabilityRequested.addListener(getCapabilities);
   chrome.printerProvider.onGetPrintersRequested.addListener(getPrinters);
+  chrome.printerProvider.onPrintRequested.addListener(handlePrintRequest);
 }
 
 export {};

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,7 @@
 import { addressChangeListener, walletsChangeListener } from "~wallets/event";
 import { keyRemoveAlarmListener, onWindowClose } from "~wallets/auth";
 import { appConfigChangeListener } from "~applications/events";
+import { getCapabilities, getPrinters } from "~lib/printer";
 import { handleApiCalls, handleChunkCalls } from "~api";
 import { handleGatewayUpdate } from "~gateways/cache";
 import { onMessage } from "@arconnect/webext-bridge";
@@ -82,5 +83,11 @@ browser.runtime.onInstalled.addListener(onInstalled);
 
 // handle ar:// protocol
 browser.webNavigation.onBeforeNavigate.addListener(protocolHandler);
+
+// print to the permaweb (only on chrome)
+if (typeof chrome !== "undefined") {
+  chrome.printerProvider.onGetCapabilityRequested.addListener(getCapabilities);
+  chrome.printerProvider.onGetPrintersRequested.addListener(getPrinters);
+}
 
 export {};

--- a/src/lib/printer.ts
+++ b/src/lib/printer.ts
@@ -31,3 +31,23 @@ export function getCapabilities(
 type PrinterCapabilitiesCallback = (
   p: chrome.printerProvider.PrinterCapabilities
 ) => void;
+
+/**
+ * Returns a list of "virtual" printers,
+ * in our case "Print/Publish to Arweave"
+ */
+export function getPrinters(callback: PrinterInfoCallback) {
+  callback([
+    {
+      id: browser.runtime.id,
+      name: "Print to Arweave",
+      description:
+        "Publish the content you want to print on Arweave, permanently."
+    }
+  ]);
+}
+
+/**
+ * Printer info request callback type
+ */
+type PrinterInfoCallback = (p: chrome.printerProvider.PrinterInfo[]) => void;

--- a/src/lib/printer.ts
+++ b/src/lib/printer.ts
@@ -1,0 +1,33 @@
+import browser from "webextension-polyfill";
+
+/**
+ * Tells Chrome about the virtual printer's
+ * capabilities in CDD format
+ */
+export function getCapabilities(
+  printerId: string,
+  callback: PrinterCapabilitiesCallback
+) {
+  // only return capabilities for the ArConnect printer
+  if (printerId !== browser.runtime.id) return;
+
+  callback({
+    capabilities: {
+      version: "1.0",
+      printer: {
+        supported_content_type: [
+          { content_type: "text/html" },
+          { content_type: "application/pdf" },
+          { content_type: "text/plain" }
+        ]
+      }
+    }
+  });
+}
+
+/**
+ * Printer capabilities request callback type
+ */
+type PrinterCapabilitiesCallback = (
+  p: chrome.printerProvider.PrinterCapabilities
+) => void;


### PR DESCRIPTION
This PR adds a virtual printer to the existing printers' list in Chrome. Once selected, the printer archives the PDF version of the website/content on Arweave using Turbo.

Example website uploaded to Arweave:
https://arweave.net/1WeS6vpKYid0jizwsGBCjWUEcTVEVXoj6xNd4UpZIEw

Preview:
<img width="1506" alt="Screenshot 2024-10-13 at PM 12 38 14" src="https://github.com/user-attachments/assets/393e62c0-e28e-42cb-8f7c-c17b114715e7">
