### PR TITLE
feat: Add print archive transactions to notifications and tx history

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -2225,5 +2225,65 @@
   "transak_unavailable": {
     "message": "Transak is unavailable at the moment. Please try again later.",
     "description": "Transak unavailable error message"
+  },
+  "print_archived": {
+    "message": "Print archived",
+    "description": "Print archived description"
+  },
+  "new_data_uploaded": {
+    "message": "New data uploaded",
+    "description": "New data uploaded description"
+  },
+  "sent_balance": {
+      "message": "Sent $QTY$ $TICKER$ to $ADDRESS$",
+      "description": "Sent balance description",
+      "placeholders": {
+          "qty": {
+              "content": "$1",
+              "example": "10"
+          },
+          "ticker": {
+            "content": "$2",
+            "example": "AR"
+          },
+          "address": {
+              "content": "$3",
+              "example": "ljvCPN31...-CS-6Iho8U"
+          }
+      }
+  },
+  "received_balance": {
+    "message": "Received $QTY$ $TICKER$ from $ADDRESS$",
+    "description": "Received balance description",
+    "placeholders": {
+        "qty": {
+            "content": "$1",
+            "example": "10"
+        },
+        "ticker": {
+          "content": "$2",
+          "example": "AR"
+        },
+        "address": {
+            "content": "$3",
+            "example": "ljvCPN31...-CS-6Iho8U"
+        }
+    }
+  },
+  "notification_from": {
+    "message": "from",
+    "description": "From description"
+  },
+  "notification_to": {
+    "message": "to",
+    "description": "To description"
+  },
+  "new_message": {
+    "message": "New message",
+    "description": "New message description"
+  },
+  "new_transaction": {
+    "message": "New transaction",
+    "description": "New transaction description"
   }
 }

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -2211,5 +2211,65 @@
   "transak_unavailable": {
     "message": "Transak 目前不可用。请稍后再试。",
     "description": "Transak unavailable error message"
-  }
+  },
+   "print_archived": {
+    "message": "打印已归档",
+    "description": "Print archived description"
+  },
+  "new_data_uploaded": {
+    "message": "新数据已上传",
+    "description": "New data uploaded description"
+  },
+  "sent_balance": {
+      "message": "已发送 $QTY$ $TICKER$ 给 $ADDRESS$",
+      "description": "Sent balance description",
+      "placeholders": {
+          "qty": {
+              "content": "$1",
+              "example": "10"
+          },
+          "ticker": {
+            "content": "$2",
+            "example": "AR"
+          },
+          "address": {
+              "content": "$3",
+              "example": "ljvCPN31...-CS-6Iho8U"
+          }
+      }
+  },
+  "received_balance": {
+      "message": "收到 $QTY$ $TICKER$ 来自 $ADDRESS$",
+      "description": "Received balance description",
+      "placeholders": {
+          "qty": {
+              "content": "$1",
+              "example": "10"
+          },
+          "ticker": {
+            "content": "$2",
+            "example": "AR"
+          },
+          "address": {
+              "content": "$3",
+              "example": "ljvCPN31...-CS-6Iho8U"
+          }
+      }
+  },
+    "notification_from": {
+        "message": "来自",
+        "description": "From description"
+    },
+    "notification_to": {
+        "message": "至",
+        "description": "To description"
+    },
+    "new_message": {
+        "message": "新消息",
+        "description": "New message description"
+    },
+    "new_transaction": {
+        "message": "新交易",
+        "description": "New transaction description"
+    }
 }

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -178,6 +178,8 @@ export const getTransactionDescription = (transaction: ExtendedTransaction) => {
       return `${browser.i18n.getMessage("received")} ${
         transaction.aoInfo.tickerName
       }`;
+    case "printArchive":
+      return browser.i18n.getMessage("print_archived");
     default:
       return "";
   }

--- a/src/notifications/utils.ts
+++ b/src/notifications/utils.ts
@@ -243,6 +243,59 @@ query($address: String!, $after: String) {
 }
 `;
 
+// PRINT ARWEAVE TRANSACTIONS
+export const PRINT_ARWEAVE_QUERY = `
+query ($address: String!) {
+  transactions(
+    first: 10,
+    owners: [$address],
+    tags: [{name: "Type", values: ["Print-Archive"]}]
+  ) {
+    edges {
+      cursor
+      node {
+        id
+        recipient
+        owner { address }
+        quantity { ar }
+        block { timestamp, height }
+        tags {
+          name
+          value
+        }
+      }
+    }
+  }
+}`;
+
+export const PRINT_ARWEAVE_QUERY_WITH_CURSOR = `
+query ($address: String!, $after: String) {
+  transactions(
+    first: 10,
+    owners: [$address],
+    tags: [{name: "Type", values: ["Print-Archive"]}],
+    after: $after
+  ) {
+    pageInfo {
+      hasNextPage
+    }
+    edges {
+      cursor
+      node {
+        id
+        recipient
+        owner { address }
+        quantity { ar }
+        block { timestamp, height }
+        tags {
+          name
+          value
+        }
+      }
+    }
+  }
+}`;
+
 export const combineAndSortTransactions = (responses: any[]) => {
   const combinedTransactions = responses.reduce((acc, response) => {
     const transactions = response.data.transactions.edges;
@@ -327,6 +380,13 @@ export const processTransactions = (
           warpContract = true;
           transactionType =
             transaction.node.owner.address === address ? "Sent" : "Received";
+        } else {
+          const printArchiveTag = transaction.node.tags.find(
+            (tag) => tag.name === "Type" && tag.value === "Print-Archive"
+          );
+          if (printArchiveTag) {
+            transactionType = "PrintArchive";
+          }
         }
       }
     }

--- a/src/routes/popup/notifications.tsx
+++ b/src/routes/popup/notifications.tsx
@@ -161,6 +161,10 @@ export default function Notifications() {
               );
               if (!recipient && contentTypeTag) {
                 formattedMessage = browser.i18n.getMessage("new_data_uploaded");
+              } else if (!recipient) {
+                formattedMessage = `${browser.i18n.getMessage(
+                  "new_transaction"
+                )} ${browser.i18n.getMessage("sent").toLowerCase()}`;
               } else {
                 formattedMessage = `${browser.i18n.getMessage(
                   "new_transaction"

--- a/src/routes/popup/notifications.tsx
+++ b/src/routes/popup/notifications.tsx
@@ -58,8 +58,9 @@ export default function Notifications() {
           n.arBalanceNotifications.arNotifications,
           n.aoNotifications.aoNotifications
         );
-        setNotifications(sortedNotifications);
-        const formattedTxMsgs = await formatTxMessage(sortedNotifications);
+        const { formattedTxMsgs, formattedNotifications } =
+          await formatTxMessage(sortedNotifications);
+        setNotifications(formattedNotifications);
         setFormattedTxMsgs(formattedTxMsgs);
         setLoading(false);
       } catch (error) {
@@ -80,12 +81,18 @@ export default function Notifications() {
 
   const formatTxMessage = async (
     notifications: Transaction[]
-  ): Promise<string[]> => {
-    const formattedTxMsgs = await Promise.all(
+  ): Promise<{
+    formattedTxMsgs: string[];
+    formattedNotifications: Transaction[];
+  }> => {
+    const address = await getActiveAddress();
+    let formattedNotifications = await Promise.all(
       notifications.map(async (notification) => {
         try {
           let formattedMessage: string = "";
-          if (notification.transactionType !== "Message") {
+          if (notification.transactionType === "PrintArchive") {
+            formattedMessage = browser.i18n.getMessage("print_archived");
+          } else if (notification.transactionType !== "Message") {
             let ticker: string;
             let quantityTransfered;
             if (notification.isAo) {
@@ -132,31 +139,67 @@ export default function Notifications() {
               }
             }
             if (notification.transactionType === "Sent") {
-              formattedMessage = `Sent ${quantityTransfered} ${ticker} to ${
+              formattedMessage = browser.i18n.getMessage("sent_balance", [
+                quantityTransfered,
+                ticker,
                 notification.isAo
                   ? findRecipient(notification)
                   : formatAddress(notification.node.recipient, 4)
-              }`;
+              ]);
             } else if (notification.transactionType === "Received") {
-              formattedMessage = `Received ${quantityTransfered} ${ticker} from ${formatAddress(
-                notification.node.owner.address,
-                4
-              )}`;
+              formattedMessage = browser.i18n.getMessage("received_balance", [
+                quantityTransfered,
+                ticker,
+                formatAddress(notification.node.owner.address, 4)
+              ]);
+            } else {
+              const recipient = notification.node.recipient;
+              const sender = notification.node.owner.address;
+              const isSent = sender === address;
+              const contentTypeTag = notification.node.tags.find(
+                (tag) => tag.name === "Content-Type"
+              );
+              if (!recipient && contentTypeTag) {
+                formattedMessage = browser.i18n.getMessage("new_data_uploaded");
+              } else {
+                formattedMessage = `${browser.i18n.getMessage(
+                  "new_transaction"
+                )} ${browser.i18n.getMessage(
+                  isSent ? "notification_to" : "notification_from"
+                )} ${formatAddress(isSent ? recipient : sender, 4)}`;
+              }
             }
           } else {
-            formattedMessage = `New message from ${formatAddress(
-              notification.node.owner.address,
-              4
-            )}`;
+            const recipient = notification.node.recipient;
+            const sender = notification.node.owner.address;
+            const isSent = sender === address;
+            formattedMessage = `${browser.i18n.getMessage(
+              "new_message"
+            )} ${browser.i18n.getMessage(
+              isSent ? "notification_to" : "notification_from"
+            )} ${formatAddress(isSent ? recipient : sender, 4)}`;
           }
-          return formattedMessage;
+          return { formattedMessage, notification };
         } catch {
-          return null;
+          return { formattedMessage: null, notification };
         }
       })
     );
 
-    return formattedTxMsgs.filter((msg) => msg);
+    formattedNotifications = formattedNotifications.filter(
+      (notification) => notification.formattedMessage
+    );
+
+    const formattedTxMsgs = formattedNotifications.map(
+      (notification) => notification.formattedMessage
+    );
+
+    return {
+      formattedTxMsgs,
+      formattedNotifications: formattedNotifications.map(
+        ({ notification }) => notification
+      )
+    };
   };
 
   const formatDate = (timestamp) => {


### PR DESCRIPTION
## Summary

This PR adds the `Print to Arweave` transactions to notifications and Tx history.

## How to Test
> Note: There are some additional messages added to notifications regarding `Print to Arweave` and others as well. Also, you could test this wallet address `5glNksg7gRpA0JIXXvCBjlx6U2RHpMG73Msfftke2lY` if you don't see all the added messages in your wallet.

- Check if you can see the `Print archived` message in TX history.
- Check if you can see the new added message in notifications. Try all options of Notifications from settings: `Enable Arweave and ao Transaction Notifications`, `Enable Arweave Transaction Notifications` and `Enable all Arweave and ao Notifications`.