### PR TITLE
Replace recently added throws w/ loading

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -11,6 +11,10 @@
     "message": "Error Info",
     "description": "Additional Fallback error message"
   },
+  "loading": {
+    "message": "Loading...",
+    "description": "Loading text"
+  },
   "extensionDescription": {
     "message": "Secure wallet management for Arweave",
     "description": "Extension description"

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -12,7 +12,7 @@
     "description": "Additional Fallback error message"
   },
   "loading": {
-    "message": "加载中",
+    "message": "加载中...",
     "description": "Loading text"
   },
   "extensionDescription": {

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -11,6 +11,10 @@
     "message": "错误信息",
     "description": "Additional Fallback error message"
   },
+  "loading": {
+    "message": "加载中",
+    "description": "Loading text"
+  },
   "extensionDescription": {
       "message": "Arweave 的安全钱包管理",
       "description": "Extension description"

--- a/src/components/dashboard/subsettings/AppSettings.tsx
+++ b/src/components/dashboard/subsettings/AppSettings.tsx
@@ -28,6 +28,7 @@ import Arweave from "arweave";
 import { defaultGateway, suggestedGateways, testnets } from "~gateways/gateway";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import { ErrorTypes } from "~utils/error/error.utils";
+import { LoadingView } from "~components/page/common/loading/loading.view";
 
 export interface AppSettingsDashboardViewParams {
   url: string;
@@ -109,7 +110,7 @@ export function AppSettingsDashboardView({
   const removeModal = useModal();
 
   if (!settings) {
-    throw new Error(ErrorTypes.SettingsNotFound);
+    return <LoadingView />;
   }
 
   return (

--- a/src/components/dashboard/subsettings/WalletSettings.tsx
+++ b/src/components/dashboard/subsettings/WalletSettings.tsx
@@ -25,7 +25,7 @@ import styled from "styled-components";
 import copy from "copy-to-clipboard";
 import { formatAddress } from "~utils/format";
 import type { CommonRouteProps } from "~wallets/router/router.types";
-import { ErrorTypes } from "~utils/error/error.utils";
+import { LoadingView } from "~components/page/common/loading/loading.view";
 
 export interface WalletSettingsDashboardViewParams {
   address: string;
@@ -169,7 +169,7 @@ export function WalletSettingsDashboardView({
   }
 
   if (!wallet) {
-    throw new Error(ErrorTypes.WalletNotFound);
+    return <LoadingView />;
   }
 
   return (

--- a/src/components/page/common/loading/loading.view.tsx
+++ b/src/components/page/common/loading/loading.view.tsx
@@ -1,8 +1,8 @@
 import { Loading } from "@arconnect/components";
 import styled from "styled-components";
-import type { CommonRouteProps } from "~wallets/router/router.types";
+import browser from "webextension-polyfill";
 
-export interface LoadingViewProps extends CommonRouteProps {
+export interface LoadingViewProps {
   label?: string;
 }
 
@@ -10,7 +10,7 @@ export const LoadingView = ({ label }: LoadingViewProps) => {
   return (
     <DivWrapper>
       <Loading style={{ width: "32px", height: "32px" }} />
-      <PLabel>{label || "Loading..."}</PLabel>
+      <PLabel>{label || browser.i18n.getMessage("loading")}</PLabel>
     </DivWrapper>
   );
 };

--- a/src/routes/popup/settings/apps/[url]/index.tsx
+++ b/src/routes/popup/settings/apps/[url]/index.tsx
@@ -27,6 +27,7 @@ import { ToggleSwitch } from "~routes/popup/subscriptions/subscriptionDetails";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import { useLocation } from "~wallets/router/router.utils";
 import { ErrorTypes } from "~utils/error/error.utils";
+import { LoadingView } from "~components/page/common/loading/loading.view";
 
 export interface AppSettingsViewParams {
   url: string;
@@ -104,7 +105,7 @@ export function AppSettingsView({ params: { url } }: AppSettingsViewProps) {
   const removeModal = useModal();
 
   if (!settings) {
-    throw new Error(ErrorTypes.SettingsNotFound);
+    return <LoadingView />;
   }
 
   return (

--- a/src/routes/popup/settings/apps/[url]/permissions.tsx
+++ b/src/routes/popup/settings/apps/[url]/permissions.tsx
@@ -8,6 +8,7 @@ import Checkbox from "~components/Checkbox";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import { useLocation } from "~wallets/router/router.utils";
 import { ErrorTypes } from "~utils/error/error.utils";
+import { LoadingView } from "~components/page/common/loading/loading.view";
 
 export interface AppPermissionsViewParams {
   url: string;
@@ -26,7 +27,7 @@ export function AppPermissionsView({
   const [settings, updateSettings] = app.hook();
 
   if (!settings) {
-    throw new Error(ErrorTypes.SettingsNotFound);
+    return <LoadingView />;
   }
 
   return (

--- a/src/routes/popup/settings/tokens/[id]/index.tsx
+++ b/src/routes/popup/settings/tokens/[id]/index.tsx
@@ -21,6 +21,7 @@ import HeadV2 from "~components/popup/HeadV2";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import { useLocation } from "~wallets/router/router.utils";
 import { ErrorTypes } from "~utils/error/error.utils";
+import { LoadingView } from "~components/page/common/loading/loading.view";
 
 export interface TokenSettingsParams {
   id: string;
@@ -84,7 +85,7 @@ export function TokenSettingsView({ params: { id } }: TokenSettingsProps) {
   }
 
   if (!token) {
-    throw new Error(ErrorTypes.TokenNotFound);
+    return <LoadingView />;
   }
 
   return (

--- a/src/routes/popup/settings/wallets/[address]/export.tsx
+++ b/src/routes/popup/settings/wallets/[address]/export.tsx
@@ -18,6 +18,7 @@ import HeadV2 from "~components/popup/HeadV2";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import { useLocation } from "~wallets/router/router.utils";
 import { ErrorTypes } from "~utils/error/error.utils";
+import { LoadingView } from "~components/page/common/loading/loading.view";
 
 export interface ExportWalletViewParams {
   address: string;
@@ -89,7 +90,7 @@ export function ExportWalletView({
   }
 
   if (!wallet) {
-    throw new Error(ErrorTypes.WalletNotFound);
+    return <LoadingView />;
   }
 
   return (

--- a/src/routes/popup/settings/wallets/[address]/index.tsx
+++ b/src/routes/popup/settings/wallets/[address]/index.tsx
@@ -27,6 +27,7 @@ import HeadV2 from "~components/popup/HeadV2";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import { useLocation } from "~wallets/router/router.utils";
 import { ErrorTypes } from "~utils/error/error.utils";
+import { LoadingView } from "~components/page/common/loading/loading.view";
 
 export interface WalletViewParams {
   address: string;
@@ -128,7 +129,7 @@ export function WalletView({ params: { address } }: WalletViewProps) {
   const removeModal = useModal();
 
   if (!wallet) {
-    throw new Error(ErrorTypes.WalletNotFound);
+    return <LoadingView />;
   }
 
   return (


### PR DESCRIPTION
## Description

This PR fix a problem when we were throwing error too earlier due an async nature of our data/state updates.

## Manual testing steps
- Goto Settings > Applications and click an application from the list
- Goto Settings > Wallets and click a wallet from the list (Also maybe on Generate QR code, Export keyfile and Remove wallet)
- Goto All Settings

## Expected behaviour.
No errors.