### PR TITLE
fix: revert nanoid to uuid in keystone

### DIFF
--- a/src/wallets/hardware/keystone.ts
+++ b/src/wallets/hardware/keystone.ts
@@ -11,7 +11,6 @@ import Arweave from "arweave";
 import { defaultGateway } from "~gateways/gateway";
 import { Signer } from "@dha-team/arbundles";
 import { EventEmitter } from "events";
-import { nanoid } from "nanoid";
 import { v4 as uuid } from "uuid";
 
 export interface KeystoneInteraction {
@@ -128,7 +127,7 @@ export async function messageToUR(message: Uint8Array, xfp: string, options: Sig
   const messageBuff = Buffer.from(message);
 
   // request ID
-  const requestID = nanoid();
+  const requestID = uuid();
 
   // construct request
   const signRequest = ArweaveSignRequest.constructArweaveRequest(

--- a/src/wallets/hardware/keystone.ts
+++ b/src/wallets/hardware/keystone.ts
@@ -12,6 +12,7 @@ import { defaultGateway } from "~gateways/gateway";
 import { Signer } from "@dha-team/arbundles";
 import { EventEmitter } from "events";
 import { nanoid } from "nanoid";
+import { v4 as uuid } from "uuid";
 
 export interface KeystoneInteraction {
   display(data: UR);
@@ -109,7 +110,7 @@ export async function transactionToUR(
   const txBuff = Buffer.from(JSON.stringify(transaction.toJSON()), "utf-8");
 
   // request ID
-  const requestID = nanoid();
+  const requestID = uuid();
 
   // construct request
   const signRequest = ArweaveSignRequest.constructArweaveRequest(


### PR DESCRIPTION
Reverted `nanoid` back to `uuid` in Keystone. Keystong QR generator was unable to generate QR codes without the structure provided by `uuid v4`