### PR TITLE
Fixes background color for Payment Method Button in Light Theme

### DIFF
--- a/src/routes/popup/purchase.tsx
+++ b/src/routes/popup/purchase.tsx
@@ -369,7 +369,7 @@ export function PurchaseView() {
           )}
           <Line />
           <InputButton
-            style={{ background: "#242426" }}
+            style={{ background: theme.surfaceTertiary }}
             label={browser.i18n.getMessage("buy_screen_payment_method_label")}
             onClick={() => setShowPaymentSelector(true)}
             disabled={!paymentMethod}


### PR DESCRIPTION
This PR fixes background color for Payment Method Button that always displayed a dark background color, even in Light Theme

| Before | After |
|:-:|:-:|
| <img width="367" alt="Screenshot 2025-02-05 at 11 50 32 PM" src="https://github.com/user-attachments/assets/a543d67d-12af-47c9-88b0-12e3ef8129ae" /> | <img width="369" alt="Screenshot 2025-02-05 at 11 49 52 PM" src="https://github.com/user-attachments/assets/b097eccc-ca59-46df-8f19-b58e5ec11064" /> |