### PR TITLE
chore: use --frozen-lockfile option for yarn install in workflow files

### DIFF
--- a/.github/workflows/create-be-build.yml
+++ b/.github/workflows/create-be-build.yml
@@ -20,7 +20,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Create .env file
         run: |
           echo "PLASMO_PUBLIC_TRANSAK_API_KEY=${{ secrets.TRANSAK_API_KEY }}" >> .env

--- a/.github/workflows/submit-beta.yml
+++ b/.github/workflows/submit-beta.yml
@@ -20,7 +20,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Create .env file
         run: |
           echo "PLASMO_PUBLIC_TRANSAK_API_KEY=${{ secrets.TRANSAK_API_KEY }}" >> .env

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -20,7 +20,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Create .env file
         run: |
           echo "PLASMO_PUBLIC_TRANSAK_API_KEY=${{ secrets.TRANSAK_API_KEY }}" >> .env


### PR DESCRIPTION
## Summary

This PR updates the workflow files to use `--frozen-lockfile` with dependency install.