### PR TITLE
fix: return default gateway if no gateways found with wayfinder disabled

### DIFF
--- a/src/gateways/wayfinder.ts
+++ b/src/gateways/wayfinder.ts
@@ -21,33 +21,33 @@ export const STAKED_GQL_FULL_HISTORY: Requirements = {
 export async function findGateway(
   requirements: Requirements
 ): Promise<Gateway> {
-  // Get if the Wayfinder feature is enabled:
-  const wayfinderEnabled = await getSetting("wayfinder").getValue();
-
-  // This should have been loaded into the cache by handleGatewayUpdateAlarm, but sometimes this function might run
-  // before that, so in that case we fall back to the same behavior has having the Wayfinder disabled:
-  const procData = await getGatewayCache();
-
-  if (!wayfinderEnabled || !procData) {
-    if (requirements.arns) {
-      return {
-        host: "arweave.dev",
-        port: 443,
-        protocol: "https"
-      };
-    }
-
-    // wayfinder disabled or all the chain is needed
-    if (requirements.startBlock === 0) {
-      return defaultGateway;
-    }
-
-    throw new Error(
-      wayfinderEnabled ? "Missing gateway cache" : "Wayfinder disabled"
-    );
-  }
-
   try {
+    // Get if the Wayfinder feature is enabled:
+    const wayfinderEnabled = await getSetting("wayfinder").getValue();
+
+    // This should have been loaded into the cache by handleGatewayUpdateAlarm, but sometimes this function might run
+    // before that, so in that case we fall back to the same behavior has having the Wayfinder disabled:
+    const procData = await getGatewayCache();
+
+    if (!wayfinderEnabled || !procData) {
+      if (requirements.arns) {
+        return {
+          host: "arweave.dev",
+          port: 443,
+          protocol: "https"
+        };
+      }
+
+      // wayfinder disabled or all the chain is needed
+      if (requirements.startBlock === 0) {
+        return defaultGateway;
+      }
+
+      throw new Error(
+        wayfinderEnabled ? "Missing gateway cache" : "Wayfinder disabled"
+      );
+    }
+
     // this could probably be filtered out during the caching process
     const filteredGateways = procData.filter((gateway) => {
       return (


### PR DESCRIPTION
## Summary

This PR fixes the issue with `findGateway` to return a default gateway in case of error or no gateway found. 

## How to Test
1. Disable the wayfinder and try to send ao tokens in `development` or prod Arconnect. You will see `Could not send transaction error` error.
2. Checkout `arc-884/wayfinder-disabled-fix` and try to send ao tokens again and make sure you can send tokens successfully without `Could not send transaction error`.