### PR TITLE
fix: Prevent arlocal devtools from breaking ArConnect

### DIFF
--- a/src/components/arlocal/Transaction.tsx
+++ b/src/components/arlocal/Transaction.tsx
@@ -109,6 +109,7 @@ export default function Transaction({ arweave }: Props) {
           content: browser.i18n.getMessage("invalidPassword"),
           duration: 2400
         });
+        setSendingTx(false);
         return;
       }
     }

--- a/src/wallets/index.ts
+++ b/src/wallets/index.ts
@@ -91,20 +91,14 @@ export const useNoWallets = () => {
  * Hook for decryption key
  */
 export function useDecryptionKey(): [string, (val: string) => void] {
-  const [decryptionKey, setDecryptionKey] = useStorage<string>(
-    {
-      key: "decryption_key",
-      instance: ExtensionStorage
-    },
-    (val) => {
-      if (!val) return undefined;
-      return atob(val);
-    }
-  );
+  const [decryptionKey, setDecryptionKey] = useStorage<string>({
+    key: "decryption_key",
+    instance: ExtensionStorage
+  });
 
   const set = (val: string) => setDecryptionKey(btoa(val));
 
-  return [decryptionKey, set];
+  return [decryptionKey ? atob(decryptionKey) : undefined, set];
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR makes sure when we use ArLocal DevTools, the normal ArConnect functionality aren't affected. Fixes https://github.com/arconnectio/ArConnect/issues/473

## How To Test

- Connect ArConnect to a dApp (for eg: https://aosweb.arweave.net/ or https://www.ao.link/#/entity/txvY5I2PDnBCW6vHpVxPN3m-SKP-ylJu0w7D_priUhs?tab=write).
- Open ArLocal DevTools.
- Mint AR to the current wallet.
- Reload the dApp. Just after reloading the dApp or when you try to sign a transaction, the Welcome page will open instead. This issue is caused due to `useDecryptionKey` incorrect usage. Just lock wallet and unlock wallet again to recover from this issue on development branch as `decryption_key` is incorrectly updated on ArLocal devtools.
- Make sure this is fixed with this PR after you test the development branch.
