### PR TITLE
feat: ARC-1400: Wallet activation and rotation retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "copy-to-clipboard": "^3.3.2",
     "currency-symbol-map": "^5.1.0",
     "dayjs": "^1.11.6",
-    "embed-api": "https://github.com/wanderwallet/embed-api#feat/arc-1400-fix-challenges",
+    "embed-api": "https://github.com/wanderwallet/embed-api#ec23a9586004c3742a3edb512bf753786d9dcdf5",
     "framer-motion": "^11.11.7",
     "human-crypto-keys": "^0.1.4",
     "js-confetti": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "copy-to-clipboard": "^3.3.2",
     "currency-symbol-map": "^5.1.0",
     "dayjs": "^1.11.6",
-    "embed-api": "https://github.com/wanderwallet/embed-api#5dbcb8722252cb6a0a7ca6092d93b18d4ac071d0",
+    "embed-api": "https://github.com/wanderwallet/embed-api#feat/arc-1400-fix-challenges",
     "framer-motion": "^11.11.7",
     "human-crypto-keys": "^0.1.4",
     "js-confetti": "^0.12.0",

--- a/src/iframe/storage/unpartitioned-storage/local-storage.ts
+++ b/src/iframe/storage/unpartitioned-storage/local-storage.ts
@@ -1,3 +1,7 @@
+import {
+  getUnpartitionedStateStatus,
+  HAS_SIMPLE_STORAGE_API,
+} from "~iframe/storage/unpartitioned-storage/unpartitioned-storage.utils";
 import { EnhancedStorage } from "./unpartitioned-storage";
 
 export class LocalStorage extends EnhancedStorage {
@@ -8,10 +12,18 @@ export class LocalStorage extends EnhancedStorage {
   }
 
   static async getInstance(): Promise<LocalStorage> {
-    if (!this.instance) {
-      this.instance = new LocalStorage();
-      await this.instance.requestStorageAccess();
+    this.instance = this.instance ?? new LocalStorage();
+
+    await this.instance.requestStorageAccess();
+
+    if (this.instance.storage === localStorage && getUnpartitionedStateStatus() === "supported") {
+      if (process.env.NODE_ENV === "development") {
+        throw new Error("Using partitioned state in a browser with unpartitioned state support.");
+      } else {
+        console.warn("Using partitioned state in a browser with unpartitioned state support.");
+      }
     }
+
     return this.instance;
   }
 }

--- a/src/iframe/storage/unpartitioned-storage/unpartitioned-storage.ts
+++ b/src/iframe/storage/unpartitioned-storage/unpartitioned-storage.ts
@@ -386,7 +386,7 @@ export class StorageManager {
 }
 
 export class EnhancedStorage implements Storage {
-  protected storage: Storage;
+  public storage: Storage;
 
   public storageType: StorageType;
 

--- a/src/routes/embedded/account/change-password/account-change-password.view.tsx
+++ b/src/routes/embedded/account/change-password/account-change-password.view.tsx
@@ -21,6 +21,7 @@ import {
 import { useCooldownCallback } from "~utils/react/useCooldownCallback";
 import { Flex } from "~components/common/Flex";
 import { sleep } from "~utils/promises/sleep";
+import type { SupabaseUserMetadata } from "embed-api";
 
 export function AccountChangePasswordEmbeddedView() {
   const { navigate } = useLocation();
@@ -162,10 +163,10 @@ export function AccountChangePasswordEmbeddedView() {
           nonce,
           data: user_metadata.hasPassword
             ? undefined
-            : {
+            : ({
                 ...user_metadata,
                 hasPassword: true,
-              },
+              } satisfies SupabaseUserMetadata),
         });
 
         if (error) {

--- a/src/routes/embedded/auth/auth-email-sign-up/auth-email-sign-up.view.tsx
+++ b/src/routes/embedded/auth/auth-email-sign-up/auth-email-sign-up.view.tsx
@@ -15,6 +15,7 @@ import { EditIcon } from "@iconicicons/react";
 import { getFriendlyAuthErrorMessage, MIN_SUPABASE_PASSWORD_LENGTH } from "~utils/authentication/authentication.utils";
 import { StorageKeys } from "~utils/storage/storage.constants";
 import browser from "~iframe/browser";
+import type { SupabaseUserMetadata } from "embed-api";
 
 export function AuthEmailSignUpEmbeddedView() {
   const { navigate } = useLocation();
@@ -87,7 +88,7 @@ export function AuthEmailSignUpEmbeddedView() {
           options: {
             data: {
               hasPassword: true,
-            },
+            } satisfies SupabaseUserMetadata,
           },
         });
 

--- a/src/utils/authentication/authentication.service.ts
+++ b/src/utils/authentication/authentication.service.ts
@@ -16,6 +16,7 @@ import {
   OAuthErrorCode,
 } from "~utils/authentication/authentication.utils";
 import type { OAuthResultMessage, SupabaseProvider } from "~utils/authentication/authentication.types";
+import type { SupabaseUserMetadata } from "embed-api";
 
 const SUPABASE_PROVIDER_BY_OAUTH_PROVIDER_TYPE: Record<OAutProviderType, SupabaseProvider | null> = {
   GOOGLE: "google",
@@ -171,13 +172,13 @@ async function signInWithPassword(authParams: AuthSignInWithPasswordParams) {
 
   if (error) throw error;
 
-  if (!data.user.user_metadata.hasPassword) {
+  if (!(data.user.user_metadata as SupabaseUserMetadata).hasPassword) {
     // No need to handle error, we can re-attempt this lazily on the next sign in:
     await supabase.auth.updateUser({
       data: {
         ...data.user.user_metadata,
         hasPassword: true,
-      },
+      } satisfies SupabaseUserMetadata,
     });
   }
 
@@ -194,13 +195,13 @@ async function verifyOtp(authParams: AuthVerifyOtpParams) {
 
   if (error) throw error;
 
-  if (!data.user.user_metadata.hasPassword) {
+  if (!(data.user.user_metadata as SupabaseUserMetadata).hasPassword) {
     // No need to handle error, we can re-attempt this lazily on the next sign in:
     await supabase.auth.updateUser({
       data: {
         ...data.user.user_metadata,
         hasPassword: true,
-      },
+      } satisfies SupabaseUserMetadata,
     });
   }
 

--- a/src/utils/authentication/authentication.types.ts
+++ b/src/utils/authentication/authentication.types.ts
@@ -1,4 +1,4 @@
-import type { DbSession } from "embed-api";
+import type { DbSession, SupabaseAuthError } from "embed-api";
 import type { JwtPayload } from "jwt-decode";
 import type { Provider, Session } from "@supabase/supabase-js";
 import type { OAuthErrorCode } from "~utils/authentication/authentication.utils";
@@ -50,14 +50,7 @@ export function isOAuthError(error: unknown): error is OAuthError {
   );
 }
 
-// TODO: Import from Supabase (should be exported from embed-api):
-
-export interface AuthError extends Error {
-  code: string;
-  status: number;
-}
-
-export function isAuthError(error: unknown): error is AuthError {
+export function isSupabaseAuthError(error: unknown): error is SupabaseAuthError {
   return (
     error instanceof Error &&
     "code" in error &&

--- a/src/utils/authentication/authentication.utils.ts
+++ b/src/utils/authentication/authentication.utils.ts
@@ -1,7 +1,7 @@
+import type { SupabaseAuthError } from "embed-api";
 import {
-  isAuthError,
   isOAuthError,
-  type AuthError,
+  isSupabaseAuthError,
   type OAuthError,
   type OAuthErrorMessage,
   type OAuthResultMessage,
@@ -50,7 +50,7 @@ const AUTH_ERRORS_BY_CODE: Record<string | OAuthErrorCode, string> = {
 };
 
 export function getFriendlyAuthErrorMessage(
-  error: Error | AuthError | OAuthError,
+  error: Error | SupabaseAuthError | OAuthError,
   defaultErrorMessage?: string,
 ): string {
   if (process.env.NODE_ENV === "development") console.error("getFriendlyAuthErrorMessage() =", error);
@@ -61,7 +61,7 @@ export function getFriendlyAuthErrorMessage(
   if (isOAuthError(error)) {
     errorCode = error.cause.errorCode;
     errorDescription = error.cause.errorDescription;
-  } else if (isAuthError(error)) {
+  } else if (isSupabaseAuthError(error)) {
     errorCode = error.code || `${error.status}` || error.name;
     errorDescription = error.message;
   } else {

--- a/src/utils/embedded/device-nonce/device-nonce.utils.ts
+++ b/src/utils/embedded/device-nonce/device-nonce.utils.ts
@@ -36,6 +36,8 @@ export function generateDeviceNonce(): DeviceNonce {
 }
 
 export async function storeDeviceNonce(deviceNonce: DeviceNonce): Promise<DeviceNonce> {
+  console.trace("Updating deviceNonce =", deviceNonce);
+
   log(LOG_GROUP.WALLET_GENERATION, "storeDeviceNonce()");
 
   setDeviceNonceHeader(deviceNonce);
@@ -60,6 +62,8 @@ export async function initializeDeviceNonce(): Promise<DeviceNonce> {
 
   return _deviceNonce;
 }
+
+// TODO: Consider always reading it from storage...
 
 export async function getDeviceNonce(): Promise<DeviceNonce> {
   await initializeDeviceNonce();

--- a/src/utils/embedded/device-nonce/device-nonce.utils.ts
+++ b/src/utils/embedded/device-nonce/device-nonce.utils.ts
@@ -13,6 +13,7 @@ let _deviceNonce: DeviceNonce | null = null;
 
 export async function loadDeviceNonce(): Promise<DeviceNonce | null> {
   const storage = await LocalStorage.getInstance();
+
   let deviceNonce = storage.getItem(DEVICE_NONCE_KEY) || null;
 
   if (
@@ -36,13 +37,12 @@ export function generateDeviceNonce(): DeviceNonce {
 }
 
 export async function storeDeviceNonce(deviceNonce: DeviceNonce): Promise<DeviceNonce> {
-  console.trace("Updating deviceNonce =", deviceNonce);
-
   log(LOG_GROUP.WALLET_GENERATION, "storeDeviceNonce()");
 
   setDeviceNonceHeader(deviceNonce);
 
   const storage = await LocalStorage.getInstance();
+
   storage.setItem(DEVICE_NONCE_KEY, deviceNonce);
 
   return (_deviceNonce = deviceNonce);
@@ -52,6 +52,7 @@ export async function initializeDeviceNonce(): Promise<DeviceNonce> {
   if (_deviceNonce) return _deviceNonce;
 
   const loadedNonce = await loadDeviceNonce();
+
   _deviceNonce = loadedNonce || generateDeviceNonce();
 
   setDeviceNonceHeader(_deviceNonce);
@@ -73,6 +74,7 @@ export async function getDeviceNonce(): Promise<DeviceNonce> {
   }
 
   const storage = await LocalStorage.getInstance();
+
   let storedDeviceNonce = storage.getItem(DEVICE_NONCE_KEY) || null;
 
   if (storedDeviceNonce === _deviceNonce) return _deviceNonce;

--- a/src/utils/embedded/embedded.provider.tsx
+++ b/src/utils/embedded/embedded.provider.tsx
@@ -1135,6 +1135,9 @@ export function EmbeddedProvider({ children }: EmbeddedProviderProps) {
       let jwk: JWKInterface | null = null;
 
       try {
+        // TODO: Add some extra logic here to wait if there are other tabs activating a wallet at the same time.
+        // Do it by checking both a stored flag as well as by querying the backend (subscribe?).
+
         const fetchFirstAvailableAuthShareReturn = await withRetry(() =>
           WalletService.fetchFirstAvailableAuthShare(wallets, session, userId),
         );

--- a/src/utils/embedded/embedded.provider.tsx
+++ b/src/utils/embedded/embedded.provider.tsx
@@ -34,6 +34,7 @@ import {
   WalletSourceType,
   type DbSession,
   type RecoverableAccount,
+  type SupabaseUser,
 } from "embed-api";
 import { AuthenticationService } from "~utils/authentication/authentication.service";
 import { EMBEDDED_FEATURE_FLAGS, EMBEDDED_SDK_AUTH_STATUS_BY_AUTH_STATUS } from "~utils/embedded/embedded.constants";
@@ -1199,7 +1200,7 @@ export function EmbeddedProvider({ children }: EmbeddedProviderProps) {
       if (!isInitialAuthEventDispatched) {
         isInitialAuthEventDispatched = true;
 
-        const cachedUser = session?.user;
+        const cachedUser = session?.user as SupabaseUser;
 
         // Send the initial state for the SDK button ASAP if there's cached data. Otherwise, the initial state will be
         // sent by the `useEffect` above that sends `"embedded_auth"` events too.
@@ -1221,7 +1222,7 @@ export function EmbeddedProvider({ children }: EmbeddedProviderProps) {
       }
 
       const accessToken = session?.access_token ?? null;
-      const user = session?.user ?? null;
+      const user = (session?.user as SupabaseUser) ?? null;
       const authProviderType = getAuthProviderTypeFromSupabaseUser(user);
 
       if (process.env.NODE_ENV === "development" && user && authProviderType === null) {

--- a/src/utils/embedded/embedded.provider.tsx
+++ b/src/utils/embedded/embedded.provider.tsx
@@ -67,6 +67,7 @@ import {
 import { useAsyncEffect } from "~utils/react/useAsyncEffect";
 import { isomorphicOnMessage } from "~isomorphic-messaging";
 import { useTheme } from "~components/embed/contexts/ThemeContext";
+import { withRetry } from "~utils/promises/retry";
 
 export type AuthStatusCopy = AuthStatus;
 
@@ -1120,7 +1121,7 @@ export function EmbeddedProvider({ children }: EmbeddedProviderProps) {
       wallets,
     }));
 
-    let authStatus = "noAuth" as AuthStatus;
+    let authStatus: AuthStatus = wallets.length === 0 ? "noWallets" : "noShares";
 
     if (wallets.length > 0) {
       // TODO: The wallet activation can be deferred until the wallet is going to be used:
@@ -1131,63 +1132,29 @@ export function EmbeddedProvider({ children }: EmbeddedProviderProps) {
       // TODO: Create an issue for the new storage needs (e.g. expiration). Note that for wallets
       // that haven't been backup up, we must never delete a share without notifying the user.
 
-      // TODO: Add try-catch. If the initialization process fails, show an error...
+      let jwk: JWKInterface | null = null;
 
-      // TODO: Move rotation logic to service and retry. Consider listening for the challenge to be resolved to get a new one. Subscribe to activation from other tabs?
+      try {
+        const fetchFirstAvailableAuthShareReturn = await withRetry(() =>
+          WalletService.fetchFirstAvailableAuthShare(wallets, session, userId),
+        );
 
-      const { activatedWallet, rotationChallenge } = await WalletService.fetchFirstAvailableAuthShare(
-        wallets,
-        session,
-        userId,
-      );
+        const { activatedWallet } = fetchFirstAvailableAuthShareReturn;
+        jwk = fetchFirstAvailableAuthShareReturn.jwk;
 
-      if (activatedWallet) {
-        const { id: walletId, address: walletAddress } = activatedWallet;
-
-        const jwk = await WalletUtils.generateWalletJWKFromShares(walletAddress, [
-          activatedWallet.authShare,
-          activatedWallet.deviceShare,
-        ]);
-
-        if (rotationChallenge) {
-          const { authShare, deviceShare } = await WalletUtils.generateWalletWorkShares(jwk);
-
-          activatedWallet.authShare = authShare;
-          activatedWallet.deviceShare = deviceShare;
-
-          const { shareHash: deviceShareHash, sharePublicKey: deviceSharePublicKey } =
-            await WalletUtils.generateShareHashAndPublicKey(deviceShare);
-
-          const challengeSolution = await ChallengeClientV1.solveChallenge({
-            challenge: rotationChallenge,
-            session,
-            shareHash: null,
-            jwk,
-          });
-
-          await WalletService.rotateAuthShare({
-            walletId,
-            authShare,
-            deviceShareHash,
-            deviceSharePublicKey,
-            challengeSolution,
-          });
-        }
-
-        await WalletUtils.storeDeviceShare(activatedWallet, userId);
-
-        try {
+        if (jwk && activatedWallet) {
+          await WalletUtils.storeDeviceShare(activatedWallet, userId);
           await addWallet(jwk, activatedWallet);
-        } finally {
-          freeDecryptedWallet(jwk);
-        }
 
-        authStatus = "unlocked";
-      } else {
-        authStatus = "noShares";
+          authStatus = "unlocked";
+        }
+      } catch (err) {
+        // All attempts failed, or activation suceded but some of the code afer that threw an error.
+
+        console.warn("Failed to activate wallet:", err);
+      } finally {
+        if (jwk) freeDecryptedWallet(jwk);
       }
-    } else {
-      authStatus = "noWallets";
     }
 
     setEmbeddedContextAuth((prevEmbeddedContextAuth) => ({

--- a/src/utils/wallets/wallets.service.ts
+++ b/src/utils/wallets/wallets.service.ts
@@ -1,11 +1,14 @@
-import { ChallengeClientV1, type DbChallenge, type DbSession } from "embed-api";
+import { ChallengeClientV1, type DbSession } from "embed-api";
 import type { Wallet, WalletActivationStatus } from "~utils/embedded/embedded.types";
 import { trpcVanilla } from "~utils/embedded/embedded.utils";
 import { isTRPCClientError } from "~utils/embedded/utils/trpc/trpc.utils";
 import { WalletUtils } from "~utils/wallets/wallets.utils";
 import { getWallets, removeWallet } from "~wallets";
+import type { JWKInterface } from "arweave/web/lib/wallet";
+import { freeDecryptedWallet } from "~wallets/encryption";
 
 // TODO: Consider getting `userId` automatically
+
 async function fetchWallets(userId: string): Promise<Wallet[]> {
   const deviceShares = await WalletUtils.getDeviceSharesForUser(userId);
   const unusedDeviceSharesWalletIDs = new Set(Object.keys(deviceShares));
@@ -114,8 +117,8 @@ async function registerWalletExport(walletExportData: RegisterWalletExportData) 
 }
 
 export interface FetchFirstAvailableAuthShareReturn {
+  jwk: null | JWKInterface;
   activatedWallet: null | Wallet;
-  rotationChallenge?: DbChallenge;
 }
 
 async function fetchFirstAvailableAuthShare(
@@ -123,15 +126,12 @@ async function fetchFirstAvailableAuthShare(
   session: DbSession,
   userId: string,
 ): Promise<FetchFirstAvailableAuthShareReturn> {
-  return new Promise(async (resolve) => {
-    for (const wallet of wallets) {
-      const { id: walletId, deviceShare } = wallet;
+  return new Promise<FetchFirstAvailableAuthShareReturn>(async (resolve, reject) => {
+    let jwk: JWKInterface | null = null;
+    let error: Error | null = null;
 
-      if (deviceShare === null) {
-        // If the device share is not present in the device, skip, otherwise
-        // `WalletUtils.generateShareHashAndPrivateKey()` will throw an error.
-        continue;
-      }
+    for (const wallet of wallets) {
+      const { id: walletId, address: walletAddress, deviceShare } = wallet;
 
       try {
         if (deviceShare === null) {
@@ -177,27 +177,71 @@ async function fetchFirstAvailableAuthShare(
         // TODO: Better with zk: instead of hashes or use a challenge here?
 
         if (authShare) {
+          // In case there was a previous one already in memory:
+          if (jwk) freeDecryptedWallet(jwk);
+
+          jwk = await WalletUtils.generateWalletJWKFromShares(walletAddress, [authShare, deviceShare]);
+
           const activatedWallet: Wallet = {
             ...wallet,
             activationStatus: "active",
             authShare,
           };
 
+          if (rotationChallenge) {
+            const { authShare, deviceShare } = await WalletUtils.generateWalletWorkShares(jwk);
+
+            // Replace authShare and deviceShare with the new ones:
+            activatedWallet.authShare = authShare;
+            activatedWallet.deviceShare = deviceShare;
+
+            const { shareHash: deviceShareHash, sharePublicKey: deviceSharePublicKey } =
+              await WalletUtils.generateShareHashAndPublicKey(deviceShare);
+
+            const challengeSolution = await ChallengeClientV1.solveChallenge({
+              challenge: rotationChallenge,
+              session,
+              shareHash: null,
+              jwk,
+            });
+
+            await rotateAuthShare({
+              walletId,
+              authShare,
+              deviceShareHash,
+              deviceSharePublicKey,
+              challengeSolution,
+            });
+          }
+
           resolve({
+            jwk,
             activatedWallet,
-            rotationChallenge,
-          } satisfies FetchFirstAvailableAuthShareReturn);
+          });
 
           return;
         }
       } catch (err) {
+        if (jwk) freeDecryptedWallet(jwk);
+
+        error = err;
+
         console.warn(`Unexpected wallet activation error (walletId = "${walletId}") =`, err);
       }
     }
 
-    resolve({
-      activatedWallet: null,
-    } satisfies FetchFirstAvailableAuthShareReturn);
+    // Once we've checked all wallets and tried to activate the ones that had a deviceShare, we:
+    // - Rethrow the last error, if the activation (or rotation) of any of them failed.
+    // - Resolve normally with null values, if none of them had a deviceShare.
+
+    if (error) {
+      reject(error);
+    } else {
+      resolve({
+        jwk: null,
+        activatedWallet: null,
+      });
+    }
   });
 }
 

--- a/src/utils/wallets/wallets.service.ts
+++ b/src/utils/wallets/wallets.service.ts
@@ -160,6 +160,9 @@ async function fetchFirstAvailableAuthShare(
             challengeSolution,
           })
           .catch(async (err: unknown) => {
+            // We do not retry 404 errors as that means the authShare is no longer in the DB. Any other error, we retry, so we re-throw it here instead of
+            // resolving normally.
+
             if (!isTRPCClientError(err) || err.data.httpStatus !== 404) throw err;
 
             console.warn(

--- a/src/utils/wallets/wallets.service.ts
+++ b/src/utils/wallets/wallets.service.ts
@@ -1,4 +1,4 @@
-import { ChallengeClientV1, type DbSession } from "embed-api";
+import { ChallengeClientV1, ErrorMessages, type DbSession } from "embed-api";
 import type { Wallet, WalletActivationStatus } from "~utils/embedded/embedded.types";
 import { trpcVanilla } from "~utils/embedded/embedded.utils";
 import { isTRPCClientError } from "~utils/embedded/utils/trpc/trpc.utils";
@@ -154,28 +154,10 @@ async function fetchFirstAvailableAuthShare(
           jwk: deviceSharePrivateKeyJWK,
         });
 
-        const { authShare, rotationChallenge } = await trpcVanilla.activateWallet
-          .mutate({
-            walletId,
-            challengeSolution,
-          })
-          .catch(async (err: unknown) => {
-            // We do not retry 404 errors as that means the authShare is no longer in the DB. Any other error, we retry, so we re-throw it here instead of
-            // resolving normally.
-
-            if (!isTRPCClientError(err) || err.data.httpStatus !== 404) throw err;
-
-            console.warn(
-              `The corresponding auth share for the device share stored for walletId = ${walletId} was not found. Deleting device share from this device...`,
-            );
-
-            await WalletUtils.removeDeviceShare(deviceShare, userId);
-
-            return {
-              authShare: null,
-              rotationChallenge: null,
-            };
-          });
+        const { authShare, rotationChallenge } = await trpcVanilla.activateWallet.mutate({
+          walletId,
+          challengeSolution,
+        });
 
         // TODO: Better with zk: instead of hashes or use a challenge here?
 
@@ -227,9 +209,27 @@ async function fetchFirstAvailableAuthShare(
       } catch (err) {
         if (jwk) freeDecryptedWallet(jwk);
 
-        error = err;
+        if (
+          isTRPCClientError(err) &&
+          err.data.httpStatus === 404 &&
+          ([ErrorMessages.WORK_SHARE_INVALIDATED, ErrorMessages.WORK_SHARE_NOT_FOUND] as string[]).includes(err.message)
+        ) {
+          // If we get one of these errors, we know we've tried to get an auth share that is already gone, so we can
+          // delete its corresponding device share:
 
-        console.warn(`Unexpected wallet activation error (walletId = "${walletId}") =`, err);
+          console.warn(
+            `The corresponding auth share for the device share stored for walletId = ${walletId} was not found. Deleting device share from this device...`,
+          );
+
+          await WalletUtils.removeDeviceShare(deviceShare, userId);
+        } else {
+          // Otherwise, for any other type of error, we handle it normally. Meaning, we'll try to repeat this same
+          // activation and, if all attempts fail, we'll reject this Promise with this error.
+
+          error = err;
+
+          console.warn(`Unexpected wallet activation error (walletId = "${walletId}") =`, err);
+        }
       }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6486,9 +6486,9 @@ elliptic@6.6.1, elliptic@^6.5.3, elliptic@^6.5.5, elliptic@^6.5.7:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-"embed-api@https://github.com/wanderwallet/embed-api#5dbcb8722252cb6a0a7ca6092d93b18d4ac071d0":
+"embed-api@https://github.com/wanderwallet/embed-api#feat/arc-1400-fix-challenges":
   version "0.1.0"
-  resolved "https://github.com/wanderwallet/embed-api#5dbcb8722252cb6a0a7ca6092d93b18d4ac071d0"
+  resolved "https://github.com/wanderwallet/embed-api#8589514f0f54f439ab10d5606ca7bbb76904c243"
   dependencies:
     "@prisma/client" "6.7.0"
     "@supabase/ssr" "^0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6486,9 +6486,9 @@ elliptic@6.6.1, elliptic@^6.5.3, elliptic@^6.5.5, elliptic@^6.5.7:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
-"embed-api@https://github.com/wanderwallet/embed-api#feat/arc-1400-fix-challenges":
+"embed-api@https://github.com/wanderwallet/embed-api#ec23a9586004c3742a3edb512bf753786d9dcdf5":
   version "0.1.0"
-  resolved "https://github.com/wanderwallet/embed-api#8589514f0f54f439ab10d5606ca7bbb76904c243"
+  resolved "https://github.com/wanderwallet/embed-api#ec23a9586004c3742a3edb512bf753786d9dcdf5"
   dependencies:
     "@prisma/client" "6.7.0"
     "@supabase/ssr" "^0.6.1"


### PR DESCRIPTION
This PR also fixes an issue when requesting unpartitioned state, that was causing some values to be read/written into the regular `localStorage` instead. Additionally:

- Re-attempt wallet activation 3 times. Closes https://communitylabs.atlassian.net/browse/ARC-1327
- Fix wallet activation/rotation issues. Closes https://communitylabs.atlassian.net/browse/ARC-1400
- Fix inability to reactive a wallet after clearing browser data. Closes https://communitylabs.atlassian.net/browse/ARC-1263

Backend PR: https://github.com/wanderwallet/embed-api/pull/39 (closes https://communitylabs.atlassian.net/browse/ARC-1406, even thought the root cause was still the issues described above).