### PR TITLE
fix: add a manifest __TEST_MODE__ check for reset storage

### DIFF
--- a/src/wallets/index.ts
+++ b/src/wallets/index.ts
@@ -111,7 +111,11 @@ export async function openOrSelectWelcomePage(force = false) {
 
   // Make sure we clear any stored value from previous installations before
   // opening the welcome page to onboard the user:
-  await resetStorage();
+  // Skip reset for test environment
+  const manifest = browser.runtime.getManifest();
+  if (manifest["__TEST_MODE__"] !== true) {
+    await resetStorage();
+  }
 
   const url = browser.runtime.getURL("tabs/welcome.html");
   const welcomePageTabs = await browser.tabs.query({ url });


### PR DESCRIPTION
## Summary

This PR adds a `__TEST_MODE__` check to prevent clearing storage for test environment.

## How To Test
1. Clone https://github.com/Autonomous-Finance/e2e-ar-connect-example
1. Create the production build `chrome-mv3-prod` for this PR and copy the build folder to [./data/extensions/ar-connect](https://github.com/Autonomous-Finance/e2e-ar-connect-example/tree/main/data/extensions/ar-connect) folder and update the build manifest to include `"__TEST_MODE__": true` in the `manifest.json`.
3. Test for `1.20.5` and `1.23.1` to see the issue with `1.23.1` following the readme of test repo [README.md](https://github.com/Autonomous-Finance/e2e-ar-connect-example/tree/main?tab=readme-ov-file#how-to-reproduce-the-issue)
4. Make sure to test the copied production build `chrome-mv3-prod` as well following the [README.md](https://github.com/Autonomous-Finance/e2e-ar-connect-example/tree/main?tab=readme-ov-file#how-to-reproduce-the-issue) to make sure the issue is fixed. 
   1. Open the file [./fixtures/testFixture.ts](https://github.com/Autonomous-Finance/e2e-ar-connect-example/blob/main/fixtures/testFixture.ts) and set the `arConnectExtensionVersion` to `chrome-mv3-prod` on line 6.
   2. Other steps are same.