### PR TITLE
fix: Use some specific gateways with retry for Print Arweave in tx history

### DIFF
--- a/src/gateways/gateway.ts
+++ b/src/gateways/gateway.ts
@@ -24,7 +24,7 @@ export const suggestedGateways: Gateway[] = [
     protocol: "https"
   },
   {
-    host: "arweave.live",
+    host: "g8way.io",
     port: 443,
     protocol: "https"
   }
@@ -48,5 +48,34 @@ export const fallbackGateway = {
   port: 443,
   protocol: "https"
 };
+
+export const printTxWorkingGateways: Gateway[] = [
+  {
+    host: "arweave-search.goldsky.com",
+    port: 443,
+    protocol: "https"
+  },
+  {
+    host: "permagate.io",
+    port: 443,
+    protocol: "https"
+  },
+  {
+    host: "ar-io.dev",
+    port: 443,
+    protocol: "https"
+  },
+  {
+    host: "arweave.dev",
+    port: 443,
+    protocol: "https"
+  }
+];
+
+export const txHistoryGateways = [
+  suggestedGateways[1],
+  suggestedGateways[0],
+  suggestedGateways[3]
+];
 
 export const defaultGateway = suggestedGateways[0];

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -1,7 +1,7 @@
 import type GQLResultInterface from "ar-gql/dist/faces";
 import type { GQLEdgeInterface } from "ar-gql/dist/faces";
 import type { RawTransaction } from "~notifications/api";
-import type { TokenInfo } from "~tokens/aoTokens/ao";
+import { timeoutPromise, type TokenInfo } from "~tokens/aoTokens/ao";
 import { formatAddress } from "~utils/format";
 import { ExtensionStorage } from "~utils/storage";
 import { getTokenInfo } from "~tokens/aoTokens/router";
@@ -91,7 +91,10 @@ const processAoTransaction = async (
   transaction: GQLEdgeInterface,
   type: string
 ) => {
-  const tokenData = await fetchTokenByProcessId(transaction.node.recipient);
+  const tokenData = await timeoutPromise(
+    fetchTokenByProcessId(transaction.node.recipient),
+    10000
+  ).catch(() => null);
   const quantityTag = transaction.node.tags.find(
     (tag) => tag.name === "Quantity"
   );

--- a/src/notifications/utils.ts
+++ b/src/notifications/utils.ts
@@ -287,6 +287,7 @@ query ($address: String!, $after: String) {
         recipient
         owner { address }
         quantity { ar }
+        fee { ar }
         block { timestamp, height }
         tags {
           name

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -6,7 +6,7 @@
  * @return A Promise that resolves with the result of the function or rejects after all attempts fail.
  */
 export async function retryWithDelay<T>(
-  fn: () => Promise<T>,
+  fn: (attemp: number) => Promise<T>,
   maxAttempts: number = 3,
   delay: number = 1000
 ): Promise<T> {
@@ -14,7 +14,7 @@ export async function retryWithDelay<T>(
 
   const attempt = async (): Promise<T> => {
     try {
-      return await fn();
+      return await fn(attempts);
     } catch (error) {
       attempts += 1;
       if (attempts < maxAttempts) {


### PR DESCRIPTION
## Summary

This PR is a fix for showing the `Print to Arweave` transactions in TX History. This might be the temporary fix as most of the gateways are throwing time out error but `goldsky` and `permagate` gateways are working but there might be some delay in showing the txs after its printed.