### PR TITLE
fix: navbar width & fullscreen menu for development

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -2925,5 +2925,9 @@
   "switch_gateway": {
     "message": "Switch Gateway",
     "description": "Switch gateway text"
+  },
+  "setting_fullscreen": {
+    "message": "Fullscreen",
+    "description": "Fullscreen text"
   }
 }

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -2915,5 +2915,9 @@
     "switch_gateway": {
         "message": "切换网关",
         "description": "Switch gateway text"
+    },
+    "setting_fullscreen": {
+        "message": "全屏",
+        "description": "Fullscreen text"
     }
 }

--- a/src/components/popup/Navigation.tsx
+++ b/src/components/popup/Navigation.tsx
@@ -2,6 +2,7 @@ import { Compass03, Grid01, Home05, Users01 } from "@untitled-ui/icons-react";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
 import { useLocation } from "~wallets/router/router.utils";
+import { IS_EMBEDDED_APP } from "~utils/embedded/embedded.constants";
 
 const Home05Active = () => (
   <svg
@@ -112,7 +113,7 @@ const NavigationBarWrapper = styled.nav`
   bottom: 0;
   height: 68px;
   background-color: ${(props) => props.theme.backgroundv2};
-  width: 100%;
+  width: ${IS_EMBEDDED_APP ? "100%" : "377px"};
   display: flex;
   box-sizing: border-box;
 `;

--- a/src/routes/dashboard/dashboard.constants.ts
+++ b/src/routes/dashboard/dashboard.constants.ts
@@ -7,6 +7,7 @@ import {
   CreditCard01,
   Grid01,
   InfoCircle,
+  Maximize01,
   Pencil02,
   Settings01,
   Users01,
@@ -28,6 +29,7 @@ import { AboutDashboardView } from "~components/dashboard/About";
 import { SignSettingsDashboardView } from "~components/dashboard/SignSettings";
 import { ResetDashboardView } from "~components/dashboard/Reset";
 import { AnalyticsSettingsDashboardView } from "~components/dashboard/Analytics";
+import { IS_EMBEDDED_APP } from "~utils/embedded/embedded.constants";
 
 export interface DashboardRouteConfig extends Omit<SettingItemProps, "active"> {
   name: string;
@@ -173,3 +175,12 @@ export const quickSettingsMenuItems: Omit<
     externalLink: "tabs/dashboard.html"
   }
 ];
+
+if (process.env.NODE_ENV === "development" && !IS_EMBEDDED_APP) {
+  quickSettingsMenuItems.splice(5, 0, {
+    name: "fullscreen",
+    displayName: "setting_fullscreen",
+    icon: Maximize01,
+    externalLink: "tabs/fullscreen.html"
+  });
+}

--- a/src/routes/popup/explore.tsx
+++ b/src/routes/popup/explore.tsx
@@ -11,6 +11,7 @@ import {
 } from "@untitled-ui/icons-react";
 import { getAppURL, truncateMiddle } from "~utils/format";
 import WanderIcon from "url:assets/icon.svg";
+import { IS_EMBEDDED_APP } from "~utils/embedded/embedded.constants";
 
 export function ExploreView() {
   const [filteredApps, setFilteredApps] = useState(apps);
@@ -357,8 +358,10 @@ const FixedHeader = styled.div`
   gap: 1rem;
   flex-direction: column;
   position: fixed;
+  width: ${IS_EMBEDDED_APP ? "100%" : "377px"};
+  margin: 0 auto;
   left: 0;
-  width: 100vw;
+  right: 0;
   padding: 24px 24px 16px 24px;
   box-sizing: border-box;
   background: linear-gradient(

--- a/src/utils/embedded/embedded.constants.ts
+++ b/src/utils/embedded/embedded.constants.ts
@@ -1,0 +1,1 @@
+export const IS_EMBEDDED_APP = import.meta.env?.VITE_IS_EMBEDDED_APP === "1";


### PR DESCRIPTION
## Summary

This PR introduces the following fixes:
- Adjusted bottom navbar & explore header width for all embed, extension popup & fullscreen.
- Added a `Fullscreen` menu item for development environment.

Fixes fullscreen issue of #662

## Screenshots
|  ![image](https://github.com/user-attachments/assets/f8028c06-5db7-40f7-9bb6-08177208ef59) | ![image](https://github.com/user-attachments/assets/43dfe5e2-9415-4cae-a857-e9f5858c2e07) |
|------------------------------------------------------------|------------------------------------------------------------|
| ![image](https://github.com/user-attachments/assets/fd12f37c-bdab-4722-b960-2e3e022b3a8c) | ![image](https://github.com/user-attachments/assets/34d84577-e9b9-4f71-99ef-9cd16458f6c5) |
