### PR TITLE
fix: wallet switcher balances

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "react-fast-marquee": "^1.3.5",
     "react-lottie": "^1.2.10",
     "react-qr-reader": "^2.2.1",
-    "redstone-api": "^0.4.11",
+    "redstone-api": "^0.4.13",
     "rss-parser": "^3.12.0",
     "shamir-secret-sharing": "^0.0.3",
     "styled-components": "^5.3.6",

--- a/src/components/popup/WalletSwitcher.tsx
+++ b/src/components/popup/WalletSwitcher.tsx
@@ -161,7 +161,12 @@ export default function WalletSwitcher({ open, close }: Props) {
       isOpen={open}
       onClose={close}
     >
-      <CloseIcon onClick={close} />
+      <CloseIcon
+        onClick={(e) => {
+          e.stopPropagation();
+          close();
+        }}
+      />
       <Wrapper>
         <CurrentWallet>
           <Avatar img={activeWallet?.avatar}>

--- a/src/components/popup/WalletSwitcher.tsx
+++ b/src/components/popup/WalletSwitcher.tsx
@@ -136,13 +136,13 @@ export default function WalletSwitcher({ open, close }: Props) {
   useEffect(() => {
     const updateBalances = async () => {
       if (open && inactiveWallets.length > 0) {
-        const balances = await fetchWalletBalances(inactiveWallets, currency);
+        const balances = await fetchWalletBalances(inactiveWallets);
         setWalletBalances(balances);
       }
     };
 
     updateBalances();
-  }, [open, inactiveWallets, currency]);
+  }, [open, inactiveWallets]);
 
   const fiatBalances = useMemo(() => {
     return Object.entries(walletBalances).reduce((acc, [address, balance]) => {

--- a/src/lib/coingecko.ts
+++ b/src/lib/coingecko.ts
@@ -35,7 +35,11 @@ export async function getArPrice(currency: string) {
 
     const res = await redstone.getPrice("AR");
 
-    if (!res.value) throw new Error("Failed to fetch AR price");
+    if (!res.value) throw new Error("No price value returned from Redstone");
+
+    if (res.timestamp && Date.now() - res.timestamp >= 7200000) {
+      throw new Error("Price is older than 2 hours");
+    }
 
     const rate = await getConversionRate(currency);
 

--- a/src/routes/auth/sign.tsx
+++ b/src/routes/auth/sign.tsx
@@ -3,11 +3,11 @@ import { isSplitTransaction } from "~api/modules/sign/transaction_builder";
 import { formatFiatBalance, formatTokenBalance } from "~tokens/currency";
 import type { DecodedTag } from "~api/modules/sign/tags";
 import type { Tag } from "arweave/web/lib/transaction";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useScanner } from "@arconnect/keystone-sdk";
 import { useActiveWallet, useAskPassword } from "~wallets/hooks";
 import { formatAddress } from "~utils/format";
-import { getArPrice } from "~lib/coingecko";
+import { useArPrice } from "~lib/coingecko";
 import type { UR } from "@ngraveio/bc-ur";
 import {
   AmountTitle,
@@ -73,13 +73,7 @@ export function SignAuthRequestView() {
   const passwordInput = useInput();
 
   // arweave price
-  const [arPrice, setArPrice] = useState(0);
-
-  useEffect(() => {
-    getArPrice(currency)
-      .then((res) => setArPrice(res))
-      .catch();
-  }, [currency]);
+  const { data: arPrice = "0" } = useArPrice(currency);
 
   // transaction price
   const fiatPrice = useMemo(

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,4 +1,4 @@
-import { currencies } from "~lib/coingecko";
+import { currencies } from "~utils/currency";
 import Setting from "./setting";
 import {
   BarChart07,

--- a/src/tabs/auth.tsx
+++ b/src/tabs/auth.tsx
@@ -10,6 +10,18 @@ import { useEffect } from "react";
 import { handleSyncLabelsAlarm } from "~api/background/handlers/alarms/sync-labels/sync-labels-alarm.handler";
 import { ErrorBoundary } from "~utils/error/ErrorBoundary/errorBoundary";
 import { FallbackView } from "~components/page/common/Fallback/fallback.view";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 300_000,
+      refetchInterval: 300_000,
+      retry: 2,
+      refetchOnWindowFocus: true
+    }
+  }
+});
 
 export function AuthApp() {
   useEffect(() => {
@@ -25,9 +37,11 @@ export function AuthAppRoot() {
       <ErrorBoundary fallback={FallbackView}>
         <WalletsProvider redirectToWelcome>
           <AuthRequestsProvider useStatusOverride={useExtensionStatusOverride}>
-            <Wouter hook={useAuthRequestsLocation}>
-              <AuthApp />
-            </Wouter>
+            <QueryClientProvider client={queryClient}>
+              <Wouter hook={useAuthRequestsLocation}>
+                <AuthApp />
+              </Wouter>
+            </QueryClientProvider>
           </AuthRequestsProvider>
         </WalletsProvider>
       </ErrorBoundary>

--- a/src/tokens/hooks.ts
+++ b/src/tokens/hooks.ts
@@ -31,6 +31,14 @@ export const defaultQueryCache = {
   staleTime: Infinity
 };
 
+export const useConversionRate = (currency: string) =>
+  useQuery({
+    queryKey: ["conversionRate", currency],
+    queryFn: () => getConversionRate(currency),
+    enabled: !!currency,
+    ...defaultOptions
+  });
+
 export function useQueryCache<T = unknown>(queryKey: unknown[]) {
   return useQuery({ ...defaultQueryCache, queryKey });
 }
@@ -59,11 +67,7 @@ export function useTokenBalance(
 export function useTokenPrice(id?: string, currency = "USD") {
   const isArToken = id === "AR";
 
-  const conversionRateQuery = useQuery({
-    queryKey: ["conversionRate", currency],
-    queryFn: () => getConversionRate(currency),
-    ...defaultOptions
-  });
+  const conversionRateQuery = useConversionRate(currency);
 
   const priceQuery = useQuery({
     queryKey: ["tokenPrice", id],
@@ -94,12 +98,7 @@ export function useTokenPrice(id?: string, currency = "USD") {
 export function useTokenPrices(ids?: string[]) {
   const [currency = "USD"] = useSetting("currency");
 
-  const conversionRateQuery = useQuery({
-    queryKey: ["conversionRate", currency],
-    queryFn: () => getConversionRate(currency),
-    enabled: !!currency,
-    ...defaultOptions
-  });
+  const conversionRateQuery = useConversionRate(currency);
 
   const pricesQuery = useQuery({
     queryKey: ["tokenPrices", ids?.slice().sort().join(",")],

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -1,4 +1,3 @@
-import { currencies } from "~lib/coingecko";
 import { ExtensionStorage } from "./storage";
 
 interface ExchangeRateResponse {
@@ -154,3 +153,51 @@ export async function getConversionRate(
   const rates = await getExchangeRates();
   return rates[targetCurrency.toUpperCase()];
 }
+
+export const currencies = [
+  "USD",
+  "EUR",
+  "GBP",
+  "CNY",
+  "INR",
+  "AED",
+  "ARS",
+  "AUD",
+  "BDT",
+  "BHD",
+  "BMD",
+  "BRL",
+  "CAD",
+  "CHF",
+  "CLP",
+  "CZK",
+  "DKK",
+  "HKD",
+  "HUF",
+  "IDR",
+  "ILS",
+  "JPY",
+  "KRW",
+  "KWD",
+  "LKR",
+  "MMK",
+  "MXN",
+  "MYR",
+  "NGN",
+  "NOK",
+  "NZD",
+  "PHP",
+  "PKR",
+  "PLN",
+  "RUB",
+  "SAR",
+  "SEK",
+  "SGD",
+  "THB",
+  "TRY",
+  "TWD",
+  "UAH",
+  "VEF",
+  "VND",
+  "ZAR"
+];

--- a/yarn.lock
+++ b/yarn.lock
@@ -9232,10 +9232,10 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-redstone-api@^0.4.11:
-  version "0.4.12"
-  resolved "https://registry.yarnpkg.com/redstone-api/-/redstone-api-0.4.12.tgz#b634f710e13e95ba64d9cc8b3be7f004707a3e96"
-  integrity sha512-AR1zb7Pv4uXdfmJXj8rMl96x09krXUFgYDQaBXo5tn34e/VrE1VMja3DLR0W81izEjr8KcG9b9SHjIy5a1peWw==
+redstone-api@^0.4.13:
+  version "0.4.13"
+  resolved "https://registry.npmjs.org/redstone-api/-/redstone-api-0.4.13.tgz#28819546f35de62eda61351d76f3dd86214d3840"
+  integrity sha512-PNPo9NZpTVEARAAtcbCs7B+ys9nLdcDDtw0fIl+5+RHGtvBEP99wR3W84f/Leazn0esn4ttRAL9SjMaLzS4zbA==
   dependencies:
     ar-gql "^0.0.6"
     arweave "^1.10.16"


### PR DESCRIPTION
## Summary  

This PR reintroduces the Redstone API as a fallback for AR balance fetching, ensuring data freshness by discarding prices older than 2 hours.