### PR TITLE
fix: api popups & embedded utils issue

### DIFF
--- a/src/api/modules/sign/chunks.ts
+++ b/src/api/modules/sign/chunks.ts
@@ -36,9 +36,9 @@ export const sendChunk = (chunk: Chunk) =>
   new Promise<void>((resolve, reject) => {
     const callID = nanoid();
     // construct message
-    const message: ApiCall & { ext: "wander" } = {
+    const message: ApiCall = {
       type: "chunk",
-      ext: "wander",
+      app: "wander",
       data: chunk,
       callID
     };

--- a/src/contents/api.ts
+++ b/src/contents/api.ts
@@ -34,31 +34,28 @@ container.removeChild(script);
 //
 //    iframeElement.contentWindow.postMessage(...);
 
-window.addEventListener(
-  "message",
-  async ({ data }: MessageEvent<ApiCall & { ext: "wander" }>) => {
-    // verify that the call is meant for the extension
-    if (data.ext !== "wander") {
-      return;
-    }
-
-    // verify that the call has an ID
-    if (!data.callID) {
-      throw new Error("The call does not have a callID");
-    }
-
-    log(LOG_GROUP.API, `${data.type} (${data.callID})...`);
-
-    // send call to the background
-    const res = await sendMessage(
-      data.type === "chunk" ? "chunk" : "api_call",
-      data,
-      "background"
-    );
-
-    log(LOG_GROUP.API, `${data.type} (${data.callID}) =`, res);
-
-    // send the response to the injected script
-    window.postMessage(res, window.location.origin);
+window.addEventListener("message", async ({ data }: MessageEvent<ApiCall>) => {
+  // verify that the call is meant for the extension
+  if (data.app !== "wander") {
+    return;
   }
-);
+
+  // verify that the call has an ID
+  if (!data.callID) {
+    throw new Error("The call does not have a callID");
+  }
+
+  log(LOG_GROUP.API, `${data.type} (${data.callID})...`);
+
+  // send call to the background
+  const res = await sendMessage(
+    data.type === "chunk" ? "chunk" : "api_call",
+    data,
+    "background"
+  );
+
+  log(LOG_GROUP.API, `${data.type} (${data.callID}) =`, res);
+
+  // send the response to the injected script
+  window.postMessage(res, window.location.origin);
+});

--- a/src/utils/embedded/sdk/utils/url/sdk-url.utils.ts
+++ b/src/utils/embedded/sdk/utils/url/sdk-url.utils.ts
@@ -1,10 +1,15 @@
+import { IS_EMBEDDED_APP } from "~utils/embedded/embedded.constants";
+
 export const PARAM_API_KEY = "api-key";
 export const PARAM_ORIGIN = "origin";
 
-const searchParams = new URLSearchParams(document.location.search);
+const searchParams =
+  IS_EMBEDDED_APP && typeof document !== "undefined"
+    ? new URLSearchParams(document.location.search)
+    : null;
 
-export const EMBEDDED_API_KEY = searchParams.get(PARAM_API_KEY);
-export const EMBEDDED_PARENT_ORIGIN = searchParams.get(PARAM_ORIGIN);
+export const EMBEDDED_API_KEY = searchParams?.get(PARAM_API_KEY);
+export const EMBEDDED_PARENT_ORIGIN = searchParams?.get(PARAM_ORIGIN);
 
 // TODO: We still need to validate EMBEDDED_API_KEY & EMBEDDED_PARENT_ORIGIN are allowed (e.g. the developer registered
 // the app and whitelisted the domain(s) correctly). We should probably use a mechanism like Google Search Console where


### PR DESCRIPTION
## Summary  

This PR fixes the extension API popups by checking if `app` is `"wander"` instead of `ext` and correctly importing `EMBEDDED_PARENT_ORIGIN` in the background setup.

## How To Test
- Make sure extension api popups works as expected.