### PR TITLE
fix: hide fiat value for AO tokens

### DIFF
--- a/src/components/popup/Token.tsx
+++ b/src/components/popup/Token.tsx
@@ -74,11 +74,11 @@ export default function Token({ onClick, ...props }: Props) {
   }, [fractBalance.toString()]);
 
   // token price
-  const { price, currency } = usePrice(props.ticker);
+  const { price, currency } = usePrice(props.ticker, props.ao);
 
   // fiat balance
   const fiatBalance = useMemo(() => {
-    if (!price) return <div />;
+    if (!price || props.ao) return <div />;
 
     const estimate = fractBalance.multipliedBy(price);
 

--- a/src/lib/redstone.ts
+++ b/src/lib/redstone.ts
@@ -9,9 +9,14 @@ import BigNumber from "bignumber.js";
  * Hook for the redstone token price API
  *
  * @param symbol Token symbol
+ * @param isAoToken Token is ao token or not
  * @param opts Custom Redstone API "getPrice" options
  */
-export function usePrice(symbol?: string, opts?: GetPriceOptions) {
+export function usePrice(
+  symbol?: string,
+  isAoToken?: boolean,
+  opts?: GetPriceOptions
+) {
   const [price, setPrice] = useState<BigNumber>();
   const [loading, setLoading] = useState(false);
 
@@ -20,7 +25,7 @@ export function usePrice(symbol?: string, opts?: GetPriceOptions) {
 
   useEffect(() => {
     (async () => {
-      if (!symbol) {
+      if (!symbol || isAoToken) {
         return;
       }
 


### PR DESCRIPTION
## Summary

This PR hides the fiat value for AO tokens to prevent displaying incorrect values due to symbol overlap with other coins/tokens like "AR."