### PR TITLE
fix: add missing password check in sign auth

### DIFF
--- a/src/routes/auth/sign.tsx
+++ b/src/routes/auth/sign.tsx
@@ -43,6 +43,7 @@ import { getTagValue } from "~tokens/aoTokens/ao";
 import { humanizeTimestampTags } from "~utils/timestamp";
 import styled from "styled-components";
 import { ChevronDownIcon, ChevronUpIcon } from "@iconicicons/react";
+import { checkPassword } from "~wallets/auth";
 
 export function SignAuthRequestView() {
   const { authRequest, acceptRequest, rejectRequest } =
@@ -240,6 +241,17 @@ export function SignAuthRequestView() {
 
   const sign = async () => {
     if (!transaction) return;
+    if (askPassword) {
+      const checkPw = await checkPassword(passwordInput.state);
+      if (!checkPw) {
+        setToast({
+          type: "error",
+          content: browser.i18n.getMessage("invalidPassword"),
+          duration: 2400
+        });
+        return;
+      }
+    }
     if (wallet.type === "hardware") {
       // load tx ur
       if (!page) await loadTransactionUR();


### PR DESCRIPTION
## Summary

This PR adds the missing password check in sign auth popup.

## How to test
- Visit https://awk-test.vercel.app/ and try to upload a file.
- Make sure the sign auth popup cannot be approved without entering the correct password.

## Questions
- Should the password be asked for hardware wallets too ?