### PR TITLE
fix: use a random fallback gateway

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1071,6 +1071,10 @@
     "message": "Could not send transaction. Please try again.",
     "description": "Transfer error notification"
   },
+  "failed_tx_with_gateway": {
+    "message": "Could not send transaction. Please try again or use a different gateway.",
+    "description": "Transfer error notification"
+  },
   "assets": {
     "message": "Assets",
     "description": "Assets title"
@@ -2917,5 +2921,9 @@
         "example": "USD"
       }
     }
+  },
+  "switch_gateway": {
+    "message": "Switch Gateway",
+    "description": "Switch gateway text"
   }
 }

--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1068,7 +1068,7 @@
     "description": "Transaction sent successfuly notification"
   },
   "failed_tx": {
-    "message": "Could not send transaction",
+    "message": "Could not send transaction. Please try again.",
     "description": "Transfer error notification"
   },
   "assets": {

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -1056,7 +1056,11 @@
       "description": "Transaction sent successfully notification"
   },
   "failed_tx": {
-      "message": "无法发送交易。请再试一次。",
+      "message": "无法发送交易，请重试。",
+      "description": "Transfer error notification"
+  },
+  "failed_tx_with_gateway": {
+      "message": "无法发送交易。请重试或使用不同的网关。",
       "description": "Transfer error notification"
   },
   "assets": {
@@ -2907,5 +2911,9 @@
             "example": "USD"
         }
         }
+    },
+    "switch_gateway": {
+        "message": "切换网关",
+        "description": "Switch gateway text"
     }
 }

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -1056,7 +1056,7 @@
       "description": "Transaction sent successfully notification"
   },
   "failed_tx": {
-      "message": "无法发送交易",
+      "message": "无法发送交易。请再试一次。",
       "description": "Transfer error notification"
   },
   "assets": {

--- a/src/gateways/wayfinder.ts
+++ b/src/gateways/wayfinder.ts
@@ -10,6 +10,7 @@ import {
 import { useEffect, useState } from "react";
 import { getGatewayCache } from "./cache";
 import { getSetting } from "~settings";
+import Arweave from "arweave";
 
 export const FULL_HISTORY: Requirements = { startBlock: 0 };
 
@@ -172,6 +173,48 @@ export function useGraphqlGateways(count?: number) {
 
   return graphqlGateways;
 }
+
+/**
+ * Retries an Arweave operation with different gateways
+ * @param operation - Function that takes an Arweave instance and returns a Promise
+ * @param options - Retry configuration
+ */
+export async function retryWithGateways<T>(
+  operation: (arweave: Arweave) => Promise<T>,
+  { maxAttempts = 3 }: RetryOptions = {}
+): Promise<RetryResult<T>> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const gateway = await findGateway({ random: attempt > 1 });
+
+    try {
+      const arweave = new Arweave(gateway);
+      const result = await operation(arweave);
+      return { result, arweave, gateway };
+    } catch (error) {
+      lastError = error as Error;
+      // console.warn(`Gateway attempt ${attempt} failed:`, error);
+      if (attempt === maxAttempts) {
+        throw new Error(
+          `Gateway operations failed after ${maxAttempts} attempts. Last error: ${lastError.message}`
+        );
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+type RetryOptions = {
+  maxAttempts?: number;
+};
+
+type RetryResult<T> = {
+  result: T;
+  gateway: Gateway;
+  arweave: Arweave;
+};
 
 export interface Requirements {
   /* Whether the gateway should be selected randomly */

--- a/src/routes/auth/connect.tsx
+++ b/src/routes/auth/connect.tsx
@@ -90,6 +90,15 @@ export function ConnectAuthRequestView() {
     gateway
   } = authRequest;
 
+  // wallet switcher open
+  const [switcherOpen, setSwitcherOpen] = useState(false);
+
+  // page
+  const [page, setPage] = useState<Page>("connect");
+
+  // password input
+  const passwordInput = useInput();
+
   // toasts
   const { setToast } = useToasts();
 

--- a/src/routes/popup/send/amount.tsx
+++ b/src/routes/popup/send/amount.tsx
@@ -489,6 +489,7 @@ export function AmountView({ params: { id, recipient } }: AmountViewProps) {
                 ticker={
                   qtyMode === "fiat" ? "USD" : token?.Ticker?.toUpperCase()
                 }
+                autoFocus
               />
               {!!+price && (
                 <Flex

--- a/src/routes/popup/send/amount.tsx
+++ b/src/routes/popup/send/amount.tsx
@@ -29,9 +29,8 @@ import { loadTokenLogo, type Token as TokenInterface } from "~tokens/token";
 import { useTheme } from "~utils/theme";
 import arLogoLight from "url:/assets/ar/logo_light.png";
 import arLogoDark from "url:/assets/ar/logo_dark.png";
-import Arweave from "arweave";
 import Collectible from "~components/popup/Collectible";
-import { findGateway } from "~gateways/wayfinder";
+import { retryWithGateways } from "~gateways/wayfinder";
 import { useLocation } from "~wallets/router/router.utils";
 import HeadV2 from "~components/popup/HeadV2";
 import SliderMenu from "~components/SliderMenu";
@@ -44,7 +43,7 @@ import {
   type TokenInfo
 } from "~tokens/aoTokens/ao";
 import BigNumber from "bignumber.js";
-import { AO_NATIVE_TOKEN, EXP_TOKEN } from "~utils/ao_import";
+import { EXP_TOKEN } from "~utils/ao_import";
 import { AnnouncementPopup } from "./announcement";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import { useTokenBalance, useTokenPrice, useTokenPrices } from "~tokens/hooks";
@@ -289,9 +288,10 @@ export function AmountView({ params: { id, recipient } }: AmountViewProps) {
         if (note) {
           byte = new TextEncoder().encode(note).byteLength;
         }
-        const gateway = await findGateway({});
-        const arweave = new Arweave(gateway);
-        const txPrice = await arweave.transactions.getPrice(byte, recipient);
+
+        const { result: txPrice, arweave } = await retryWithGateways(
+          (arweave) => arweave.transactions.getPrice(byte, recipient)
+        );
 
         if (tokenID === "AR") {
           setNetworkFee(arweave.ar.winstonToAr(txPrice));

--- a/src/routes/popup/send/auth.tsx
+++ b/src/routes/popup/send/auth.tsx
@@ -34,15 +34,12 @@ import browser from "webextension-polyfill";
 import Head from "~components/popup/Head";
 import styled from "styled-components";
 import Arweave from "arweave";
-import {
-  defaultGateway,
-  fallbackGateway,
-  type Gateway
-} from "~gateways/gateway";
+import { defaultGateway, type Gateway } from "~gateways/gateway";
 import { EventType, trackEvent } from "~utils/analytics";
 import BigNumber from "bignumber.js";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import { useStorage } from "@plasmohq/storage/hook";
+import { findGateway } from "~gateways/wayfinder";
 
 export interface SendAuthViewParams {
   tokenID?: string;
@@ -200,8 +197,8 @@ export function SendAuthView({ params: { tokenID } }: SendAuthViewProps) {
           // Post the transaction
           await submitTx(transaction, arweave, type);
         } catch (e) {
-          // FALLBACK IF ISP BLOCKS ARWEAVE.NET OR IF WAYFINDER FAILS
-          gateway = fallbackGateway;
+          // FALLBACK IF ISP BLOCKS the gateway or if the gateway fails
+          gateway = await findGateway({ random: true });
           const fallbackArweave = new Arweave(gateway);
           await fallbackArweave.transactions.sign(transaction, keyfile);
           await submitTx(transaction, fallbackArweave, type);
@@ -265,8 +262,8 @@ export function SendAuthView({ params: { tokenID } }: SendAuthViewProps) {
           // post tx
           await submitTx(transaction, arweave, type);
         } catch (e) {
-          // FALLBACK IF ISP BLOCKS ARWEAVE.NET OR IF WAYFINDER FAILS
-          gateway = fallbackGateway;
+          // FALLBACK IF ISP BLOCKS the gateway or if the gateway fails
+          gateway = await findGateway({ random: true });
           const fallbackArweave = new Arweave(gateway);
           await fallbackArweave.transactions.sign(transaction, keyfile);
           await submitTx(transaction, fallbackArweave, type);

--- a/src/routes/popup/send/confirm.tsx
+++ b/src/routes/popup/send/confirm.tsx
@@ -343,11 +343,19 @@ export function ConfirmView({
           });
           navigate(`/send/completed/${res}?isAo=true`);
           setIsLoading(false);
+        } else {
+          throw new Error("Failed to send ao transfer");
         }
         return res;
       } catch (err) {
         console.log("err in ao", err);
-        throw err;
+        setIsLoading(false);
+        setToast({
+          type: "error",
+          content: browser.i18n.getMessage("failed_tx"),
+          duration: 2000
+        });
+        return;
       }
     }
     // Prepare transaction

--- a/src/routes/popup/send/confirm.tsx
+++ b/src/routes/popup/send/confirm.tsx
@@ -23,7 +23,7 @@ import { useEffect, useMemo, useState } from "react";
 import { findGateway } from "~gateways/wayfinder";
 import Arweave from "arweave";
 import { useLocation } from "~wallets/router/router.utils";
-import { fallbackGateway, type Gateway } from "~gateways/gateway";
+import { type Gateway } from "~gateways/gateway";
 import AnimatedQRScanner from "~components/hardware/AnimatedQRScanner";
 import AnimatedQRPlayer from "~components/hardware/AnimatedQRPlayer";
 import { getActiveKeyfile, getActiveWallet, type StoredWallet } from "~wallets";
@@ -377,7 +377,7 @@ export function ConfirmView({
                 SubscriptionStatus.ACTIVE
               ));
           } catch (e) {
-            gateway = fallbackGateway;
+            gateway = await findGateway({ random: true });
             const fallbackArweave = new Arweave(gateway);
             await fallbackArweave.transactions.sign(
               convertedTransaction,
@@ -442,7 +442,7 @@ export function ConfirmView({
           try {
             await submitTx(convertedTransaction, arweave, type);
           } catch (e) {
-            gateway = fallbackGateway;
+            gateway = await findGateway({ random: true });
             const fallbackArweave = new Arweave(gateway);
             await fallbackArweave.transactions.sign(
               convertedTransaction,

--- a/src/routes/popup/send/confirm.tsx
+++ b/src/routes/popup/send/confirm.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Input,
   Section,
   Spacer,
@@ -75,6 +76,7 @@ import {
 import prettyBytes from "pretty-bytes";
 import { stringToBuffer } from "arweave/web/lib/utils";
 import useSetting from "~settings/hook";
+import { Flex } from "~components/common/Flex";
 
 export interface ConfirmViewParams {
   token: string;
@@ -234,6 +236,30 @@ export function ConfirmView({
     transaction.addTag("Type", "Transfer");
     transaction.addTag("Client", "Wander");
     transaction.addTag("Client-Version", browser.runtime.getManifest().version);
+  }
+
+  function showTransferError() {
+    setToast({
+      type: "error",
+      content: (
+        <Flex direction="column" gap={16}>
+          <Text style={{ color: "#EEE" }} noMargin>
+            {browser.i18n.getMessage("failed_tx_with_gateway")}
+          </Text>
+          <Button
+            fullWidth
+            onClick={() =>
+              browser.tabs.create({
+                url: browser.runtime.getURL("tabs/dashboard.html#/gateways")
+              })
+            }
+          >
+            {browser.i18n.getMessage("switch_gateway")}
+          </Button>
+        </Flex>
+      ),
+      duration: 5000
+    });
   }
 
   async function submitTx(
@@ -418,11 +444,7 @@ export function ConfirmView({
           console.log(e);
           setIsLoading(false);
           freeDecryptedWallet(keyfile);
-          setToast({
-            type: "error",
-            content: browser.i18n.getMessage("failed_tx"),
-            duration: 2000
-          });
+          showTransferError();
         }
       } else {
         const activeWallet = await getActiveWallet();
@@ -479,11 +501,7 @@ export function ConfirmView({
         } catch (e) {
           freeDecryptedWallet(keyfile);
           setIsLoading(false);
-          setToast({
-            type: "error",
-            content: browser.i18n.getMessage("failed_tx"),
-            duration: 2000
-          });
+          showTransferError();
         }
       }
     }
@@ -664,11 +682,7 @@ export function ConfirmView({
         );
       } catch (e) {
         console.log(e);
-        setToast({
-          type: "error",
-          content: browser.i18n.getMessage("failed_tx"),
-          duration: 2000
-        });
+        showTransferError();
       }
     }
   );

--- a/src/routes/popup/send/confirm.tsx
+++ b/src/routes/popup/send/confirm.tsx
@@ -20,7 +20,7 @@ import {
   TempTransactionStorage,
   type RawStoredTransfer
 } from "~utils/storage";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { findGateway } from "~gateways/wayfinder";
 import Arweave from "arweave";
 import { useLocation } from "~wallets/router/router.utils";
@@ -97,6 +97,8 @@ export function ConfirmView({
   // TODO: Need to get Token information
   const [token, setToken] = useState<TokenInfo | undefined>();
   const [amount, setAmount] = useState<string>("");
+
+  const toastTimestamp = useRef<number | undefined>();
 
   const [isAo, setIsAo] = useState<boolean>(false);
   const passwordInput = useInput();
@@ -195,8 +197,8 @@ export function ConfirmView({
   ): Promise<Partial<RawStoredTransfer> | void> {
     try {
       // create tx
-      let gateway = await findGateway({});
-      let arweave = new Arweave(gateway);
+      const gateway = await findGateway({});
+      const arweave = new Arweave(gateway);
 
       // save tx json into the session
       // to be signed and submitted
@@ -205,7 +207,7 @@ export function ConfirmView({
         gateway: gateway
       };
 
-      const tx = await arweave.createTransaction({
+      const data = {
         target,
         quantity: fractionedToBalance(
           amount,
@@ -213,7 +215,18 @@ export function ConfirmView({
           "AR"
         ),
         data: message ? decodeURIComponent(message) : undefined
-      });
+      };
+
+      let tx: Transaction;
+
+      try {
+        tx = await arweave.createTransaction(data);
+      } catch {
+        const fallbackGateway = await findGateway({ random: true });
+        const fallbackArweave = new Arweave(fallbackGateway);
+        tx = await fallbackArweave.createTransaction(data);
+        storedTx.gateway = fallbackGateway;
+      }
 
       addTransferTags(tx);
 
@@ -221,11 +234,7 @@ export function ConfirmView({
 
       return storedTx;
     } catch {
-      return setToast({
-        type: "error",
-        content: browser.i18n.getMessage("transaction_send_error"),
-        duration: 2000
-      });
+      showTransferError();
     }
   }
 
@@ -239,6 +248,12 @@ export function ConfirmView({
   }
 
   function showTransferError() {
+    if (toastTimestamp.current && Date.now() - toastTimestamp.current < 1000) {
+      return;
+    }
+
+    toastTimestamp.current = Date.now();
+
     setToast({
       type: "error",
       content: (

--- a/src/routes/popup/send/confirm.tsx
+++ b/src/routes/popup/send/confirm.tsx
@@ -21,7 +21,7 @@ import {
   type RawStoredTransfer
 } from "~utils/storage";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { findGateway } from "~gateways/wayfinder";
+import { findGateway, retryWithGateways } from "~gateways/wayfinder";
 import Arweave from "arweave";
 import { useLocation } from "~wallets/router/router.utils";
 import { type Gateway } from "~gateways/gateway";
@@ -197,8 +197,22 @@ export function ConfirmView({
   ): Promise<Partial<RawStoredTransfer> | void> {
     try {
       // create tx
-      const gateway = await findGateway({});
-      const arweave = new Arweave(gateway);
+      const { result: tx, gateway } = await retryWithGateways(
+        async (arweave) => {
+          const transaction = await arweave.createTransaction({
+            target,
+            quantity: fractionedToBalance(
+              amount,
+              { decimals: token.Denomination },
+              "AR"
+            ),
+            data: message ? decodeURIComponent(message) : undefined
+          });
+
+          addTransferTags(transaction);
+          return transaction;
+        }
+      );
 
       // save tx json into the session
       // to be signed and submitted
@@ -206,29 +220,6 @@ export function ConfirmView({
         type: tokenID === "AR" ? "native" : "token",
         gateway: gateway
       };
-
-      const data = {
-        target,
-        quantity: fractionedToBalance(
-          amount,
-          { decimals: token.Denomination },
-          "AR"
-        ),
-        data: message ? decodeURIComponent(message) : undefined
-      };
-
-      let tx: Transaction;
-
-      try {
-        tx = await arweave.createTransaction(data);
-      } catch {
-        const fallbackGateway = await findGateway({ random: true });
-        const fallbackArweave = new Arweave(fallbackGateway);
-        tx = await fallbackArweave.createTransaction(data);
-        storedTx.gateway = fallbackGateway;
-      }
-
-      addTransferTags(tx);
 
       storedTx.transaction = tx.toJSON();
 

--- a/src/subscriptions/payments.ts
+++ b/src/subscriptions/payments.ts
@@ -1,5 +1,4 @@
 import { ExtensionStorage, type RawStoredTransfer } from "~utils/storage";
-import { fallbackGateway } from "~gateways/gateway";
 import type Transaction from "arweave/web/lib/transaction";
 import { EventType, trackEvent } from "~utils/analytics";
 import { SubscriptionStatus, type SubscriptionData } from "./subscription";
@@ -161,8 +160,8 @@ export const send = async (
       return submitted;
     } catch (e) {
       console.log("entered fallback gateway");
-      // FALLBACK IF ISP BLOCKS ARWEAVE.NET OR IF WAYFINDER FAILS
-      gateway = fallbackGateway;
+      // FALLBACK IF ISP BLOCKS the gateway or if the gateway fails
+      gateway = await findGateway({ random: true });
       const fallbackArweave = new Arweave(gateway);
       await fallbackArweave.transactions.sign(unRaw, keyfile);
       const submitted = await submitTx(

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,7 +12,7 @@
 
 "@arconnect/components-rebrand@github:arconnectio/components-rebrand.git#master":
   version "1.0.0"
-  resolved "git+ssh://git@github.com/arconnectio/components-rebrand.git#d8d6f0698f2f651391d3ca082af32e3c98ca03da"
+  resolved "https://codeload.github.com/arconnectio/components-rebrand/tar.gz/2147c649dc8d7cd9c29077053fef25b92032be16"
   dependencies:
     "@iconicicons/react" "^1.5.1"
     "@untitled-ui/icons-react" "^0.1.4"


### PR DESCRIPTION
## Summary  

This PR improves the transaction retry mechanism in the send flow by selecting a random gateway as a fallback. Additionally, it enhances the error-handling experience by displaying a **gateway switch** button on the error toast, allowing users to manually switch gateways when a transaction fails.

**Jira Ticket:** [ARC-1112](https://communitylabs.atlassian.net/browse/ARC-1112)

## Screenshots  
<img width="380" alt="image" src="https://github.com/user-attachments/assets/608a577a-79b0-4be4-a275-d5ea43879e91" />

## How to Test  
Since the issue might not be easily reproducible (depending on gateway availability), you can manually introduce an error in the code to:  
- Test the **gateway fallback** mechanism.  
- Verify that the **error toast** displays correctly with the gateway switch option.  

Let me know if you have any questions! 🚀 

[ARC-1112]: https://communitylabs.atlassian.net/browse/ARC-1112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ