### PR TITLE
fix: use nullish coalescing for button label fallback

### DIFF
--- a/wander-embedded-sdk/src/components/button/wander-button.component.ts
+++ b/wander-embedded-sdk/src/components/button/wander-button.component.ts
@@ -151,7 +151,7 @@ export class WanderButton {
       wanderLogo: options.wanderLogo || WanderButton.DEFAULT_CONFIG.wanderLogo,
       dappLogoSrc:
         options.dappLogoSrc || WanderButton.DEFAULT_CONFIG.dappLogoSrc,
-      label: options.label || WanderButton.DEFAULT_CONFIG.label,
+      label: options.label ?? WanderButton.DEFAULT_CONFIG.label,
       balance:
         options.balance === false
           ? false


### PR DESCRIPTION
## Summary

This PR updates button label to use nullish coalescing as `false` is a valid value as well.