### PR TITLE
feat: add connect to dapps password settings

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -463,17 +463,21 @@
     "message": "Sign notification",
     "description": "Sign notification settings title"
   },
-  "setting_transfer_settings": {
-    "message": "Transfer settings",
-    "description": "Transfer settings title"
+  "setting_password_settings": {
+    "message": "Password settings",
+    "description": "Password settings title"
   },
-  "setting_transfer_settings_description": {
-    "message": "Requiring a password any time assets are being transferred",
-    "description": "Transfer settings description"
+  "setting_password_settings_description": {
+    "message": "Actions that require a password",
+    "description": "Password settings description"
   },
   "enable_transfer_settings": {
     "message": "Require password when signing a transaction",
     "description": "Enable transfer settings title"
+  },
+  "enable_connect_settings": {
+    "message": "Require password when connecting to an application",
+    "description": "Enable connect settings title"
   },
   "setting_display_theme": {
     "message": "Theme",

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -459,17 +459,21 @@
       "message": "签署通知",
       "description": "Sign notification settings title"
   },
-  "setting_transfer_settings": {
-      "message": "转账设置",
-      "description": "Transfer settings title"
+  "setting_password_settings": {
+      "message": "密码设置",
+      "description": "Password settings title"
   },
-  "setting_transfer_settings_description": {
-    "message": "任何时候转移资产时都需要密码",
-    "description": "Transfer settings description"
+  "setting_password_settings_description": {
+    "message": "需要密码的操作",
+    "description": "Password settings description"
   },
   "enable_transfer_settings": {
     "message": "签署交易时需要密码",
     "description": "Enable transfer settings title"
+  },
+  "enable_connect_settings": {
+    "message": "连接应用时需要密码",
+    "description": "Enable connect settings title"
   },
   "setting_display_theme": {
       "message": "主题",

--- a/src/components/dashboard/SignSettings.tsx
+++ b/src/components/dashboard/SignSettings.tsx
@@ -14,15 +14,36 @@ export const SignSettingsDashboardView = () => {
     false
   );
 
+  const [connectRequirePassword, setConnectRequirePassword] = useStorage(
+    {
+      key: "connect_require_password",
+      instance: ExtensionStorage
+    },
+    false
+  );
+
   return (
     <Wrapper>
       <ToggleSwitchWrapper>
-        <Text>{browser.i18n.getMessage("enable_transfer_settings")}</Text>
+        <Text noMargin>
+          {browser.i18n.getMessage("enable_transfer_settings")}
+        </Text>
         <ToggleSwitch
           width={51}
           height={31}
           checked={transferRequirePassword}
           setChecked={setTransferRequirePassword}
+        />
+      </ToggleSwitchWrapper>
+      <ToggleSwitchWrapper>
+        <Text noMargin>
+          {browser.i18n.getMessage("enable_connect_settings")}
+        </Text>
+        <ToggleSwitch
+          width={51}
+          height={31}
+          checked={connectRequirePassword}
+          setChecked={setConnectRequirePassword}
         />
       </ToggleSwitchWrapper>
     </Wrapper>
@@ -31,6 +52,9 @@ export const SignSettingsDashboardView = () => {
 
 const Wrapper = styled.div`
   position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 `;
 
 const ToggleSwitchWrapper = styled.div`

--- a/src/routes/auth/connect.tsx
+++ b/src/routes/auth/connect.tsx
@@ -32,7 +32,7 @@ import Permissions from "../../components/auth/Permissions";
 import { HeadAuth } from "~components/HeadAuth";
 import { AuthButtons } from "~components/auth/AuthButtons";
 import Squircle from "~components/Squircle";
-import { useActiveWallet, useAskPassword } from "~wallets/hooks";
+import { useActiveWallet } from "~wallets/hooks";
 import Checkbox from "~components/Checkbox";
 import { ChevronRight, Edit02, InfoCircle } from "@untitled-ui/icons-react";
 import WanderIcon from "url:assets/icon.svg";
@@ -58,7 +58,13 @@ export function ConnectAuthRequestView() {
 
   const [signPolicy, setSignPolicy] = useState<SignPolicy>("ask_when_spending");
 
-  const askPassword = useAskPassword();
+  const [askPassword] = useStorage<boolean>(
+    {
+      key: "connect_require_password",
+      instance: ExtensionStorage
+    },
+    false
+  );
 
   // permissions to add
   const [permissions, setPermissions] = useState<PermissionType[]>([]);

--- a/src/routes/dashboard/dashboard.constants.ts
+++ b/src/routes/dashboard/dashboard.constants.ts
@@ -92,9 +92,9 @@ export const basicSettings: (DashboardRouteConfig | Setting)[] = [
 
 export const advancedSettings: (DashboardRouteConfig | Setting)[] = [
   {
-    name: "transfer_settings",
-    displayName: "setting_transfer_settings",
-    description: "setting_transfer_settings_description",
+    name: "password_settings",
+    displayName: "setting_password_settings",
+    description: "setting_password_settings_description",
     icon: Pencil02,
     component: SignSettingsDashboardView
   },


### PR DESCRIPTION
## Summary

This PR renames `Transfer Settings` to `Password Settings` and adds a new toggle: "Require password when connecting to an application." The default setting is disabled.

Related Jira Ticket: [ARC-1129](https://communitylabs.atlassian.net/browse/ARC-1129)

## Changes
- **Rename** `Transfer Settings` to `Password Settings`
- **Existing:** Retain "Require password when signing a transaction" toggle
- **New:** Add "Require password when connecting to an application" toggle
  - **Enabled**: Requires password when connecting to a dApp
  - **Disabled**: No password required (default)

## How to Test
- Verify that the setting update appears correctly in the UI.
- Ensure enabling/disabling the new toggle works as expected.
- Confirm the default state is disabled.


[ARC-1129]: https://communitylabs.atlassian.net/browse/ARC-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ