### PR TITLE
fix: overflowing transaction sign message

### DIFF
--- a/src/components/auth/Message.tsx
+++ b/src/components/auth/Message.tsx
@@ -77,8 +77,10 @@ const EncodingSelect = styled.select`
   background-color: transparent;
 `;
 
-const MessageText = styled(Text).attrs({
-  noMargin: true
-})`
+const MessageText = styled.div`
   font-size: 0.9rem;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  height: 200px;
+  overflow-y: auto;
 `;


### PR DESCRIPTION
Jira: https://communitylabs.atlassian.net/browse/ARC-1052?atlOrigin=eyJpIjoiMDQwNjczNmI5Yzk2NDU1M2JiZTViYmIyMDMwN2UwOWEiLCJwIjoiaiJ9

There is an issue where the tx message in the sign message screen is overflowing out of the card container.  To resolve this:

- ensure tx message text is word wrapping
- height is fixed at 200px (any long tx message the user can scroll)