### PR TITLE
fix: wallet view labels should not append .ar

### DIFF
--- a/src/routes/popup/settings/wallets/index.tsx
+++ b/src/routes/popup/settings/wallets/index.tsx
@@ -67,7 +67,7 @@ export function WalletsView() {
     const label = findProfile(address)?.name;
 
     if (!label) return undefined;
-    return label + ".ar";
+    return label;
   }
 
   return (


### PR DESCRIPTION
NameServiceProfile data for ANS appends .ar to the profile name. Appending .ar here make it not work for either ArNS nor ANS. 