### PR TITLE
refactor: update sign header, humanize timestamps, hide fiat amount

### DIFF
--- a/src/tokens/aoTokens/ao.ts
+++ b/src/tokens/aoTokens/ao.ts
@@ -17,6 +17,7 @@ import type { KeystoneSigner } from "~wallets/hardware/keystone";
 import browser from "webextension-polyfill";
 import { fetchTokenByProcessId } from "~lib/transactions";
 import { timeoutPromise } from "~utils/promises/timeout";
+import type { DecodedTag } from "~api/modules/sign/tags";
 
 export type AoInstance = ReturnType<typeof connect>;
 
@@ -413,7 +414,7 @@ export function useAoTokensCache(): [TokenInfoWithBalance[], boolean] {
 /**
  * Find the value for a tag name
  */
-export const getTagValue = (tagName: string, tags: Tag[]) =>
+export const getTagValue = (tagName: string, tags: (Tag | DecodedTag)[]) =>
   tags.find((t) => t.name === tagName)?.value;
 
 export const sendAoTransfer = async (

--- a/src/utils/timestamp.ts
+++ b/src/utils/timestamp.ts
@@ -1,0 +1,41 @@
+import type { DecodedTag } from "~api/modules/sign/tags";
+
+export const TIMESTAMP_TAGS = ["Expires-At", "X-Timestamp"] as const;
+type TimestampTag = (typeof TIMESTAMP_TAGS)[number];
+
+const TIMESTAMP_TAG_SET = Object.freeze(new Set(TIMESTAMP_TAGS));
+
+const timestampFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false
+});
+
+const isTimestampTag = (tag: string): tag is TimestampTag =>
+  TIMESTAMP_TAG_SET.has(tag as TimestampTag);
+
+export const humanizeTimestamp = (
+  timestamp: string | number | Date | undefined
+): string => {
+  if (!timestamp) return "";
+
+  try {
+    const date = timestamp instanceof Date ? timestamp : new Date(+timestamp);
+    if (isNaN(date.getTime())) throw new Error("Invalid date");
+    return timestampFormatter.format(date);
+  } catch {
+    return String(timestamp);
+  }
+};
+
+export const humanizeTimestampTags = (tags: DecodedTag[]): DecodedTag[] => {
+  return tags.map(({ name, ...rest }) =>
+    isTimestampTag(name)
+      ? { name, ...rest, value: humanizeTimestamp(rest.value) }
+      : { name, ...rest }
+  );
+};


### PR DESCRIPTION
## Summary

This PR adds improvements to the sign transaction popup:
- Update sign header for AO transactions with `Action` tag if present.
- Humanize some known timestamp tags
- Hide fiat amount if its zero.