### PR TITLE
Feature: `decrypt()` & `signMessage()` permissions + fix `dispatch()` requesting permissions twice (when rejected)

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1345,13 +1345,31 @@
     "message": "Sign items",
     "description": "Batch sign message popup title"
   },
+  "titles_decrypt": {
+    "message": "Decrypt",
+    "description": "Request decrypt authorization password"
+  },
+  "decrypt_description": {
+    "message": "$APPNAME$ wants to decrypt and access the following data:",
+    "description": "Description for decrypting some data",
+    "placeholders": {
+      "appname": {
+        "content": "$1",
+        "example": "permafacts.arweave.dev"
+      }
+    }
+  },
+  "decrypt_authorize": {
+    "message": "Authorize",
+    "description": "Authorize button label"
+  },
   "titles_signature": {
     "message": "Sign message",
     "description": "Sign message popup title"
   },
   "sign_data_description": {
     "message": "$APPNAME$ wants to sign a transaction. Review the details below.",
-    "description": "Desription for signing an item containing a transfer",
+    "description": "Description for signing an item containing a transfer",
     "placeholders": {
       "appname": {
         "content": "$1",
@@ -2309,6 +2327,10 @@
   "tokenRequestLoading": {
     "message": "Adding token...",
     "description": "Loading message for AuthRequest of type token"
+  },
+  "decryptRequestLoading": {
+    "message": "Decrypting...",
+    "description": "Loading message for AuthRequest of type decrypt"
   },
   "signRequestLoading": {
     "message": "Signing...",

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -1333,6 +1333,24 @@
       "message": "批量签署项目",
       "description": "批量签署消息弹出标题"
   },
+  "titles_decrypt": {
+    "message": "Decrypt",
+    "description": "Request decrypt authorization password"
+  },
+  "decrypt_description": {
+    "message": "$APPNAME$ wants to decrypt and access the following data:",
+    "description": "Description for decrypting some data",
+    "placeholders": {
+      "appname": {
+        "content": "$1",
+        "example": "permafacts.arweave.dev"
+      }
+    }
+  },
+  "decrypt_authorize": {
+    "message": "授权",
+    "description": "Authorize button label"
+  },
   "titles_signature": {
       "message": "签署消息",
       "description": "Sign message popup title"
@@ -2295,6 +2313,10 @@
     "tokenRequestLoading": {
       "message": "Adding token...",
       "description": "Loading message for AuthRequest of type token"
+    },
+    "decryptRequestLoading": {
+      "message": "Decrypting...",
+      "description": "Loading message for AuthRequest of type decrypt"
     },
     "signRequestLoading": {
       "message": "Signing...",

--- a/src/api/modules/decrypt/decrypt.background.ts
+++ b/src/api/modules/decrypt/decrypt.background.ts
@@ -10,6 +10,7 @@ import {
   isLocalWallet,
   isRawArrayBuffer
 } from "~utils/assertions";
+import { requestUserAuthorization } from "~utils/auth/auth.utils";
 
 const background: BackgroundModuleFunction<string | Uint8Array> = async (
   appData,
@@ -18,6 +19,8 @@ const background: BackgroundModuleFunction<string | Uint8Array> = async (
 ) => {
   // validate data
   isRawArrayBuffer(data);
+
+  const message = Object.values(data);
 
   // override with byte array
   data = new Uint8Array(Object.values(data));
@@ -40,6 +43,22 @@ const background: BackgroundModuleFunction<string | Uint8Array> = async (
 
   // remove wallet from memory
   freeDecryptedWallet(decryptedWallet.keyfile);
+
+  // TODO: Some functions just decrypt the keyfile just to get the public key (keyfile.n)
+
+  // TODO: Some functions unlock the wallet before requesting permissions. It looks like the private key might not be
+  // needed to request permissions, so it would be better to combine both "user requests" in a single one to avoid
+  // unlocking the wallet unnecessarily. Also, if the wallet has been unlocked from an auth popup but the request(s) is
+  // finally rejected, it might be worth re-locking the wallet.
+
+  // request "decrypt" popup
+  await requestUserAuthorization(
+    {
+      type: "decrypt",
+      message
+    },
+    appData
+  );
 
   if (options.algorithm) {
     // validate

--- a/src/api/modules/dispatch/dispatch.background.ts
+++ b/src/api/modules/dispatch/dispatch.background.ts
@@ -15,6 +15,8 @@ import Arweave from "arweave";
 import { ensureAllowanceDispatch } from "./allowance";
 import { updateAllowance } from "../sign/allowance";
 import BigNumber from "bignumber.js";
+import { isError } from "~utils/error/error.utils";
+import { ERR_MSG_USER_CANCELLED_AUTH } from "~utils/auth/auth.constants";
 
 type ReturnType = {
   arConfetti: string | false;
@@ -110,7 +112,14 @@ const background: BackgroundModuleFunction<ReturnType> = async (
         type: "BUNDLED"
       }
     };
-  } catch {
+  } catch (err) {
+    if (isError(err) && err.message === ERR_MSG_USER_CANCELLED_AUTH) {
+      throw err;
+    }
+
+    // TODO: If there's an error in the first request, the previous (already accepted) AuthRequest's UI should probably
+    // reflect that. Maybe we could even reuse the same AuthRequest item instead of creating a separated one.
+
     // sign & post if there is something wrong with turbo
     // add ArConnect tags to the tx object
     for (const arcTag of signedTxTags) {

--- a/src/api/modules/sign_message/sign_message.background.ts
+++ b/src/api/modules/sign_message/sign_message.background.ts
@@ -8,6 +8,7 @@ import {
 } from "~utils/assertions";
 import { signAuthKeystone, type AuthKeystoneData } from "../sign/sign_auth";
 import Arweave from "arweave";
+import { requestUserAuthorization } from "~utils/auth/auth.utils";
 
 const background: BackgroundModuleFunction<number[]> = async (
   appData,
@@ -22,6 +23,14 @@ const background: BackgroundModuleFunction<number[]> = async (
   const dataToSign = new Uint8Array(data);
 
   isArrayBuffer(dataToSign);
+
+  await requestUserAuthorization(
+    {
+      type: "signature",
+      message: data
+    },
+    appData
+  );
 
   // hash the message
   const hash = await crypto.subtle.digest(options.hashAlgorithm, dataToSign);

--- a/src/components/popup/HeadV2.tsx
+++ b/src/components/popup/HeadV2.tsx
@@ -100,7 +100,7 @@ export default function HeadV2({
   const hardwareApi = useHardwareApi();
 
   const appName = appInfo?.name;
-  const appIconPlaceholderText = appInfo.placeholder;
+  const appIconPlaceholderText = appInfo?.placeholder;
 
   const SquircleWrapper = onAppInfoClick ? ButtonSquircle : React.Fragment;
 

--- a/src/routes/auth/decrypt.tsx
+++ b/src/routes/auth/decrypt.tsx
@@ -1,0 +1,58 @@
+import { Section, Text } from "@arconnect/components";
+import Message from "~components/auth/Message";
+import Wrapper from "~components/auth/Wrapper";
+import browser from "webextension-polyfill";
+import { useEffect } from "react";
+import { useCurrentAuthRequest } from "~utils/auth/auth.hooks";
+import { HeadAuth } from "~components/HeadAuth";
+import { AuthButtons } from "~components/auth/AuthButtons";
+
+export function DecryptAuthRequestView() {
+  const { authRequest, acceptRequest, rejectRequest } =
+    useCurrentAuthRequest("decrypt");
+
+  const { authID, url, message } = authRequest;
+
+  // listen for enter to reset
+  useEffect(() => {
+    const listener = async (e: KeyboardEvent) => {
+      if (e.key !== "Enter") return;
+      await acceptRequest();
+    };
+
+    window.addEventListener("keydown", listener);
+
+    return () => window.removeEventListener("keydown", listener);
+  }, [authID]);
+
+  return (
+    <Wrapper>
+      <div>
+        <HeadAuth title={browser.i18n.getMessage("titles_decrypt")} />
+
+        <Section>
+          <Text noMargin>
+            {browser.i18n.getMessage("decrypt_description", url)}
+          </Text>
+
+          <div style={{ marginTop: "16px" }}>
+            <Message message={message} />
+          </div>
+        </Section>
+      </div>
+
+      <Section>
+        <AuthButtons
+          authRequest={authRequest}
+          primaryButtonProps={{
+            label: browser.i18n.getMessage("decrypt_authorize"),
+            onClick: () => acceptRequest()
+          }}
+          secondaryButtonProps={{
+            onClick: () => rejectRequest()
+          }}
+        />
+      </Section>
+    </Wrapper>
+  );
+}

--- a/src/utils/auth/auth.types.ts
+++ b/src/utils/auth/auth.types.ts
@@ -79,6 +79,13 @@ export interface TokenAuthRequestData {
   dre?: string;
 }
 
+// DECRYPT
+
+export interface DecryptAuthRequestData {
+  type: "decrypt";
+  message: number[];
+}
+
 // SIGN:
 
 export interface SignAuthRequestData {
@@ -86,12 +93,6 @@ export interface SignAuthRequestData {
   address: string;
   transaction: SplitTransaction;
   collectionID: string;
-}
-
-// SUBSCRIPTION:
-
-export interface SubscriptionAuthRequestData extends SubscriptionData {
-  type: "subscription";
 }
 
 // SIGN KEYSTONE:
@@ -123,6 +124,12 @@ export interface BatchSignDataItemAuthRequestData {
   data: RawDataItem;
 }
 
+// SUBSCRIPTION:
+
+export interface SubscriptionAuthRequestData extends SubscriptionData {
+  type: "subscription";
+}
+
 // AuthRequestMessageData:
 
 export type ConnectAuthRequestMessageData = ConnectAuthRequestData &
@@ -131,9 +138,9 @@ export type AllowanceAuthRequestMessageData = AllowanceAuthRequestData &
   CommonAuthRequestProps;
 export type TokenAuthRequestMessageData = TokenAuthRequestData &
   CommonAuthRequestProps;
-export type SignAuthRequestMessageData = SignAuthRequestData &
+export type DecryptAuthRequestMessageData = DecryptAuthRequestData &
   CommonAuthRequestProps;
-export type SubscriptionAuthRequestMessageData = SubscriptionAuthRequestData &
+export type SignAuthRequestMessageData = SignAuthRequestData &
   CommonAuthRequestProps;
 export type SignKeystoneAuthRequestMessageData = SignKeystoneAuthRequestData &
   CommonAuthRequestProps;
@@ -143,19 +150,20 @@ export type SignDataItemAuthRequestMessageData = SignDataItemAuthRequestData &
   CommonAuthRequestProps;
 export type BatchSignDataItemAuthRequestMessageData =
   BatchSignDataItemAuthRequestData & CommonAuthRequestProps;
+export type SubscriptionAuthRequestMessageData = SubscriptionAuthRequestData &
+  CommonAuthRequestProps;
 
 // AuthRequest:
 
 export type ConnectAuthRequest = ConnectAuthRequestMessageData;
 export type AllowanceAuthRequest = AllowanceAuthRequestMessageData;
 export type TokenAuthRequest = TokenAuthRequestMessageData;
+export type DecryptAuthRequest = DecryptAuthRequestMessageData;
 
 export interface SignAuthRequest
   extends Omit<SignAuthRequestMessageData, "transaction"> {
   transaction: SplitTransaction | Transaction;
 }
-
-export type SubscriptionAuthRequest = SubscriptionAuthRequestMessageData;
 
 export interface SignKeystoneAuthRequest
   extends SignKeystoneAuthRequestMessageData {
@@ -167,6 +175,8 @@ export type SignDataItemAuthRequest = SignDataItemAuthRequestMessageData;
 export type BatchSignDataItemAuthRequest =
   BatchSignDataItemAuthRequestMessageData;
 
+export type SubscriptionAuthRequest = SubscriptionAuthRequestMessageData;
+
 // Unions & Misc:
 
 export type AuthType = AuthRequestData["type"];
@@ -175,43 +185,47 @@ export type AuthRequestData =
   | ConnectAuthRequestData
   | AllowanceAuthRequestData
   | TokenAuthRequestData
+  | DecryptAuthRequestData
   | SignAuthRequestData
-  | SubscriptionAuthRequestData
   | SignKeystoneAuthRequestData
   | SignatureAuthRequestData
   | SignDataItemAuthRequestData
-  | BatchSignDataItemAuthRequestData;
+  | BatchSignDataItemAuthRequestData
+  | SubscriptionAuthRequestData;
 
 export type AuthRequestMessageData =
   | ConnectAuthRequestMessageData
   | AllowanceAuthRequestMessageData
   | TokenAuthRequestMessageData
+  | DecryptAuthRequestMessageData
   | SignAuthRequestMessageData
-  | SubscriptionAuthRequestMessageData
   | SignKeystoneAuthRequestMessageData
   | SignatureAuthRequestMessageData
   | SignDataItemAuthRequestMessageData
-  | BatchSignDataItemAuthRequestMessageData;
+  | BatchSignDataItemAuthRequestMessageData
+  | SubscriptionAuthRequestMessageData;
 
 export type AuthRequest =
   | ConnectAuthRequest
   | AllowanceAuthRequest
   | TokenAuthRequest
+  | DecryptAuthRequest
   | SignAuthRequest
-  | SubscriptionAuthRequest
   | SignKeystoneAuthRequest
   | SignatureAuthRequest
   | SignDataItemAuthRequest
-  | BatchSignDataItemAuthRequest;
+  | BatchSignDataItemAuthRequest
+  | SubscriptionAuthRequest;
 
 export type AuthRequestByType = {
   connect: ConnectAuthRequest;
   allowance: AllowanceAuthRequest;
   token: TokenAuthRequest;
+  decrypt: DecryptAuthRequest;
   sign: SignAuthRequest;
-  subscription: SubscriptionAuthRequest;
   signKeystone: SignKeystoneAuthRequest;
   signature: SignatureAuthRequest;
   signDataItem: SignDataItemAuthRequest;
   batchSignDataItem: BatchSignDataItemAuthRequest;
+  subscription: SubscriptionAuthRequest;
 };

--- a/src/wallets/router/auth/auth.routes.ts
+++ b/src/wallets/router/auth/auth.routes.ts
@@ -1,6 +1,7 @@
 import { AllowanceAuthRequestView } from "~routes/auth/allowance";
 import { BatchSignDataItemAuthRequestView } from "~routes/auth/batchSignDataItem";
 import { ConnectAuthRequestView } from "~routes/auth/connect";
+import { DecryptAuthRequestView } from "~routes/auth/decrypt";
 import { LoadingAuthRequestView } from "~routes/auth/loading";
 import { SignAuthRequestView } from "~routes/auth/sign";
 import { SignatureAuthRequestView } from "~routes/auth/signature";

--- a/src/wallets/router/auth/auth.routes.ts
+++ b/src/wallets/router/auth/auth.routes.ts
@@ -17,23 +17,25 @@ export type AuthRoutePath =
   | `/connect/${string}`
   | `/allowance/${string}`
   | `/token/${string}`
+  | `/decrypt/${string}`
   | `/sign/${string}`
   | `/signKeystone/${string}`
   | `/signature/${string}`
-  | `/subscription/${string}`
   | `/signDataItem/${string}`
-  | `/batchSignDataItem/${string}`;
+  | `/batchSignDataItem/${string}`
+  | `/subscription/${string}`;
 
 export const AuthPaths = {
   Connect: "/connect/:authID",
   Allowance: "/allowance/:authID",
   Token: "/token/:authID",
+  Decrypt: "/decrypt/:authID",
   Sign: "/sign/:authID",
   SignKeystone: "/signKeystone/:authID",
   Signature: "/signature/:authID",
-  Subscription: "/subscription/:authID",
   SignDataItem: "/signDataItem/:authID",
-  BatchSignDataItem: "/batchSignDataItem/:authID"
+  BatchSignDataItem: "/batchSignDataItem/:authID",
+  Subscription: "/subscription/:authID"
 } as const satisfies Record<string, AuthRoutePath>;
 
 export const AUTH_ROUTES = [
@@ -54,6 +56,10 @@ export const AUTH_ROUTES = [
     component: TokenAuthRequestView
   },
   {
+    path: AuthPaths.Decrypt,
+    component: DecryptAuthRequestView
+  },
+  {
     path: AuthPaths.Sign,
     component: SignAuthRequestView
   },
@@ -66,15 +72,15 @@ export const AUTH_ROUTES = [
     component: SignatureAuthRequestView
   },
   {
-    path: AuthPaths.Subscription,
-    component: SubscriptionAuthRequestView
-  },
-  {
     path: AuthPaths.SignDataItem,
     component: SignDataItemAuthRequestView
   },
   {
     path: AuthPaths.BatchSignDataItem,
     component: BatchSignDataItemAuthRequestView
+  },
+  {
+    path: AuthPaths.Subscription,
+    component: SubscriptionAuthRequestView
   }
 ] as const satisfies RouteConfig[];


### PR DESCRIPTION
- `decrypt()` now always asks permissions.
- `signMessage()` now always asks permissions.
- `dispatch()` won't re-request permissions / re-attempt posting if the user rejected the auth request (it will still do it if the auth request is accepted but uploading it to Turbo fails).

Partially fixes https://github.com/arconnectio/ArConnect/issues/550.
Closes https://github.com/arconnectio/ArConnect/issues/551.