### PR TITLE
fix: show popup for signMessage with always ask permission only

### DIFF
--- a/src/api/modules/sign/sign_policy.ts
+++ b/src/api/modules/sign/sign_policy.ts
@@ -7,7 +7,7 @@ export type SignPolicy = "always_ask" | "ask_when_spending" | "auto_confirm";
 
 export function checkIfUserNeedsToSign(
   signPolicy: SignPolicy,
-  transaction: Transaction | DataItem | RawDataItem,
+  transaction?: Transaction | DataItem | RawDataItem,
   walletType: "local" | "hardware" = "local"
 ) {
   try {
@@ -20,6 +20,7 @@ export function checkIfUserNeedsToSign(
         return true;
 
       case "ask_when_spending":
+        if (!transaction) return false;
         const tags = transaction?.tags || [];
         let isAo = false,
           isTransfer = false,


### PR DESCRIPTION
## Summary

This PR makes `signMessage` only show the popup when `always ask` permission is set for the dApp. Also, seems there was the issue with not saving the correct `signPolicy` when a dApp is connected which is also fixed by this PR.

## How to Test
- Make sure the `signMessage` popup is only seen for the `always ask` permissions.
- Also check the other apis like `sign` works correctly with all the permissions like `always ask`, `auto confirm` and `ask when spending`.

Related Jira Ticket: [ARC-1026](https://communitylabs.atlassian.net/browse/ARC-1026)

[ARC-1026]: https://communitylabs.atlassian.net/browse/ARC-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ