### PR TITLE
Fix dapp first load issue

### DIFF
--- a/src/api/background/handlers/message/api-call-message/api-call-message.handler.ts
+++ b/src/api/background/handlers/message/api-call-message/api-call-message.handler.ts
@@ -70,7 +70,7 @@ export const handleApiCallMessage: OnMessageCallback<
       });
 
       // update app value with the app belonging to the frame
-      if (frame.url) {
+      if (frame?.url) {
         app = new Application(getAppURL(frame.url));
       }
     }


### PR DESCRIPTION
## Summary
This PR fixes the issue that only happens for some dapps on loading the page for the first time.

## How to test:
1. Load https://awk-test.vercel.app and connect to the dapp
2. Close the page/tab
3. Open https://awk-test.vercel.app again and check if you are already connected
4. Open the dev console and run `await window.arweaveWallet.getPermissions()` to verify the api is responding correctly

You can verify against **beta** or **prod** that in step 3 the page shouldn't show you as connected and the api in step 4 should return an error
