### PR TITLE
refactor: Show Print Arweave tx description & network fee in tx history

### DIFF
--- a/src/components/popup/home/Transactions.tsx
+++ b/src/components/popup/home/Transactions.tsx
@@ -166,14 +166,13 @@ export default function Transactions() {
                         : "Pending"}
                     </Secondary>
                   </Section>
-                  {transaction.transactionType !== "printArchive" && (
-                    <Section alignRight>
-                      <Main>{getFormattedAmount(transaction)}</Main>
-                      <Secondary>
-                        {getFormattedFiatAmount(transaction, arPrice, currency)}
-                      </Secondary>
-                    </Section>
-                  )}
+
+                  <Section alignRight>
+                    <Main>{getFormattedAmount(transaction)}</Main>
+                    <Secondary>
+                      {getFormattedFiatAmount(transaction, arPrice, currency)}
+                    </Secondary>
+                  </Section>
                 </Transaction>
               </TransactionItem>
             ))

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -143,6 +143,8 @@ export const getFormattedAmount = (transaction: ExtendedTransaction) => {
         }).toFixed()} ${transaction.aoInfo.tickerName}`;
       }
       return "";
+    case "printArchive":
+      return `${parseFloat(transaction.node.fee.ar).toFixed(3)} AR`;
     default:
       return "";
   }
@@ -154,8 +156,19 @@ export const getFormattedFiatAmount = (
   currency: string
 ) => {
   try {
-    if (transaction.node.quantity) {
+    if (
+      transaction.node.quantity &&
+      transaction.transactionType !== "printArchive"
+    ) {
       const fiatBalance = BigNumber(transaction.node.quantity.ar).multipliedBy(
+        arPrice
+      );
+      return formatFiatBalance(fiatBalance, currency);
+    } else if (
+      transaction.node.fee &&
+      transaction.transactionType === "printArchive"
+    ) {
+      const fiatBalance = BigNumber(transaction.node.fee.ar).multipliedBy(
         arPrice
       );
       return formatFiatBalance(fiatBalance, currency);

--- a/src/notifications/api.ts
+++ b/src/notifications/api.ts
@@ -26,6 +26,9 @@ export type RawTransaction = {
     quantity: {
       ar: string;
     };
+    fee: {
+      ar: string;
+    };
     block: {
       timestamp: number;
       height: number;

--- a/src/notifications/utils.ts
+++ b/src/notifications/utils.ts
@@ -258,6 +258,7 @@ query ($address: String!) {
         recipient
         owner { address }
         quantity { ar }
+        fee { ar }
         block { timestamp, height }
         tags {
           name

--- a/src/routes/popup/transaction/[id].tsx
+++ b/src/routes/popup/transaction/[id].tsx
@@ -475,6 +475,12 @@ export default function Transaction({ id: rawId, gw, message }: Props) {
                     </div>
                   </PropertyValue>
                 </TransactionProperty>
+                <TransactionProperty>
+                  <PropertyName>
+                    {browser.i18n.getMessage("transaction_fee")}
+                  </PropertyName>
+                  <PropertyValue>{transaction.fee.ar} AR</PropertyValue>
+                </TransactionProperty>
                 {!message && (
                   <TransactionProperty>
                     <PropertyName>


### PR DESCRIPTION
## Summary

This PR adds the following:
- For `Print to Arweave` transactions, network fee description is shown in the transaction history.
- For all transactions, network fee is shown in the `Transcription Complete` screen when you see the details of a particular transaction in the transaction history.