### PR TITLE
fix: improve error handling in email check

### DIFF
--- a/src/components/embed/ui/atoms/button/Button.types.ts
+++ b/src/components/embed/ui/atoms/button/Button.types.ts
@@ -82,4 +82,9 @@ export type ButtonBaseProps = {
    * Optional prop for the style of the ButtonBase component
    */
   style?: React.CSSProperties;
+
+  /**
+   * Optional prop for the tabIndex of the ButtonBase component
+   */
+  tabIndex?: number;
 };

--- a/src/components/embed/ui/atoms/text-input/TextInput.tsx
+++ b/src/components/embed/ui/atoms/text-input/TextInput.tsx
@@ -33,7 +33,8 @@ const TextInput = forwardRef<HTMLInputElement, TextInputBaseProps>(
             className={clsx(styles["button"], buttonLabel ? styles["button__text"] : styles["button__icon"], className)}
             onClick={buttonOnClick}
             isLoading={isLoading}
-            isDisabled={isDisabled}>
+            isDisabled={isDisabled}
+            tabIndex={-1}>
             {buttonIcon || buttonLabel}
           </Button>
         )}

--- a/src/routes/embedded/auth/auth-email-signup/auth-email-signin.view.tsx
+++ b/src/routes/embedded/auth/auth-email-signup/auth-email-signin.view.tsx
@@ -43,6 +43,9 @@ export function AuthEmailSigninEmbeddedView() {
 
       if (error) {
         toast.error(error.message);
+        if (error.code === "email_not_confirmed") {
+          navigate(EmbeddedPaths.AuthEmailVerify);
+        }
         return;
       }
 

--- a/src/routes/embedded/auth/auth-email-signup/auth-email-signup.view.tsx
+++ b/src/routes/embedded/auth/auth-email-signup/auth-email-signup.view.tsx
@@ -102,8 +102,13 @@ export function AuthEmailSignupEmbeddedView() {
           <TextInput
             type={passwordType}
             {...validPasswordInput.bindings}
-            placeholder="Enter your password"
+            placeholder="Confirm your password"
             isDisabled={areButtonsDisabled}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                handleEmailSignup();
+              }
+            }}
           />
 
           <PasswordMatch matches={matches} />

--- a/src/routes/embedded/auth/auth-email-signup/auth-email-verify.view.tsx
+++ b/src/routes/embedded/auth/auth-email-signup/auth-email-verify.view.tsx
@@ -69,7 +69,6 @@ export function AuthEmailVerifyEmbeddedView() {
         });
 
         if (error) {
-          console.log(error.code);
           toast.error(error.message);
           return;
         }

--- a/src/routes/embedded/auth/auth-email-signup/auth-email-verify.view.tsx
+++ b/src/routes/embedded/auth/auth-email-signup/auth-email-verify.view.tsx
@@ -6,64 +6,86 @@ import { getSupabaseClient } from "~utils/embedded/embedded.utils";
 import { useLocation } from "~wallets/router/router.utils";
 import { Flex } from "~components/common/Flex";
 import { EmbeddedPaths } from "~wallets/router/iframe/iframe.routes";
+import { PersistentStorage, useStorage } from "~utils/storage";
+
+const COOLDOWN_DURATION = 60; // seconds
 
 export function AuthEmailVerifyEmbeddedView() {
   const { navigate } = useLocation();
   const { authEmail } = useEmbedded();
   const [isResending, setIsResending] = useState(false);
-  const [cooldownTime, setCooldownTime] = useState(60);
+  const [cooldownTime, setCooldownTime] = useState(0);
   const [canResend, setCanResend] = useState(false);
 
+  const [verifyEmailResentTimestamp, setVerifyEmailResentTimestamp] = useStorage<number>(
+    { key: "sb-verify-email-resent-timestamp", instance: PersistentStorage },
+    (v) => (v === undefined ? Date.now() : v),
+  );
+
   useEffect(() => {
-    let timer: number | undefined;
+    if (!verifyEmailResentTimestamp) return;
 
-    if (cooldownTime > 0) {
-      timer = window.setInterval(() => {
-        setCooldownTime((prevTime) => {
-          const newTime = prevTime - 1;
-          if (newTime <= 0) {
-            setCanResend(true);
-            clearInterval(timer);
-            return 0;
-          }
-          return newTime;
-        });
-      }, 1000);
-    } else {
+    const now = Date.now();
+    const elapsedTime = Math.floor((now - verifyEmailResentTimestamp) / 1000);
+    const initialCooldown = Math.max(0, COOLDOWN_DURATION - elapsedTime);
+
+    if (initialCooldown === 0) {
       setCanResend(true);
+      setCooldownTime(0);
+      return;
     }
 
-    return () => {
-      if (timer) clearInterval(timer);
-    };
-  }, [cooldownTime]);
+    setCooldownTime(initialCooldown);
+    setCanResend(false);
 
-  const handleResendEmail = useCallback(async () => {
-    if (!authEmail || !canResend) return;
-
-    try {
-      setIsResending(true);
-      const supabase = await getSupabaseClient();
-
-      const { error } = await supabase.auth.resend({
-        type: "signup",
-        email: authEmail,
+    const timer = window.setInterval(() => {
+      setCooldownTime((prevTime) => {
+        if (prevTime <= 1) {
+          clearInterval(timer);
+          setCanResend(true);
+          return 0;
+        }
+        return prevTime - 1;
       });
+    }, 1000);
 
-      if (error) {
-        toast.error(error.message);
-        return;
+    return () => clearInterval(timer);
+  }, [verifyEmailResentTimestamp]);
+
+  const handleResendEmail = useCallback(
+    async (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (!authEmail || !canResend) return;
+
+      try {
+        setIsResending(true);
+        const supabase = await getSupabaseClient();
+
+        const { error } = await supabase.auth.resend({
+          type: "signup",
+          email: authEmail,
+        });
+
+        if (error) {
+          console.log(error.code);
+          toast.error(error.message);
+          return;
+        }
+
+        toast.success("Verification email resent successfully");
+        setVerifyEmailResentTimestamp(Date.now());
+        setCanResend(false);
+        setCooldownTime(COOLDOWN_DURATION);
+      } catch (error) {
+        toast.error("Error sending verification email");
+      } finally {
+        setIsResending(false);
       }
-
-      toast.success("Verification email resent successfully");
-      setCanResend(false);
-      setCooldownTime(60);
-    } catch (error) {
-      toast.error("Error sending verification email");
-    } finally {
-      setIsResending(false);
-    }
-  }, [authEmail, canResend]);
+    },
+    [authEmail, canResend, setVerifyEmailResentTimestamp],
+  );
 
   return (
     <Card

--- a/src/routes/embedded/auth/auth/auth.view.tsx
+++ b/src/routes/embedded/auth/auth/auth.view.tsx
@@ -91,7 +91,7 @@ export function AuthEmbeddedView() {
       });
 
       if (error) {
-        toast.error("Error checking email");
+        toast.error(error.message || "Error checking email");
         return;
       }
 


### PR DESCRIPTION
## Summary

This PR improves the signup flow by:

* Displaying an error message if `user_exists_by_email` returns an error
* Fixing the tab order issue where it required two tabs to focus on the "Confirm your password" field
* Adding an `onKeyDown` handler to allow submitting the form via the Enter key in the password field

Related PR: https://github.com/wanderwallet/embed-api/pull/35