### PR TITLE
fix: update WalletIcon color

### DIFF
--- a/src/components/embed/ui/organisms/account-selector/AccountSelector.tsx
+++ b/src/components/embed/ui/organisms/account-selector/AccountSelector.tsx
@@ -59,7 +59,7 @@ export function AccountSelector({
         }
         buttonAvatar={
           <Avatar fontColor={"#FFF"}>
-            <WalletIcon style={{ height: 16, width: 16 }} />
+            <WalletIcon color="#FFF" style={{ height: 16, width: 16 }} />
           </Avatar>
         }
         buttonText={
@@ -78,7 +78,10 @@ export function AccountSelector({
                   style={{ padding: "8px 16px" }}
                 >
                   <Avatar fontColor={"#FFF"}>
-                    <WalletIcon style={{ height: 16, width: 16 }} />
+                    <WalletIcon
+                      color="#FFF"
+                      style={{ height: 16, width: 16 }}
+                    />
                   </Avatar>
                   <Text
                     variant="bodyMd"

--- a/src/routes/embedded/wallet/connect/dapp-connect.view.tsx
+++ b/src/routes/embedded/wallet/connect/dapp-connect.view.tsx
@@ -99,7 +99,7 @@ export function EmbeddedConnectAuthRequestView() {
                 style={{ padding: 0, flex: 1 }}
               >
                 <Avatar fontColor="#EBEBF0" backgroundColor="#0D6CE9" size="lg">
-                  <WalletIcon />
+                  <WalletIcon color="#FFF" />
                 </Avatar>
                 <Box isAutoWidth alignment="left" style={{ padding: 0 }}>
                   <Text variant="bodyLg" style={{ color: "#121212" }}>
@@ -212,7 +212,7 @@ export function EmbeddedConnectAuthRequestView() {
                 style={{ paddingInline: "22px", marginTop: "4px" }}
               >
                 <Avatar fontColor="#EBEBF0" backgroundColor="#0D6CE9" size="lg">
-                  <WalletIcon />
+                  <WalletIcon color="#FFF" />
                 </Avatar>
                 <Box isAutoWidth alignment="left">
                   <Text variant="bodyLg" style={{ color: "#121212" }}>


### PR DESCRIPTION
## Summary

This PR updates the `WalletIcon` color to white for Wallet Connect wallets.

## Screenshots
<img src="https://github.com/user-attachments/assets/5511dff7-fa0a-4ad7-b743-ba0a6d194929" height="300" />
<img src="https://github.com/user-attachments/assets/58e7fa24-fc43-4876-aa13-8edefd802c57" height="300" />