### PR TITLE
Add support for ArNS primary names

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -617,9 +617,9 @@
     "message": "address copied",
     "description": "Address copy notification 2"
   },
-  "cannot_edit_with_ans": {
-    "message": "Cannot edit nickname. Wallet already has an ANS label.",
-    "description": "Explainer for disabled edits for wallets with ANS profiles"
+  "cannot_edit_with_name_service": {
+    "message": "Cannot edit nickname. Wallet already has a name service name.",
+    "description": "Explainer for disabled edits for wallets with name service names"
   },
   "add_wallet_subtitle": {
     "message": "You can add as many as you like",

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -613,9 +613,9 @@
       "message": "地址已复制",
       "description": "Address copy notification 2"
   },
-  "cannot_edit_with_ans": {
-      "message": "无法编辑昵称。钱包已经有 ANS 标签。",
-      "description": "Explainer for disabled edits for wallets with ANS profiles"
+  "cannot_edit_with_name_service": {
+      "message": "无法编辑昵称。钱包已经有 Name Service 标签。",
+      "description": "Explainer for disabled edits for wallets with name service names"
   },
   "add_wallet_subtitle": {
       "message": "您可以添加任意数量",

--- a/src/api/background/handlers/alarms/sync-labels/sync-labels-alarm.handler.ts
+++ b/src/api/background/handlers/alarms/sync-labels/sync-labels-alarm.handler.ts
@@ -1,5 +1,5 @@
-import { getAnsProfile, type AnsUser } from "~lib/ans";
 import type { Alarms } from "webextension-polyfill";
+import { getNameServiceProfiles } from "~lib/nameservice";
 import { ExtensionStorage } from "~utils/storage";
 import { getWallets } from "~wallets";
 
@@ -18,21 +18,16 @@ export async function handleSyncLabelsAlarm(alarm?: Alarms.Alarm) {
   if (wallets.length === 0) return;
 
   // get profiles
-  const profiles = (await getAnsProfile(
-    wallets.map((w) => w.address)
-  )) as AnsUser[];
+  const profiles = await getNameServiceProfiles(wallets.map((w) => w.address));
 
-  const find = (addr: string) =>
-    profiles.find((w) => w.user === addr)?.currentLabel;
+  const find = (addr: string) => profiles.find((w) => w.address === addr)?.name;
 
   // save updated wallets
   await ExtensionStorage.set(
     "wallets",
     wallets.map((wallet) => ({
       ...wallet,
-      nickname: find(wallet.address)
-        ? find(wallet.address) + ".ar"
-        : wallet.nickname
+      nickname: find(wallet.address) || wallet.nickname
     }))
   );
 }

--- a/src/components/dashboard/Wallets.tsx
+++ b/src/components/dashboard/Wallets.tsx
@@ -83,9 +83,9 @@ export function WalletsDashboardView() {
 
   function findAvatar(address: string) {
     const avatar = findProfile(address)?.logo;
-    const gatewayUrl = concatGatewayURL(gateway);
-
     if (!avatar) return undefined;
+
+    const gatewayUrl = concatGatewayURL(gateway);
     return gatewayUrl + "/" + avatar;
   }
 

--- a/src/components/dashboard/Wallets.tsx
+++ b/src/components/dashboard/Wallets.tsx
@@ -1,8 +1,6 @@
-import { concatGatewayURL } from "~gateways/utils";
 import { ButtonV2, Spacer, useInput } from "@arconnect/components";
 import { useEffect, useMemo, useState } from "react";
 import { useStorage } from "~utils/storage";
-import { type AnsUser, getAnsProfile } from "~lib/ans";
 import { ExtensionStorage } from "~utils/storage";
 import { useRoute } from "wouter";
 import type { StoredWallet } from "~wallets";
@@ -13,6 +11,8 @@ import SearchInput from "./SearchInput";
 import styled from "styled-components";
 import { FULL_HISTORY, useGateway } from "~gateways/wayfinder";
 import { useLocation } from "~wallets/router/router.utils";
+import { getNameServiceProfiles } from "~lib/nameservice";
+import type { NameServiceProfile } from "~lib/types";
 
 export function WalletsDashboardView() {
   const { navigate } = useLocation();
@@ -57,38 +57,35 @@ export function WalletsDashboardView() {
   }, [wallets, activeWalletSetting]);
 
   // ans data
-  const [ansProfiles, setAnsProfiles] = useState<AnsUser[]>([]);
+  const [nameServiceProfiles, setNameServiceProfiles] = useState<
+    NameServiceProfile[]
+  >([]);
 
   useEffect(() => {
     (async () => {
       if (!wallets) return;
 
       // fetch profiles
-      const profiles = await getAnsProfile(wallets.map((w) => w.address));
+      const profiles = await getNameServiceProfiles(
+        wallets.map((w) => w.address)
+      );
 
-      setAnsProfiles(profiles as AnsUser[]);
+      setNameServiceProfiles(profiles);
     })();
   }, [wallets]);
 
   // ans shortcuts
   const findProfile = (address: string) =>
-    ansProfiles.find((profile) => profile.user === address);
+    nameServiceProfiles.find((profile) => profile.address === address);
 
   const gateway = useGateway(FULL_HISTORY);
 
   function findAvatar(address: string) {
-    const avatar = findProfile(address)?.avatar;
-    const gatewayUrl = concatGatewayURL(gateway);
-
-    if (!avatar) return undefined;
-    return gatewayUrl + "/" + avatar;
+    return findProfile(address)?.logo;
   }
 
   function findLabel(address: string) {
-    const label = findProfile(address)?.currentLabel;
-
-    if (!label) return undefined;
-    return label + ".ar";
+    return findProfile(address)?.name;
   }
 
   // search

--- a/src/components/dashboard/Wallets.tsx
+++ b/src/components/dashboard/Wallets.tsx
@@ -13,6 +13,7 @@ import { FULL_HISTORY, useGateway } from "~gateways/wayfinder";
 import { useLocation } from "~wallets/router/router.utils";
 import { getNameServiceProfiles } from "~lib/nameservice";
 import type { NameServiceProfile } from "~lib/types";
+import { concatGatewayURL } from "~gateways/utils";
 
 export function WalletsDashboardView() {
   const { navigate } = useLocation();
@@ -81,7 +82,11 @@ export function WalletsDashboardView() {
   const gateway = useGateway(FULL_HISTORY);
 
   function findAvatar(address: string) {
-    return findProfile(address)?.logo;
+    const avatar = findProfile(address)?.logo;
+    const gatewayUrl = concatGatewayURL(gateway);
+
+    if (!avatar) return undefined;
+    return gatewayUrl + "/" + avatar;
   }
 
   function findLabel(address: string) {

--- a/src/components/dashboard/subsettings/WalletSettings.tsx
+++ b/src/components/dashboard/subsettings/WalletSettings.tsx
@@ -16,7 +16,6 @@ import { useEffect, useMemo, useState } from "react";
 import { useStorage } from "~utils/storage";
 import { IconButton } from "~components/IconButton";
 import { decryptWallet, freeDecryptedWallet } from "~wallets/encryption";
-import { type AnsUser, getAnsProfile } from "~lib/ans";
 import { ExtensionStorage } from "~utils/storage";
 import { downloadKeyfile } from "~utils/file";
 import keystoneLogo from "url:/assets/hardware/keystone.png";
@@ -26,6 +25,7 @@ import copy from "copy-to-clipboard";
 import { formatAddress } from "~utils/format";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import { LoadingView } from "~components/page/common/loading/loading.view";
+import { getNameServiceProfile } from "~lib/nameservice";
 
 export interface WalletSettingsDashboardViewParams {
   address: string;
@@ -55,19 +55,15 @@ export function WalletSettingsDashboardView({
   // toasts
   const { setToast } = useToasts();
 
-  // ans
-  const [ansLabel, setAnsLabel] = useState<string>();
+  // name service name
+  const [nameServiceName, setNameServiceName] = useState<string>();
 
   useEffect(() => {
     (async () => {
       if (!wallet) return;
 
-      // get ans profile
-      const profile = (await getAnsProfile(wallet.address)) as AnsUser;
-
-      if (!profile?.currentLabel) return;
-
-      setAnsLabel(profile.currentLabel + ".ar");
+      const nameServiceProfile = await getNameServiceProfile(wallet.address);
+      setNameServiceName(nameServiceProfile?.name);
     })();
   }, [wallet?.address]);
 
@@ -76,12 +72,12 @@ export function WalletSettingsDashboardView({
 
   useEffect(() => {
     if (!wallet) return;
-    walletNameInput.setState(ansLabel || wallet.nickname);
-  }, [wallet, ansLabel]);
+    walletNameInput.setState(nameServiceName || wallet.nickname);
+  }, [wallet, nameServiceName]);
 
   // update nickname function
   async function updateNickname() {
-    if (!!ansLabel) return;
+    if (!!nameServiceName) return;
 
     // check name
     const newName = walletNameInput.state;
@@ -173,7 +169,7 @@ export function WalletSettingsDashboardView({
       <div>
         <Spacer y={0.45} />
         <WalletName>
-          {ansLabel || wallet.nickname}
+          {nameServiceName || wallet.nickname}
           {wallet.type === "hardware" && (
             <TooltipV2
               content={
@@ -209,8 +205,10 @@ export function WalletSettingsDashboardView({
           </TooltipV2>
         </WalletAddress>
         <Title>{browser.i18n.getMessage("edit_wallet_name")}</Title>
-        {!!ansLabel && (
-          <Warning>{browser.i18n.getMessage("cannot_edit_with_ans")}</Warning>
+        {!!nameServiceName && (
+          <Warning>
+            {browser.i18n.getMessage("cannot_edit_with_name_service")}
+          </Warning>
         )}
         <InputWithBtn>
           <InputWrapper>
@@ -219,10 +217,10 @@ export function WalletSettingsDashboardView({
               type="text"
               placeholder={browser.i18n.getMessage("edit_wallet_name")}
               fullWidth
-              disabled={!!ansLabel}
+              disabled={!!nameServiceName}
             />
           </InputWrapper>
-          <IconButton onClick={updateNickname} disabled={!!ansLabel}>
+          <IconButton onClick={updateNickname} disabled={!!nameServiceName}>
             Save
           </IconButton>
         </InputWithBtn>

--- a/src/components/popup/Head.tsx
+++ b/src/components/popup/Head.tsx
@@ -9,7 +9,6 @@ import { AnimatePresence, motion } from "framer-motion";
 import { hoverEffect, useTheme } from "~utils/theme";
 import { useStorage } from "~utils/storage";
 import { ArrowLeftIcon } from "@iconicicons/react";
-import { useAnsProfile } from "~lib/ans";
 import { ExtensionStorage } from "~utils/storage";
 import HardwareWalletIcon, {
   hwIconAnimateProps
@@ -21,6 +20,7 @@ import WalletSwitcher from "./WalletSwitcher";
 import styled from "styled-components";
 import { svgie } from "~utils/svgies";
 import { useLocation } from "~wallets/router/router.utils";
+import { useNameServiceProfile } from "~lib/nameservice";
 
 export default function Head({
   title,
@@ -70,7 +70,7 @@ export default function Head({
     instance: ExtensionStorage
   });
 
-  const ans = useAnsProfile(activeAddress);
+  const nameServiceProfile = useNameServiceProfile(activeAddress);
 
   const svgieAvatar = useMemo(
     () => svgie(activeAddress, { asDataURI: true }),
@@ -114,13 +114,13 @@ export default function Head({
       >
         <PageTitle>{title}</PageTitle>
         <ClickableAvatar
-          img={ans?.avatar || svgieAvatar}
+          img={nameServiceProfile?.logo || svgieAvatar}
           onClick={() => {
             if (!allowOpen) return;
             setOpen(true);
           }}
         >
-          {!ans?.avatar && !svgieAvatar && <NoAvatarIcon />}
+          {!nameServiceProfile?.logo && !svgieAvatar && <NoAvatarIcon />}
           <AnimatePresence initial={false}>
             {hardwareApi === "keystone" && (
               <HardwareWalletIcon

--- a/src/components/popup/Head.tsx
+++ b/src/components/popup/Head.tsx
@@ -21,6 +21,8 @@ import styled from "styled-components";
 import { svgie } from "~utils/svgies";
 import { useLocation } from "~wallets/router/router.utils";
 import { useNameServiceProfile } from "~lib/nameservice";
+import { FULL_HISTORY, useGateway } from "~gateways/wayfinder";
+import { concatGatewayURL } from "~gateways/utils";
 
 export default function Head({
   title,
@@ -87,6 +89,7 @@ export default function Head({
 
   // hardware api type
   const hardwareApi = useHardwareApi();
+  const gateway = useGateway(FULL_HISTORY);
 
   return (
     <HeadWrapper
@@ -114,7 +117,11 @@ export default function Head({
       >
         <PageTitle>{title}</PageTitle>
         <ClickableAvatar
-          img={nameServiceProfile?.logo || svgieAvatar}
+          img={
+            nameServiceProfile?.logo
+              ? concatGatewayURL(gateway) + "/" + nameServiceProfile.logo
+              : svgieAvatar
+          }
           onClick={() => {
             if (!allowOpen) return;
             setOpen(true);

--- a/src/components/popup/HeadV2.tsx
+++ b/src/components/popup/HeadV2.tsx
@@ -8,7 +8,6 @@ import { Avatar, CloseLayer, NoAvatarIcon } from "./WalletHeader";
 import { AnimatePresence } from "framer-motion";
 import { useTheme } from "~utils/theme";
 import { useStorage } from "~utils/storage";
-import { useAnsProfile } from "~lib/ans";
 import { ExtensionStorage } from "~utils/storage";
 import HardwareWalletIcon, {
   hwIconAnimateProps
@@ -23,6 +22,7 @@ import type { AppLogoInfo } from "~applications/application";
 import Squircle from "~components/Squircle";
 import { useLocation } from "~wallets/router/router.utils";
 import { ArrowNarrowLeft } from "@untitled-ui/icons-react";
+import { useNameServiceProfile } from "~lib/nameservice";
 
 export interface HeadV2Props {
   title: string;
@@ -86,7 +86,7 @@ export default function HeadV2({
     instance: ExtensionStorage
   });
 
-  const ans = useAnsProfile(activeAddress);
+  const nameServiceProfile = useNameServiceProfile(activeAddress);
 
   const svgieAvatar = useMemo(
     () => svgie(activeAddress, { asDataURI: true }),
@@ -144,12 +144,12 @@ export default function HeadV2({
         <>
           <AvatarButton>
             <ButtonAvatar
-              img={ans?.avatar || svgieAvatar}
+              img={nameServiceProfile?.logo || svgieAvatar}
               onClick={() => {
                 setOpen(true);
               }}
             >
-              {!ans?.avatar && !svgieAvatar && <NoAvatarIcon />}
+              {!nameServiceProfile?.logo && !svgieAvatar && <NoAvatarIcon />}
               <AnimatePresence initial={false}>
                 {hardwareApi === "keystone" && (
                   <HardwareWalletIcon

--- a/src/components/popup/HeadV2.tsx
+++ b/src/components/popup/HeadV2.tsx
@@ -23,6 +23,8 @@ import Squircle from "~components/Squircle";
 import { useLocation } from "~wallets/router/router.utils";
 import { ArrowNarrowLeft } from "@untitled-ui/icons-react";
 import { useNameServiceProfile } from "~lib/nameservice";
+import { concatGatewayURL } from "~gateways/utils";
+import { FULL_HISTORY, useGateway } from "~gateways/wayfinder";
 
 export interface HeadV2Props {
   title: string;
@@ -103,6 +105,7 @@ export default function HeadV2({
   const appIconPlaceholderText = appInfo?.placeholder;
 
   const SquircleWrapper = onAppInfoClick ? ButtonSquircle : React.Fragment;
+  const gateway = useGateway(FULL_HISTORY);
 
   return (
     <HeadWrapper
@@ -144,7 +147,11 @@ export default function HeadV2({
         <>
           <AvatarButton>
             <ButtonAvatar
-              img={nameServiceProfile?.logo || svgieAvatar}
+              img={
+                nameServiceProfile?.logo
+                  ? concatGatewayURL(gateway) + "/" + nameServiceProfile.logo
+                  : svgieAvatar
+              }
               onClick={() => {
                 setOpen(true);
               }}

--- a/src/components/popup/WalletHeader.tsx
+++ b/src/components/popup/WalletHeader.tsx
@@ -9,7 +9,6 @@ import { useHardwareApi } from "~wallets/hooks";
 import type { StoredWallet } from "~wallets";
 import { formatAddress, getAppURL } from "~utils/format";
 import { removeApp } from "~applications";
-import { useAnsProfile } from "~lib/ans";
 import { useTheme } from "~utils/theme";
 import {
   ButtonV2,
@@ -52,6 +51,7 @@ import {
 import { svgie } from "~utils/svgies";
 import WalletMenu from "./WalletMenu";
 import { useLocation } from "~wallets/router/router.utils";
+import { useNameServiceProfile } from "~lib/nameservice";
 
 export default function WalletHeader() {
   const theme = useTheme();
@@ -98,7 +98,7 @@ export default function WalletHeader() {
   };
 
   // profile picture
-  const ansProfile = useAnsProfile(activeAddress);
+  const nameServiceProfile = useNameServiceProfile(activeAddress);
 
   // fallback svgie for profile picture
   const svgieAvatar = useMemo(
@@ -114,7 +114,7 @@ export default function WalletHeader() {
 
   // wallet name
   const walletName = useMemo(() => {
-    if (!ansProfile?.label) {
+    if (!nameServiceProfile?.name) {
       const wallet = wallets.find(({ address }) => address === activeAddress);
       let name = wallet?.nickname || "Wallet";
 
@@ -128,8 +128,8 @@ export default function WalletHeader() {
       return wallet?.nickname || "Wallet";
     }
 
-    return ansProfile.label;
-  }, [wallets, ansProfile, activeAddress]);
+    return nameServiceProfile.name;
+  }, [wallets, nameServiceProfile, activeAddress]);
 
   // hardware wallet type
   const hardwareApi = useHardwareApi();
@@ -256,8 +256,8 @@ export default function WalletHeader() {
             if (!isOpen) setOpen(true);
           }}
         >
-          <Avatar img={ansProfile?.avatar || svgieAvatar}>
-            {!ansProfile?.avatar && !svgieAvatar && <NoAvatarIcon />}
+          <Avatar img={nameServiceProfile?.logo || svgieAvatar}>
+            {!nameServiceProfile?.logo && !svgieAvatar && <NoAvatarIcon />}
             <AnimatePresence initial={false}>
               {hardwareApi === "keystone" && (
                 <HardwareWalletIcon

--- a/src/components/popup/WalletHeader.tsx
+++ b/src/components/popup/WalletHeader.tsx
@@ -52,6 +52,8 @@ import { svgie } from "~utils/svgies";
 import WalletMenu from "./WalletMenu";
 import { useLocation } from "~wallets/router/router.utils";
 import { useNameServiceProfile } from "~lib/nameservice";
+import { concatGatewayURL } from "~gateways/utils";
+import { FULL_HISTORY, useGateway } from "~gateways/wayfinder";
 
 export default function WalletHeader() {
   const theme = useTheme();
@@ -99,6 +101,7 @@ export default function WalletHeader() {
 
   // profile picture
   const nameServiceProfile = useNameServiceProfile(activeAddress);
+  const gateway = useGateway(FULL_HISTORY);
 
   // fallback svgie for profile picture
   const svgieAvatar = useMemo(
@@ -256,7 +259,13 @@ export default function WalletHeader() {
             if (!isOpen) setOpen(true);
           }}
         >
-          <Avatar img={nameServiceProfile?.logo || svgieAvatar}>
+          <Avatar
+            img={
+              nameServiceProfile?.logo
+                ? concatGatewayURL(gateway) + "/" + nameServiceProfile.logo
+                : svgieAvatar
+            }
+          >
             {!nameServiceProfile?.logo && !svgieAvatar && <NoAvatarIcon />}
             <AnimatePresence initial={false}>
               {hardwareApi === "keystone" && (

--- a/src/components/popup/WalletSwitcher.tsx
+++ b/src/components/popup/WalletSwitcher.tsx
@@ -7,7 +7,6 @@ import {
   TooltipV2,
   useToasts
 } from "@arconnect/components";
-import { concatGatewayURL } from "~gateways/utils";
 import { motion, AnimatePresence, type Variants } from "framer-motion";
 import { formatTokenBalance } from "~tokens/currency";
 import type { HardwareApi } from "~wallets/hardware";

--- a/src/components/popup/WalletSwitcher.tsx
+++ b/src/components/popup/WalletSwitcher.tsx
@@ -27,6 +27,7 @@ import { Action } from "./WalletHeader";
 import copy from "copy-to-clipboard";
 import { useLocation } from "~wallets/router/router.utils";
 import { getNameServiceProfiles } from "~lib/nameservice";
+import { concatGatewayURL } from "~gateways/utils";
 
 export default function WalletSwitcher({
   open,
@@ -95,7 +96,9 @@ export default function WalletSwitcher({
           return {
             ...wallet,
             name: profile?.name || wallet.name,
-            avatar: profile?.logo || svgieAvatar,
+            avatar: profile?.logo
+              ? concatGatewayURL(gateway) + "/" + profile.logo
+              : svgieAvatar,
             hasAns: !!profile
           };
         })

--- a/src/lib/ans.ts
+++ b/src/lib/ans.ts
@@ -80,8 +80,6 @@ export async function getAnsNameServiceProfile(
         address: profile.user,
         name: profile.currentLabel + ".ar",
         logo: profile.avatar
-          ? concatGatewayURL(gateway) + "/" + profile.avatar
-          : undefined
       };
 }
 

--- a/src/lib/arns.ts
+++ b/src/lib/arns.ts
@@ -1,5 +1,8 @@
 import { pLimit } from "plimit-lit";
 import { AOProcess } from "./ao";
+import { findGateway } from "~gateways/wayfinder";
+import { concatGatewayURL } from "~gateways/utils";
+import type { NameServiceProfile } from "./types";
 
 export const AO_ARNS_PROCESS = "agYcCFJtrMG6cqMuZfskIkFTGvUPddICmtQSBIoPdiA";
 
@@ -47,6 +50,12 @@ export type ANTInfo = {
   Ticker: string;
   Denomination: number;
   Owner: string;
+};
+export type ArNSPrimaryName = {
+  owner: WalletAddress;
+  name: string;
+  startTimestamp: number;
+  processId: string;
 };
 
 export async function getArNSRecord(
@@ -141,4 +150,70 @@ export async function searchArNSName(name: string) {
     success: false,
     record: null
   };
+}
+
+/**
+ * Generalized method to find the logo (avatar) for an ArNS name.
+ * Fetches the ArNS record and ANT info to retrieve the transaction ID for the logo.
+ * @param name - The ArNS name to fetch the logo for.
+ * @returns The transaction ID of the logo if found, otherwise undefined.
+ */
+export async function findLogo(processId: string): Promise<string | undefined> {
+  try {
+    // Fetch the ANT info to get the logo transaction ID
+    const antInfo = await getANTState(processId);
+    return antInfo?.Logo || undefined;
+  } catch (error) {
+    console.error(`Failed to fetch logo for name ${name}:`, error);
+    return undefined;
+  }
+}
+
+/**
+ * Fetches the primary ArNS name for a wallet address.
+ * @param address - Wallet address to fetch the primary name for.
+ * @returns Primary name record or undefined.
+ */
+export async function getPrimaryArNSName(
+  address: WalletAddress
+): Promise<ArNSPrimaryName | undefined> {
+  const ArIO = new AOProcess({ processId: AO_ARNS_PROCESS });
+  const primaryName = ArIO.read<ArNSPrimaryName>({
+    tags: [
+      { name: "Action", value: "Primary-Name" },
+      { name: "Address", value: address }
+    ]
+  });
+  console.log(primaryName);
+  return primaryName;
+}
+
+export async function getArNSProfile(
+  query: string
+): Promise<NameServiceProfile | undefined> {
+  if (!query) {
+    return undefined;
+  }
+
+  try {
+    // Fetch the primary name and logo
+    const primaryName = await getPrimaryArNSName(query);
+    const gateway = await findGateway({ startBlock: 0 });
+    let logoUrl: string | undefined;
+
+    if (primaryName?.name) {
+      logoUrl = await findLogo(primaryName.processId);
+      logoUrl = logoUrl ? concatGatewayURL(gateway) + "/" + logoUrl : undefined;
+    }
+
+    return {
+      address: query,
+      name: primaryName?.name,
+      logo: logoUrl
+    };
+  } catch (error) {
+    console.error("Error fetching ArNS profile:", error);
+  }
+
+  return undefined;
 }

--- a/src/lib/arns.ts
+++ b/src/lib/arns.ts
@@ -1,7 +1,5 @@
 import { pLimit } from "plimit-lit";
 import { AOProcess } from "./ao";
-import { findGateway } from "~gateways/wayfinder";
-import { concatGatewayURL } from "~gateways/utils";
 import type { NameServiceProfile } from "./types";
 
 export const AO_ARNS_PROCESS = "agYcCFJtrMG6cqMuZfskIkFTGvUPddICmtQSBIoPdiA";
@@ -162,7 +160,7 @@ export async function findLogo(processId: string): Promise<string | undefined> {
   try {
     // Fetch the ANT info to get the logo transaction ID
     const antInfo = await getANTState(processId);
-    return antInfo?.Logo || undefined;
+    return antInfo?.Logo;
   } catch (error) {
     console.error(`Failed to fetch logo for name ${name}:`, error);
     return undefined;
@@ -198,18 +196,12 @@ export async function getArNSProfile(
   try {
     // Fetch the primary name and logo
     const primaryName = await getPrimaryArNSName(query);
-    const gateway = await findGateway({ startBlock: 0 });
-    let logoUrl: string | undefined;
-
-    if (primaryName?.name) {
-      logoUrl = await findLogo(primaryName.processId);
-      logoUrl = logoUrl ? concatGatewayURL(gateway) + "/" + logoUrl : undefined;
-    }
+    const logo = await findLogo(primaryName.processId);
 
     return {
       address: query,
       name: primaryName?.name,
-      logo: logoUrl
+      logo
     };
   } catch (error) {
     console.error("Error fetching ArNS profile:", error);

--- a/src/lib/arns.ts
+++ b/src/lib/arns.ts
@@ -176,13 +176,15 @@ export async function getPrimaryArNSName(
   address: WalletAddress
 ): Promise<ArNSPrimaryName | undefined> {
   const ArIO = new AOProcess({ processId: AO_ARNS_PROCESS });
+  // Use retries of 1 as AOProcess is treating assertion errors (i.e., "Primary name not found") as
+  // a retry-able error.
   const primaryName = ArIO.read<ArNSPrimaryName>({
     tags: [
       { name: "Action", value: "Primary-Name" },
       { name: "Address", value: address }
-    ]
+    ],
+    retries: 1
   });
-  console.log(primaryName);
   return primaryName;
 }
 

--- a/src/lib/nameservice.ts
+++ b/src/lib/nameservice.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import type { NameServiceProfile } from "./types";
+import { getAnsNameServiceProfile } from "./ans";
+import { getArNSProfile } from "./arns";
+
+/**
+ * Return a NameServiceProfile for a query
+ *
+ * @param walletAddress Address
+ *
+ * @returns NameServiceProfile | undefined
+ */
+export async function getNameServiceProfile(
+  walletAddress: string
+): Promise<NameServiceProfile | undefined> {
+  return (
+    (await getArNSProfile(walletAddress)) ||
+    (await getAnsNameServiceProfile(walletAddress))
+  );
+}
+
+/**
+ * Return NameServiceProfile[] for a wallet addresses
+ *
+ * @param walletAddress Address[]
+ *
+ * @returns NameServiceProfile[] | undefined
+ */
+export async function getNameServiceProfiles(
+  walletAddress: string[]
+): Promise<Array<NameServiceProfile>> {
+  const profiles = [];
+  for (let wallet of walletAddress) {
+    const profile = await getNameServiceProfile(wallet);
+    if (profile) {
+      profiles.push(profile);
+    }
+  }
+  return profiles;
+}
+
+/**
+ * React hook for Nameservice (ArNS, ANS) profile
+ *
+ * @param walletAddress Address
+ *
+ * @returns NameServiceProfile | undefined
+ */
+export function useNameServiceProfile(walletAddress: string) {
+  const [profile, setProfile] = useState<NameServiceProfile>();
+
+  useEffect(() => {
+    (async () => {
+      if (!walletAddress) {
+        return setProfile(undefined);
+      }
+
+      const profile = await getNameServiceProfile(walletAddress);
+
+      setProfile(profile);
+    })();
+  }, [walletAddress]);
+
+  return profile;
+}

--- a/src/lib/nameservice.ts
+++ b/src/lib/nameservice.ts
@@ -3,29 +3,39 @@ import type { NameServiceProfile } from "./types";
 import { getAnsNameServiceProfile } from "./ans";
 import { getArNSProfile } from "./arns";
 import { ExtensionStorage } from "~utils/storage";
+import { getWallets } from "~wallets";
 
-let IN_MEM_CACHE: Record<string, NameServiceProfile> = {};
+let IN_MEM_CACHE: Record<string, NameServiceProfile | "none"> = {};
 
+/**
+ * Refreshes memory and storage caches with latest from name services.
+ */
 async function updateCache() {
-  for (const walletAddress of Object.keys(IN_MEM_CACHE)) {
+  // use wallets from storage to clear out any stale cache
+  const wallets = await getWallets();
+  const walletAddresses = wallets.map((w) => w.address);
+
+  const newMemCache = {};
+
+  for (let walletAddress of walletAddresses) {
     const profile =
       (await getArNSProfile(walletAddress)) ||
       (await getAnsNameServiceProfile(walletAddress));
-    IN_MEM_CACHE[walletAddress] = profile;
+
+    newMemCache[walletAddress] = profile || "none";
   }
-  ExtensionStorage.set("name_service_cache", IN_MEM_CACHE);
+
+  IN_MEM_CACHE = newMemCache;
+  ExtensionStorage.set("name_service_cache", newMemCache);
 }
 
+// load cache from storage and then do background update
 ExtensionStorage.get<Record<string, NameServiceProfile>>("name_service_cache")
   .then((cache) => {
     if (cache) {
       IN_MEM_CACHE = cache;
     }
-
-    // update cache every 2 minutes
-    // TODO: make this more robust
     updateCache();
-    setInterval(updateCache, 2 * 60 * 1000);
   })
   .catch((e) => {
     console.error(e);
@@ -43,14 +53,14 @@ export async function getNameServiceProfile(
 ): Promise<NameServiceProfile | undefined> {
   const cached = IN_MEM_CACHE[walletAddress];
   if (cached) {
-    return cached;
+    return cached === "none" ? undefined : cached;
   }
 
   const profile =
     (await getArNSProfile(walletAddress)) ||
     (await getAnsNameServiceProfile(walletAddress));
 
-  IN_MEM_CACHE[walletAddress] = profile;
+  IN_MEM_CACHE[walletAddress] = profile || "none";
   ExtensionStorage.set("name_service_cache", IN_MEM_CACHE);
 
   return profile;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,5 @@
+export interface NameServiceProfile {
+  address: string;
+  name: string;
+  logo?: string;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,8 @@
 export interface NameServiceProfile {
+  /** address of the wallet */
   address: string;
+  /** name associated with the address */
   name: string;
+  /** logo Arweave TxID */
   logo?: string;
 }

--- a/src/routes/popup/settings/wallets/index.tsx
+++ b/src/routes/popup/settings/wallets/index.tsx
@@ -52,7 +52,11 @@ export function WalletsView() {
   const gateway = useGateway(FULL_HISTORY);
 
   function findAvatar(address: string) {
-    return findProfile(address)?.logo;
+    const avatar = findProfile(address)?.logo;
+    const gatewayUrl = concatGatewayURL(gateway);
+
+    if (!avatar) return undefined;
+    return gatewayUrl + "/" + avatar;
   }
 
   function findLabel(address: string) {

--- a/src/routes/popup/settings/wallets/index.tsx
+++ b/src/routes/popup/settings/wallets/index.tsx
@@ -52,11 +52,7 @@ export function WalletsView() {
   const gateway = useGateway(FULL_HISTORY);
 
   function findAvatar(address: string) {
-    const avatar = findProfile(address)?.logo;
-    const gatewayUrl = concatGatewayURL(gateway);
-
-    if (!avatar) return undefined;
-    return gatewayUrl + "/" + avatar;
+    return findProfile(address)?.logo;
   }
 
   function findLabel(address: string) {

--- a/src/routes/popup/settings/wallets/index.tsx
+++ b/src/routes/popup/settings/wallets/index.tsx
@@ -2,7 +2,6 @@ import { concatGatewayURL } from "~gateways/utils";
 import { ButtonV2, Spacer, useInput } from "@arconnect/components";
 import { useEffect, useState } from "react";
 import { useStorage } from "~utils/storage";
-import { type AnsUser, getAnsProfile } from "~lib/ans";
 import { ExtensionStorage } from "~utils/storage";
 import type { StoredWallet } from "~wallets";
 import { Reorder } from "framer-motion";
@@ -13,6 +12,8 @@ import WalletListItem from "~components/dashboard/list/WalletListItem";
 import SearchInput from "~components/dashboard/SearchInput";
 import HeadV2 from "~components/popup/HeadV2";
 import { useLocation } from "~wallets/router/router.utils";
+import { getNameServiceProfiles } from "~lib/nameservice";
+import type { NameServiceProfile } from "~lib/types";
 
 export function WalletsView() {
   const { navigate } = useLocation();
@@ -27,27 +28,31 @@ export function WalletsView() {
   );
 
   // ans data
-  const [ansProfiles, setAnsProfiles] = useState<AnsUser[]>([]);
+  const [nameServiceProfiles, setNameServiceProfiles] = useState<
+    NameServiceProfile[]
+  >([]);
 
   useEffect(() => {
     (async () => {
       if (!wallets) return;
 
       // fetch profiles
-      const profiles = await getAnsProfile(wallets.map((w) => w.address));
+      const profiles = await getNameServiceProfiles(
+        wallets.map((w) => w.address)
+      );
 
-      setAnsProfiles(profiles as AnsUser[]);
+      setNameServiceProfiles(profiles);
     })();
   }, [wallets]);
 
   // ans shortcuts
   const findProfile = (address: string) =>
-    ansProfiles.find((profile) => profile.user === address);
+    nameServiceProfiles.find((profile) => profile.address === address);
 
   const gateway = useGateway(FULL_HISTORY);
 
   function findAvatar(address: string) {
-    const avatar = findProfile(address)?.avatar;
+    const avatar = findProfile(address)?.logo;
     const gatewayUrl = concatGatewayURL(gateway);
 
     if (!avatar) return undefined;
@@ -55,10 +60,7 @@ export function WalletsView() {
   }
 
   function findLabel(address: string) {
-    const label = findProfile(address)?.currentLabel;
-
-    if (!label) return undefined;
-    return label + ".ar";
+    return findProfile(address)?.name;
   }
 
   // search

--- a/src/routes/welcome/generate/done.tsx
+++ b/src/routes/welcome/generate/done.tsx
@@ -1,6 +1,5 @@
 import { ButtonV2, Checkbox, Spacer, Text } from "@arconnect/components";
 import { PasswordContext, WalletContext } from "../setup";
-import { type AnsUser, getAnsProfile } from "~lib/ans";
 import { formatAddress } from "~utils/format";
 import Paragraph from "~components/Paragraph";
 import browser from "webextension-polyfill";
@@ -19,6 +18,7 @@ import { useStorage } from "~utils/storage";
 import JSConfetti from "js-confetti";
 import { useLocation } from "~wallets/router/router.utils";
 import { loadTokens } from "~tokens/token";
+import { getNameServiceProfile } from "~lib/nameservice";
 
 export function GenerateDoneWelcomeView() {
   const { navigate } = useLocation();
@@ -66,12 +66,12 @@ export function GenerateDoneWelcomeView() {
     }
 
     try {
-      const ansProfile = (await getAnsProfile(
+      const nameServiceProfile = await getNameServiceProfile(
         walletRef.current.address
-      )) as AnsUser;
+      );
 
-      if (ansProfile) {
-        nickname = ansProfile.currentLabel;
+      if (nameServiceProfile) {
+        nickname = nameServiceProfile.name;
       }
     } catch {}
 

--- a/src/wallets/hooks.ts
+++ b/src/wallets/hooks.ts
@@ -1,6 +1,5 @@
 import type { WalletInterface } from "~components/welcome/load/Migrate";
 import type { JWKInterface } from "arweave/web/lib/wallet";
-import { type AnsUser, getAnsProfile } from "~lib/ans";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useStorage } from "~utils/storage";
 import { defaultGateway } from "~gateways/gateway";
@@ -12,6 +11,7 @@ import Arweave from "arweave";
 import BigNumber from "bignumber.js";
 import { retryWithDelayAndTimeout } from "~utils/promises/retry";
 import { isPasswordFresh } from "./auth";
+import { getNameServiceProfiles } from "~lib/nameservice";
 
 /**
  * Wallets with details hook
@@ -38,15 +38,15 @@ export function useWalletsDetails(wallets: JWKInterface[]) {
 
       // load ans labels
       try {
-        const profiles = (await getAnsProfile(
+        const profiles = await getNameServiceProfiles(
           details.map((w) => w.address)
-        )) as AnsUser[];
+        );
 
         for (const wallet of details) {
-          const profile = profiles.find((p) => p.user === wallet.address);
+          const profile = profiles.find((p) => p.address === wallet.address);
 
-          if (!profile?.currentLabel) continue;
-          wallet.label = profile.currentLabel + ".ar";
+          if (!profile?.name) continue;
+          wallet.label = profile.name;
         }
       } catch {}
 


### PR DESCRIPTION
This PR introduces nameservice.ts that searches and provides ArNS Primary Name profiles in addition to ANS profiles. Code that formerly used ans.ts directly was refactored to use nameservice. Additionally, an in-memory cache backed by ExtensionStorage was introduced to optimize profile lookup.  