### PR TITLE
fix: add getFormattedColor utility for color formatting

### DIFF
--- a/src/components/hardware/HardwareWalletTheme.tsx
+++ b/src/components/hardware/HardwareWalletTheme.tsx
@@ -1,6 +1,6 @@
 import { useEffect, type PropsWithChildren } from "react";
 import { useHardwareApi } from "~wallets/hooks";
-import { useTheme } from "~utils/theme";
+import { getFormattedColor, useTheme } from "~utils/theme";
 import { useTheme as useStyledComponentsTheme } from "styled-components";
 import { MotionGlobalConfig } from "framer-motion";
 import {
@@ -77,15 +77,7 @@ export function ThemeBackgroundObserver({
   useEffect(() => {
     if (!theme) return;
 
-    let formattedBackgroundColor = "";
-
-    if (backgroundColor.length === 3 || backgroundColor.length === 6) {
-      formattedBackgroundColor = `#${backgroundColor}`;
-    } else if (/\d{1,3}, ?\d{1,3}, ?\d{1,3}/.test(backgroundColor)) {
-      formattedBackgroundColor = `rgb(${backgroundColor})`;
-    } else if (/\d{1,3}, ?\d{1,3}, ?\d{1,3}, ?.+/.test(backgroundColor)) {
-      formattedBackgroundColor = `rgba(${backgroundColor})`;
-    }
+    let formattedBackgroundColor = getFormattedColor(backgroundColor);
 
     if (formattedBackgroundColor) {
       localStorage.setItem(
@@ -103,15 +95,7 @@ export function ThemeBackgroundObserver({
   useEffect(() => {
     if (!theme) return;
 
-    let formattedTextColor = "";
-
-    if (textColor.length === 3 || textColor.length === 6) {
-      formattedTextColor = `#${textColor}`;
-    } else if (/\d{1,3}, ?\d{1,3}, ?\d{1,3}/.test(textColor)) {
-      formattedTextColor = `rgb(${textColor})`;
-    } else if (/\d{1,3}, ?\d{1,3}, ?\d{1,3}, ?.+/.test(textColor)) {
-      formattedTextColor = `rgba(${textColor})`;
-    }
+    let formattedTextColor = getFormattedColor(textColor);
 
     if (formattedTextColor) {
       localStorage.setItem(ARCONNECT_THEME_TEXT_COLOR, formattedTextColor);

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -86,9 +86,9 @@ export function getFormattedColor(color: string) {
     formattedColor = color;
   } else if (/^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(color)) {
     formattedColor = `#${color}`;
-  } else if (/\d{1,3}, ?\d{1,3}, ?\d{1,3}/.test(color)) {
+  } else if (/^\d{1,3}, ?\d{1,3}, ?\d{1,3}$/.test(color)) {
     formattedColor = `rgb(${color})`;
-  } else if (/\d{1,3}, ?\d{1,3}, ?\d{1,3}, ?.+/.test(color)) {
+  } else if (/^\d{1,3}, ?\d{1,3}, ?\d{1,3}, ?.+$/.test(color)) {
     formattedColor = `rgba(${color})`;
   }
   return formattedColor;

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -79,3 +79,17 @@ export const hoverEffect = css`
     background-color: rgba(${(props) => props.theme.theme}, 0.15);
   }
 `;
+
+export function getFormattedColor(color: string) {
+  let formattedColor = "";
+  if (/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(color)) {
+    formattedColor = color;
+  } else if (/^([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(color)) {
+    formattedColor = `#${color}`;
+  } else if (/\d{1,3}, ?\d{1,3}, ?\d{1,3}/.test(color)) {
+    formattedColor = `rgb(${color})`;
+  } else if (/\d{1,3}, ?\d{1,3}, ?\d{1,3}, ?.+/.test(color)) {
+    formattedColor = `rgba(${color})`;
+  }
+  return formattedColor;
+}


### PR DESCRIPTION
## Summary

This PR introduces a utility function, `getFormattedColor`, which ensures proper formatting of color values, including validating hex codes that start with `#`.  

Following Wander's rebranding, `primaryText` was changed from an RGB value to a hex code. However, `ThemeBackgroundObserver` did not recognize it as a valid color, preventing `ARCONNECT_THEME_TEXT_COLOR` from being set. As a result, components relying on `currentColor` such as `Loading` (which became invisible in light mode, affecting elements like dashboard balance loading, activity tab loading, etc.) were impacted.  

By incorporating `getFormattedColor`, we ensure consistent color detection, preventing such issues.
