### PR TITLE
fix: Prevent instant iframe close on button-triggered open

### DIFF
--- a/wander-embedded-sdk/src/components/button/wander-button.template.ts
+++ b/wander-embedded-sdk/src/components/button/wander-button.template.ts
@@ -34,38 +34,48 @@ export const getWanderButtonTemplateContent = ({
   }
 
   .button {
+    position: relative;
     display: flex;
     align-items: center;
     gap: var(--gapInside);
     outline: none;
     user-select: none;
     cursor: pointer;
-    transition: transform linear 50ms;
-
     min-width: var(--minWidth);
     min-height: var(--minHeight);
     z-index: var(--zIndex);
     padding: var(--padding);
     font: var(--font);
-
-    background: var(--background);
     color: var(--color);
+    background: transparent;
+    border: none;
+    border-radius: var(--borderRadius);
+  }
+
+  .button::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: var(--background);
     border: var(--borderWidth) solid var(--borderColor);
     border-radius: var(--borderRadius);
     box-shadow: var(--boxShadow);
+    z-index: -1;
+    transition: transform linear 50ms;
   }
 
   .button:hover .wanderLogo {
     animation: sail 3s infinite;
   }
 
-  .button:active {
+  .button:active::before {
     transform: scale(0.95);
   }
 
   .wanderLogo {
     width: 32px;
     aspect-ratio: 1;
+    transition: transform linear 50ms;
   }
 
   .label:empty {

--- a/wander-embedded-sdk/src/wander-embedded.ts
+++ b/wander-embedded-sdk/src/wander-embedded.ts
@@ -137,7 +137,7 @@ export class WanderEmbedded {
       {
         clientId: "",
         iframe: {
-          clickOutsideBehavior: "auto"
+          clickOutsideBehavior: true
         },
         button: true
       } satisfies WanderEmbeddedOptions,
@@ -223,18 +223,9 @@ export class WanderEmbedded {
         ? false
         : iframeOptions?.clickOutsideBehavior;
 
-    if (clickOutsideBehavior) {
-      this.backdropRef?.addEventListener("click", () => {
-        const shouldClose =
-          clickOutsideBehavior === true ||
-          (this.backdropRef &&
-            (getComputedStyle(this.backdropRef).backdropFilter !== "none" ||
-              // TODO: This is not a good way to check if it's totally transparent:
-              getComputedStyle(this.backdropRef).background !== "transparent"));
-
-        if (shouldClose) {
-          this.close();
-        }
+    if (clickOutsideBehavior && this.backdropRef) {
+      this.backdropRef.addEventListener("click", () => {
+        this.close();
       });
     }
 

--- a/wander-embedded-sdk/src/wander-embedded.ts
+++ b/wander-embedded-sdk/src/wander-embedded.ts
@@ -166,8 +166,6 @@ export class WanderEmbedded {
   }
 
   private initializeComponents(options: WanderEmbeddedOptions): string {
-    let iframeHostRef: null | HTMLDivElement = null;
-
     const {
       clientId,
       baseURL = WanderEmbedded.DEFAULT_IFRAME_SRC,
@@ -199,7 +197,6 @@ export class WanderEmbedded {
 
       this.backdropRef = elements.backdrop;
       this.iframeRef = elements.iframe;
-      iframeHostRef = elements.host;
 
       // document.body.appendChild(elements.backdrop);
       // document.body.appendChild(elements.iframe);
@@ -227,16 +224,10 @@ export class WanderEmbedded {
         : iframeOptions?.clickOutsideBehavior;
 
     if (clickOutsideBehavior) {
-      iframeHostRef?.addEventListener("click", ({ target }) => {
-        // Do not check if `target` is the backdrop <div> as it might have pointer-events: none.
-
+      this.backdropRef?.addEventListener("click", () => {
         const shouldClose =
           clickOutsideBehavior === true ||
-          (this.iframeRef !== target &&
-            this.buttonHostRef !== target &&
-            !this.iframeRef?.contains(target as HTMLElement) &&
-            !this.buttonHostRef?.contains(target as HTMLElement) &&
-            this.backdropRef &&
+          (this.backdropRef &&
             (getComputedStyle(this.backdropRef).backdropFilter !== "none" ||
               // TODO: This is not a good way to check if it's totally transparent:
               getComputedStyle(this.backdropRef).background !== "transparent"));

--- a/wander-embedded-sdk/src/wander-embedded.ts
+++ b/wander-embedded-sdk/src/wander-embedded.ts
@@ -75,9 +75,6 @@ export class WanderEmbedded {
   // State:
   private shouldOpenAutomatically = true;
 
-  // Timestamp of when open was called
-  private _openClickTimestamp = 0;
-
   /**
    * Indicates whether the wallet interface is currently open/visible
    */
@@ -169,6 +166,8 @@ export class WanderEmbedded {
   }
 
   private initializeComponents(options: WanderEmbeddedOptions): string {
+    let iframeHostRef: null | HTMLDivElement = null;
+
     const {
       clientId,
       baseURL = WanderEmbedded.DEFAULT_IFRAME_SRC,
@@ -200,6 +199,7 @@ export class WanderEmbedded {
 
       this.backdropRef = elements.backdrop;
       this.iframeRef = elements.iframe;
+      iframeHostRef = elements.host;
 
       // document.body.appendChild(elements.backdrop);
       // document.body.appendChild(elements.iframe);
@@ -227,7 +227,7 @@ export class WanderEmbedded {
         : iframeOptions?.clickOutsideBehavior;
 
     if (clickOutsideBehavior) {
-      document.body.addEventListener("click", ({ target }) => {
+      iframeHostRef?.addEventListener("click", ({ target }) => {
         // Do not check if `target` is the backdrop <div> as it might have pointer-events: none.
 
         const shouldClose =
@@ -242,8 +242,6 @@ export class WanderEmbedded {
               getComputedStyle(this.backdropRef).background !== "transparent"));
 
         if (shouldClose) {
-          // If we just opened within the last 50ms, ignore this click
-          if (Date.now() - this._openClickTimestamp < 50) return;
           this.close();
         }
       });
@@ -350,9 +348,6 @@ export class WanderEmbedded {
    * @throws Error if Wander Embedded's iframe and button has been created manually
    */
   public open(): void {
-    // Record the timestamp for when open was called
-    this._openClickTimestamp = Date.now();
-
     if (!this.iframeComponent && !this.buttonComponent) {
       throw new Error(
         "Wander Embedded's iframe and button has been created manually"

--- a/wander-embedded-sdk/src/wander-embedded.ts
+++ b/wander-embedded-sdk/src/wander-embedded.ts
@@ -75,6 +75,9 @@ export class WanderEmbedded {
   // State:
   private shouldOpenAutomatically = true;
 
+  // Timestamp of when open was called
+  private _openClickTimestamp = 0;
+
   /**
    * Indicates whether the wallet interface is currently open/visible
    */
@@ -238,7 +241,11 @@ export class WanderEmbedded {
               // TODO: This is not a good way to check if it's totally transparent:
               getComputedStyle(this.backdropRef).background !== "transparent"));
 
-        if (shouldClose) this.close();
+        if (shouldClose) {
+          // If we just opened within the last 50ms, ignore this click
+          if (Date.now() - this._openClickTimestamp < 50) return;
+          this.close();
+        }
       });
     }
 
@@ -343,6 +350,9 @@ export class WanderEmbedded {
    * @throws Error if Wander Embedded's iframe and button has been created manually
    */
   public open(): void {
+    // Record the timestamp for when open was called
+    this._openClickTimestamp = Date.now();
+
     if (!this.iframeComponent && !this.buttonComponent) {
       throw new Error(
         "Wander Embedded's iframe and button has been created manually"

--- a/wander-embedded-sdk/src/wander-embedded.types.ts
+++ b/wander-embedded-sdk/src/wander-embedded.types.ts
@@ -353,12 +353,6 @@ export function isThemeRecord<T>(
 // Modal (iframe):
 
 /**
- * Behavior when clicking outside the iframe.
- * Controls how the iframe responds when users click outside of it.
- */
-export type WanderEmbeddedClickOutsideBehavior = "auto" | boolean;
-
-/**
  * Configuration options for the iframe.
  * Customizes the appearance and behavior of the Wander Embedded iframe,
  * which displays the wallet UI.
@@ -379,12 +373,11 @@ export interface WanderEmbeddedIframeOptions
   /**
    * Close Wander Embedded when clicking outside of it.
    * Controls the behavior when a user clicks outside the iframe:
-   * - "auto": Will close if `backdropBackground` is not transparent or if `backdropBackdropFilter` is used.
    * - false: Will never close. The user must click the close icon.
-   * - true: Will always close when clicking outside, even if the backdrop is not visible.
+   * - true: Will always close when clicking outside.
    * @default "auto"
    */
-  clickOutsideBehavior?: WanderEmbeddedClickOutsideBehavior;
+  clickOutsideBehavior?: boolean;
 }
 
 /**
@@ -402,7 +395,7 @@ export interface WanderEmbeddedIframeConfig
    * Behavior when clicking outside the iframe.
    * How the component responds to clicks outside its boundaries.
    */
-  clickOutsideBehavior: WanderEmbeddedClickOutsideBehavior;
+  clickOutsideBehavior: boolean;
 }
 
 // Button:


### PR DESCRIPTION
## Summary

This fixes the issue with closing the iframe as soon as its opened from a button calling `instance.open()`.