### PR TITLE
fix: show total fiat balance of all tokens

### DIFF
--- a/src/tokens/hooks.ts
+++ b/src/tokens/hooks.ts
@@ -150,7 +150,7 @@ export function useTotalFiatBalance() {
     .filter((id) => id !== EXP_TOKEN && id !== "AR");
 
   const pricesQuery = useQueryCache<Record<string, number>>([
-    "botegaPrices",
+    "tokenPrices",
     tokenIds?.slice().sort().join(",")
   ]);
 
@@ -185,6 +185,7 @@ export function useTotalFiatBalance() {
     address,
     conversionRateQuery.data,
     pricesQuery.data,
-    tokenBalanceQueries
+    tokenBalanceQueries,
+    arPrice
   ]);
 }


### PR DESCRIPTION
## Summary

This PR fixes the issue with hook `useTotalFiatBalance` to use the tokens price correctly to show the total fiat balance on the dashboard.