### PR TITLE
fix: wallet switcher close

### DIFF
--- a/src/components/popup/WalletSwitcher.tsx
+++ b/src/components/popup/WalletSwitcher.tsx
@@ -147,7 +147,12 @@ export default function WalletSwitcher({ open, close }: Props) {
       isOpen={open}
       onClose={close}
     >
-      <CloseIcon onClick={close} />
+      <CloseIcon
+        onClick={(e) => {
+          e.stopPropagation();
+          close();
+        }}
+      />
       <Wrapper>
         <CurrentWallet>
           <Avatar img={activeWallet?.avatar}>

--- a/src/routes/auth/connect.tsx
+++ b/src/routes/auth/connect.tsx
@@ -90,6 +90,15 @@ export function ConnectAuthRequestView() {
     gateway
   } = authRequest;
 
+  // wallet switcher open
+  const [switcherOpen, setSwitcherOpen] = useState(false);
+
+  // page
+  const [page, setPage] = useState<Page>("connect");
+
+  // password input
+  const passwordInput = useInput();
+
   // toasts
   const { setToast } = useToasts();
 


### PR DESCRIPTION
## Summary

This PR fixes the issue where the wallet switcher close button was not working in the `Connect` popup.
## How to Test  
1. Visit [playground.othent.io](https://playground.othent.io/) and connect your wallet.  
2. In the `Connect` popup, open the wallet switcher and attempt to close it using the close button.  
3. Verify that the wallet switcher now closes properly with this fix and confirm that it was not working before.  