### PR TITLE
fix: update dynamic QR code to be scannable

### DIFF
--- a/src/routes/popup/settings/wallets/[address]/qr.tsx
+++ b/src/routes/popup/settings/wallets/[address]/qr.tsx
@@ -219,7 +219,7 @@ const QRCodeLoop = ({
         position: "relative",
         width: size,
         height: size,
-        backgroundColor: "#000"
+        backgroundColor: "#fff"
       }}
     >
       {frames.map((chunk: any, i: Key) => (
@@ -227,12 +227,7 @@ const QRCodeLoop = ({
           key={i}
           style={{ position: "absolute", opacity: i === frame ? 1 : 0 }}
         >
-          <QRCodeSVG
-            fgColor="#fff"
-            bgColor="transparent"
-            size={size}
-            value={chunk}
-          />
+          <QRCodeSVG fgColor="#000" bgColor="#fff" size={size} value={chunk} />
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary  

This PR improves the QR code to ensure it is easily scannable on Android devices. Seems we were showing the QR code with white color and background with black color and Android was finding difficulty in scanning the QR.

| Before | After |  
|--------|-------|  
| <img width="355" alt="image" src="https://github.com/user-attachments/assets/eb18501c-69a0-41eb-ac7e-b93d4a6aad0f" /> | <img width="352" alt="image" src="https://github.com/user-attachments/assets/a5654376-f715-45d3-a0c2-ce5194713cf9" /> |

## How To Test
- Make sure its scannable in both iOS and Andorid.