### PR TITLE
fix: Update logic for showing `Add $AR to get started` #472

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1083,6 +1083,10 @@
     "message": "View all",
     "description": "View all link text"
   },
+  "view_all_assets": {
+    "message": "View all assets",
+    "description": "View all link text"
+  },
   "setting_tokens": {
     "message": "Tokens",
     "description": "Tokens setting title"

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -1071,6 +1071,10 @@
       "message": "查看全部",
       "description": "View all link text"
   },
+  "view_all_assets": {
+      "message": "查看所有资产",
+      "description": "View all assets link text"
+  },
   "setting_tokens": {
       "message": "代币",
       "description": "Tokens setting title"

--- a/src/components/popup/home/NoBalance.tsx
+++ b/src/components/popup/home/NoBalance.tsx
@@ -18,12 +18,12 @@ export default function NoBalance() {
       <ButtonWrapper>
         <PureBuyButton />
         <ButtonV2
-          onClick={() => push("/receive")}
+          onClick={() => push("/tokens")}
           secondary
           fullWidth
           className="normal-font-weight"
         >
-          {browser.i18n.getMessage("receive_AR_button")}
+          {browser.i18n.getMessage("view_all_assets")}
           <ArrowRight style={{ marginLeft: "5px" }} />
         </ButtonV2>
       </ButtonWrapper>

--- a/src/routes/popup/index.tsx
+++ b/src/routes/popup/index.tsx
@@ -22,6 +22,7 @@ import BuyButton from "~components/popup/home/BuyButton";
 import Tabs from "~components/popup/home/Tabs";
 import AoBanner from "~components/popup/home/AoBanner";
 import { scheduleImportAoTokens } from "~tokens/aoTokens/sync";
+import BigNumber from "bignumber.js";
 
 export default function Home() {
   // get if the user has no balance
@@ -37,6 +38,14 @@ export default function Home() {
     key: "show_announcement",
     instance: ExtensionStorage
   });
+
+  const [historicalBalance] = useStorage<number[]>(
+    {
+      key: "historical_balance",
+      instance: ExtensionStorage
+    },
+    []
+  );
 
   const balance = useBalance();
 
@@ -59,23 +68,18 @@ export default function Home() {
     if (!activeAddress) return;
 
     const findBalances = async (assets, aoTokens) => {
-      const t = [...assets, ...aoTokens];
-      const tokens = t.find((token) => token.balance !== 0);
-      if (tokens) {
+      const hasTokensWithBalance = [...assets, ...aoTokens].some((token) =>
+        BigNumber(token.balance || "0").gt(0)
+      );
+
+      if (
+        hasTokensWithBalance ||
+        balance.toNumber() ||
+        historicalBalance[historicalBalance.length - 1] !== 0
+      ) {
         setNoBalance(false);
-        return;
-      } else if (balance.toNumber()) {
-        setNoBalance(false);
-        return;
       } else {
-        const history = await ExtensionStorage.get("historical_balance");
-        // @ts-ignore
-        if (history[0] !== 0) {
-          setNoBalance(false);
-          return;
-        } else {
-          setNoBalance(true);
-        }
+        setNoBalance(true);
       }
     };
 
@@ -84,7 +88,7 @@ export default function Home() {
     } catch (error) {
       console.log(error);
     }
-  }, [activeAddress, assets, aoTokens]);
+  }, [activeAddress, assets, aoTokens, balance, historicalBalance]);
 
   useEffect(() => {
     const trackEventAndPage = async () => {

--- a/src/routes/popup/index.tsx
+++ b/src/routes/popup/index.tsx
@@ -53,7 +53,7 @@ export default function Home() {
   const tokens = useTokens();
 
   // ao Tokens
-  const [aoTokens] = useAoTokens();
+  const [aoTokens, aoTokensLoading] = useAoTokens();
 
   // checking to see if it's a hardware wallet
   const wallet = useActiveWallet();
@@ -68,9 +68,11 @@ export default function Home() {
     if (!activeAddress) return;
 
     const findBalances = async (assets, aoTokens) => {
-      const hasTokensWithBalance = [...assets, ...aoTokens].some((token) =>
-        BigNumber(token.balance || "0").gt(0)
-      );
+      const hasTokensWithBalance =
+        aoTokensLoading ||
+        [...assets, ...aoTokens].some((token) =>
+          BigNumber(token.balance || "0").gt(0)
+        );
 
       if (
         hasTokensWithBalance ||
@@ -88,7 +90,14 @@ export default function Home() {
     } catch (error) {
       console.log(error);
     }
-  }, [activeAddress, assets, aoTokens, balance, historicalBalance]);
+  }, [
+    activeAddress,
+    assets,
+    aoTokens,
+    balance,
+    historicalBalance,
+    aoTokensLoading
+  ]);
 
   useEffect(() => {
     const trackEventAndPage = async () => {


### PR DESCRIPTION
## Summary

This PR updates the logic for displaying the message **"Add $AR to get started."**

## How to Test

1. Prepare at least one wallet from each of the following categories:
   - **Wallet with AR:** Contains a balance of AR tokens.
   - **Wallet without AR:** Contains balances of other tokens but no AR.
    - **Wallet without AR and other tokens:** Contains no balances of AR and other tokens.

2. **Testing Wallet Switching and Popup:**
   - Make sure this is done with both scenarios: **all assets** and **zero assets** (delete all assets).
   - Open the ArConnect popup and switch between wallets to observe the UI changes.
   - Open the ArConnect popup for each wallet individually to observe the UI for all wallet types.

3. Ensure all issues from [#472](https://github.com/arconnectio/ArConnect/issues/472) have been resolved.