### PR TITLE
fix: reset import issue

### DIFF
--- a/src/routes/auth/signDataItem.tsx
+++ b/src/routes/auth/signDataItem.tsx
@@ -31,7 +31,11 @@ import prettyBytes from "pretty-bytes";
 import { formatFiatBalance } from "~tokens/currency";
 import useSetting from "~settings/hook";
 import { getPrice } from "~lib/coingecko";
-import type { TokenInfo, TokenInfoWithProcessId } from "~tokens/aoTokens/ao";
+import {
+  getTagValue,
+  type TokenInfo,
+  type TokenInfoWithProcessId
+} from "~tokens/aoTokens/ao";
 import { ChevronUpIcon, ChevronDownIcon } from "@iconicicons/react";
 import { getUserAvatar } from "~lib/avatar";
 import { LogoWrapper, Logo, WarningIcon } from "~components/popup/Token";
@@ -43,6 +47,7 @@ import { Degraded, WarningWrapper } from "~routes/popup/send";
 import { useCurrentAuthRequest } from "~utils/auth/auth.hooks";
 import { HeadAuth } from "~components/HeadAuth";
 import { AuthButtons } from "~components/auth/AuthButtons";
+import { humanizeTimestampTags } from "~utils/timestamp";
 
 export function SignDataItemAuthRequestView() {
   const { authRequest, acceptRequest, rejectRequest } =
@@ -59,12 +64,12 @@ export function SignDataItemAuthRequestView() {
   const [mismatch, setMismatch] = useState<boolean>(false);
   const { setToast } = useToasts();
 
-  const recipient =
-    data?.tags?.find((tag) => tag.name === "Recipient")?.value || "";
-  const quantity =
-    data?.tags?.find((tag) => tag.name === "Quantity")?.value || "0";
-  const transfer = data?.tags?.some(
-    (tag) => tag.name === "Action" && tag.value === "Transfer"
+  const tags = useMemo(() => humanizeTimestampTags(data?.tags || []), [data]);
+  const recipient = useMemo(() => getTagValue("Recipient", tags) || "", [tags]);
+  const quantity = useMemo(() => getTagValue("Quantity", tags) || "0", [tags]);
+  const transfer = useMemo(
+    () => tags.some((tag) => tag.name === "Action" && tag.value === "Transfer"),
+    [tags]
   );
 
   const process = data?.target;
@@ -113,6 +118,21 @@ export function SignDataItemAuthRequestView() {
   const fiatPrice = useMemo(() => +(amount || 0) * price, [amount]);
 
   const passwordInput = useInput();
+
+  const headerTitle = useMemo(() => {
+    if (!tags?.length) return browser.i18n.getMessage("sign_item");
+
+    const actionValue = getTagValue("Action", tags);
+    const isAOTransaction = tags.some(
+      (tag) => tag.name === "Data-Protocol" && tag.value === "ao"
+    );
+
+    if (isAOTransaction && actionValue) {
+      return actionValue.replace(/-/g, " ");
+    }
+
+    return browser.i18n.getMessage("sign_item");
+  }, [tags]);
 
   // sign message
   async function sign() {
@@ -252,7 +272,7 @@ export function SignDataItemAuthRequestView() {
   return (
     <Wrapper ref={parentRef}>
       <div>
-        <HeadAuth title={browser.i18n.getMessage("sign_item")} />
+        <HeadAuth title={headerTitle} />
         {mismatch && transfer && (
           <Degraded>
             <WarningWrapper>
@@ -294,7 +314,11 @@ export function SignDataItemAuthRequestView() {
           </div>
           {transfer && (
             <>
-              <FiatAmount>{formatFiatBalance(fiatPrice, currency)}</FiatAmount>
+              {+fiatPrice > 0 && (
+                <FiatAmount>
+                  {formatFiatBalance(fiatPrice, currency)}
+                </FiatAmount>
+              )}
               <AmountTitle
                 ref={childRef}
                 style={{

--- a/src/routes/welcome/generate/done.tsx
+++ b/src/routes/welcome/generate/done.tsx
@@ -18,6 +18,7 @@ import { ExtensionStorage } from "~utils/storage";
 import { useStorage } from "@plasmohq/storage/hook";
 import JSConfetti from "js-confetti";
 import { useLocation } from "~wallets/router/router.utils";
+import { loadTokens } from "~tokens/token";
 
 export function GenerateDoneWelcomeView() {
   const { navigate } = useLocation();
@@ -81,6 +82,9 @@ export function GenerateDoneWelcomeView() {
         : walletRef.current.jwk,
       password
     );
+
+    // load tokens
+    await loadTokens();
 
     // log user onboarded
     await trackEvent(EventType.ONBOARDED, {});

--- a/src/routes/welcome/load/wallets.tsx
+++ b/src/routes/welcome/load/wallets.tsx
@@ -29,6 +29,7 @@ import styled from "styled-components";
 import { WalletKeySizeErrorModal } from "~components/modals/WalletKeySizeErrorModal";
 import { useLocation } from "~wallets/router/router.utils";
 import type { CommonRouteProps } from "~wallets/router/router.types";
+import { loadTokens } from "~tokens/token";
 
 export type WalletsWelcomeViewProps = CommonRouteProps<SetupWelcomeViewParams>;
 
@@ -165,6 +166,9 @@ export function WalletsWelcomeView({ params }: WalletsWelcomeViewProps) {
 
         // add wallet
         await addWallet(jwk, password);
+
+        // load tokens
+        await loadTokens();
       } else if (existingWallets.length < 1) {
         // the user has not migrated, so they need to add a wallet
         return finishUp();
@@ -244,6 +248,9 @@ export function WalletsWelcomeView({ params }: WalletsWelcomeViewProps) {
                 try {
                   // add migrated wallets
                   await addWallet(walletsToMigrate, password);
+
+                  // load tokens
+                  await loadTokens();
 
                   // confirmation toast
                   setToast({


### PR DESCRIPTION
## Summary

This PR resolves the issue of loading the default tokens after reset and onboarding. Also, it updates `signDataItem` popup to show action as header and hide fiat amount if absent.

## How to Test
1. Reset the wallet
2. Generate or import wallet using keyfile/seedphrase
3. Make sure there are default tokens present