### PR TITLE
feat: ARC-1332: Allow creating a new wallet if recovery methods do not exist or are lost

### DIFF
--- a/src/routes/embedded/auth/add-wallet/auth-add-wallet.view.tsx
+++ b/src/routes/embedded/auth/add-wallet/auth-add-wallet.view.tsx
@@ -5,9 +5,11 @@ import type { WalletSourceType } from "embed-api";
 import { OnboardingCard } from "~components/embed/ui/molecules/card/onboarding-card/OnboardingCard";
 import { signOut } from "~utils/embedded/embedded.utils";
 import { QrCode02 } from "@untitled-ui/icons-react";
+import { navigate } from "wouter/use-hash-location";
+import { EmbeddedPaths } from "~wallets/router/iframe/iframe.routes";
 
 export function AuthAddWalletEmbeddedView() {
-  const { generateTempWallet, registerWallet } = useEmbedded();
+  const { generateTempWallet, registerWallet, authStatus } = useEmbedded();
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
@@ -27,9 +29,11 @@ export function AuthAddWalletEmbeddedView() {
 
   return (
     <OnboardingCard
-      headerText="Add a wallet"
+      headerText={authStatus === "noWallets" ? "Add a wallet" : "Restore wallet"}
       subtitle="Add a wallet to your account to hold your funds. Create or add an existing wallet to continue."
-      onBackButtonClick={() => signOut(false)}
+      onBackButtonClick={() =>
+        authStatus === "noWallets" ? signOut(false) : navigate(EmbeddedPaths.AuthRestoreShares)
+      }
       isLoading={isLoading}>
       <Button
         onClick={() => handleRegisterWallet("GENERATED")}

--- a/src/routes/embedded/auth/import-keyfile/auth-import-keyfile.view.tsx
+++ b/src/routes/embedded/auth/import-keyfile/auth-import-keyfile.view.tsx
@@ -1,6 +1,5 @@
 import { useEmbedded } from "~utils/embedded/embedded.hooks";
-import { useCallback, useEffect, useState } from "react";
-
+import { useEffect, useState } from "react";
 import { Row, Upload, Copyable, Button, Text, Snackbar } from "~components/embed";
 import copy from "copy-to-clipboard";
 import { useLocation } from "~wallets/router/router.utils";
@@ -13,7 +12,7 @@ export function AuthImportKeyfileEmbeddedView() {
   const { navigate } = useLocation();
   const [isAdding, setIsAdding] = useState(false);
 
-  const { importTempWallet, deleteImportedTempWallet, registerWallet, wallets } = useEmbedded();
+  const { importTempWallet, deleteImportedTempWallet, registerWallet, wallets, authStatus } = useEmbedded();
 
   const {
     data: uploadData,
@@ -74,7 +73,7 @@ export function AuthImportKeyfileEmbeddedView() {
 
   return importedWalletAddress ? (
     <OnboardingCard
-      headerText="Import Keyfile"
+      headerText={authStatus === "noWallets" ? "Import Keyfile" : "Restore wallet"}
       subtitle="Would you like to add this wallet to your account?"
       onBackButtonClick={() => navigate(`/auth/add-wallet`)}
       isLoading={isViewLoading}>
@@ -98,7 +97,7 @@ export function AuthImportKeyfileEmbeddedView() {
     </OnboardingCard>
   ) : (
     <OnboardingCard
-      headerText="Import Keyfile"
+      headerText={authStatus === "noWallets" ? "Import Keyfile" : "Restore wallet"}
       subtitle="Upload your private key to add your wallet to your account."
       onBackButtonClick={() => navigate(`/auth/add-wallet`)}
       isLoading={isViewLoading}>

--- a/src/routes/embedded/auth/import-qrcode/auth-import-qrcode.tsx
+++ b/src/routes/embedded/auth/import-qrcode/auth-import-qrcode.tsx
@@ -1,9 +1,12 @@
+import { useEmbedded } from "~utils/embedded/embedded.hooks";
 import { QrCodeScanEmbeddedView } from "./components/QrCodeEmbeddedView";
 
 export function AuthImportQrCodeEmbeddedView() {
+  const { authStatus } = useEmbedded();
+
   return (
     <QrCodeScanEmbeddedView
-      headerText="Import wallet"
+      headerText={authStatus === "noWallets" ? "Import Wallet" : "Restore Wallet"}
       subtitle="Scan your wallet QR code to import your account."
       backButtonClickHref="/auth/add-wallet"
       type="importWallet"

--- a/src/routes/embedded/auth/import-seedphrase/auth-import-seedphrase.view.tsx
+++ b/src/routes/embedded/auth/import-seedphrase/auth-import-seedphrase.view.tsx
@@ -10,7 +10,7 @@ export function AuthImportSeedphraseEmbeddedView() {
   const [loading, setLoading] = useState(false);
   const { navigate } = useLocation();
   const [seedPhrase, setSeedPhrase] = useState<string[]>([]);
-  const { importTempWallet, importedTempWalletAddress, deleteImportedTempWallet, registerWallet, wallets } =
+  const { importTempWallet, importedTempWalletAddress, deleteImportedTempWallet, registerWallet, wallets, authStatus } =
     useEmbedded();
 
   const validateSeedPhrase = useCallback(() => {
@@ -90,7 +90,7 @@ export function AuthImportSeedphraseEmbeddedView() {
 
   return importedTempWalletAddress ? (
     <OnboardingCard
-      headerText="Enter Seedphrase"
+      headerText={authStatus === "noWallets" ? "Enter Seedphrase" : "Restore wallet"}
       subtitle="Would you like to add this wallet to your account?"
       onBackButtonClick={() => navigate(`/auth/add-wallet`)}
       isLoading={loading}>
@@ -114,7 +114,7 @@ export function AuthImportSeedphraseEmbeddedView() {
     </OnboardingCard>
   ) : (
     <OnboardingCard
-      headerText="Enter Seedphrase"
+      headerText={authStatus === "noWallets" ? "Enter Seedphrase" : "Restore wallet"}
       subtitle="Enter your seedphrase to add your wallet to your account."
       onBackButtonClick={() => navigate(`/auth/add-wallet`)}
       isLoading={loading}>

--- a/src/routes/embedded/auth/recover-account/auth-recover-account.view.tsx
+++ b/src/routes/embedded/auth/recover-account/auth-recover-account.view.tsx
@@ -90,7 +90,7 @@ export function AuthRecoverAccountEmbeddedView() {
     <OnboardingCard
       headerIcon={<RecoverHeaderIcon />}
       headerText="Recover your account"
-      subtitle="Select a method for logging in on new devices and recovering your account."
+      subtitle="Select a method for recovering your account."
       onBackButtonClick={() => navigate(`/auth`)}
       isLoading={isViewLoading}
       onSubmit={signInWithOtp}>

--- a/src/routes/embedded/auth/recover-account/otp/auth-recover-account-otp.view.tsx
+++ b/src/routes/embedded/auth/recover-account/otp/auth-recover-account-otp.view.tsx
@@ -138,13 +138,13 @@ export function AuthRecoverAccountOtpEmbeddedView() {
       onBackButtonClick={() => navigate(EmbeddedPaths.AuthRecoverAccount)}
       isLoading={isViewLoading}
       onSubmit={handleVerifyOtp}>
-      <Text variant={"bodySm"} alignment={"center"} style={{ color: "var(--text-color-secondary, #666666)" }}>
+      <Text variant="bodySm" alignment="center">
         Enter the 6-digit verification code from that email to recover your account. If you don't see the email, please
         check your spam folder.
       </Text>
 
       <Flex direction="column" gap={12} width="100%">
-        <Text alignment="center" variant={"bodySm"} style={{ color: "var(--text-color-secondary, #666666)" }}>
+        <Text alignment="center" variant="bodySm">
           Verification Code
         </Text>
 

--- a/src/routes/embedded/auth/restore-shares/auth-restore-shares.view.tsx
+++ b/src/routes/embedded/auth/restore-shares/auth-restore-shares.view.tsx
@@ -1,74 +1,88 @@
 import { QrCode02 } from "@untitled-ui/icons-react";
 import { useMemo } from "react";
-import {
-  Button,
-  WalletIcon,
-  SeedIcon,
-  KeyIcon,
-  Text,
-  Snackbar,
-  type SnackbarVariant,
-  Divider,
-} from "~components/embed/ui";
+import { Button, WalletIcon, SeedIcon, KeyIcon, Snackbar, type SnackbarVariant, Divider } from "~components/embed/ui";
 import { OnboardingCard } from "~components/embed/ui/molecules/card/onboarding-card/OnboardingCard";
+import { formatDate } from "~utils/agents/utils";
 import { useEmbedded } from "~utils/embedded/embedded.hooks";
 import { signOut } from "~utils/embedded/embedded.utils";
+import browser from "webextension-polyfill";
 
 export function AuthRestoreSharesEmbeddedView() {
   const { wallets, unpartitionedStateStatus } = useEmbedded();
   const hasMultipleWallets = wallets.length > 1;
-  const hasRecoverableWallets = wallets.some((wallet) => wallet.canBeRecovered) || true;
+
+  // TODO: Let them know what type of backup/export they made and where? Let them check all available options?
+
+  const { lastRecovery, hasRecoverableWallets } = useMemo(() => {
+    let lastRecovery = 0;
+    let hasRecoverableWallets = false;
+
+    wallets.forEach(({ canBeRecovered, lastBackedUpAt, lastExportedAt }) => {
+      lastRecovery = canBeRecovered
+        ? Math.max(lastRecovery, lastBackedUpAt?.getTime() || 0, lastExportedAt?.getTime() || 0)
+        : lastRecovery;
+      hasRecoverableWallets = hasRecoverableWallets || canBeRecovered;
+    });
+
+    return {
+      lastRecovery,
+      hasRecoverableWallets,
+    };
+  }, []);
 
   let createFirst = false;
   let snackbarVariant: SnackbarVariant = "warning";
-  let title = "Using a new device?";
-  let message =
-    "This happens when you start using Wander on a new device or browser, or clear your browser data. If you've lost your backup options, you can create a new one instead.";
+  let title = "No wallets found on this device";
+  let message = "New device or browser? Did you clear your browser data? Select a method for restoring your wallet.";
   let unpartitionedStorageMessage = "";
-  let showSupportLinks = false;
-  let needsWalletCreationConfirmation = false;
-
-  // TODO: Let them know what type of backup/export they made and where? Let them check all available options?
-  const lastRecovery = useMemo(() => {
-    let lastRecovery = 0;
-
-    wallets.forEach(({ lastBackedUpAt, lastExportedAt }) => {
-      lastRecovery = Math.max(lastRecovery, lastBackedUpAt?.getTime() || 0, lastExportedAt?.getTime() || 0);
-    });
-  }, []);
 
   // Keep in mind users could have seen the QR or seedphrase backup but then they might not scan or save it, respectively. Also, users might have exported
   // a keyfile or recovery file, but they might have lost it.
 
   if (!hasRecoverableWallets) {
     createFirst = true;
-    showSupportLinks = true;
     snackbarVariant = "error";
     title = "No backups detected";
     message = hasMultipleWallets
-      ? `It looks like your wallets are not recoverable. Unless you backed any of them up, they are lost forever. Create a new wallet instead.`
-      : `It looks like your wallet is not recoverable. Unless you backed it up, it's lost forever. Create a new wallet instead.`;
-  } else if (unpartitionedStateStatus !== "supported") {
-    // TODO: Let them know where they've previously signed in?
-    showSupportLinks = true;
-    snackbarVariant = "error";
-    unpartitionedStorageMessage =
-      "If you've previously used Wander on a different site, your might still be able to backup your wallet from it. Please, go back and try to backup your wallet.";
+      ? `It looks like your wallets are not recoverable. Unless you backed any of them up, they are lost forever.`
+      : `It looks like your wallet is not recoverable. Unless you backed it up, it's lost forever.`;
+
+    if (unpartitionedStateStatus !== "supported") {
+      // TODO: Let them know where they've previously signed in?
+      unpartitionedStorageMessage =
+        "If you've previously used Wander on a different site, your might still be able to backup your wallet from it.";
+    }
   }
 
   return (
     <OnboardingCard
-      headerText="Restore wallet"
-      subtitle="Select a method for restoring your wallet."
+      headerText="Restore Wallet"
+      subtitle="We need to restore you wallet on this device."
       onBackButtonClick={() => signOut(false)}>
       <Snackbar title={title} variant={snackbarVariant}>
         <p>{message}</p>
         {unpartitionedStorageMessage ? <p>{unpartitionedStorageMessage} </p> : null}
+        {lastRecovery ? <p>You last backed up your wallet on {formatDate(new Date(lastRecovery), "")}</p> : null}
+        <p>
+          Need help?{" "}
+          <Button
+            variant="link"
+            onClick={(e) => {
+              e.preventDefault();
+              browser.tabs.create({ url: "https://www.wander.app/help" });
+            }}>
+            Learn more
+          </Button>
+        </p>
       </Snackbar>
 
       {createFirst ? (
         <>
-          <Button variant="outlined" isFullWidth icon={<WalletIcon fontSize={24} />} href="/auth/add-wallet">
+          <Button
+            variant="outlined"
+            isFullWidth
+            icon={<WalletIcon fontSize={24} />}
+            href="/auth/restore-shares/create-confirmation">
             Create new wallet
           </Button>
 
@@ -130,7 +144,11 @@ export function AuthRestoreSharesEmbeddedView() {
         <>
           <Divider text={"OR"} />
 
-          <Button variant="outlined" isFullWidth icon={<WalletIcon fontSize={24} />} href="/auth/add-wallet">
+          <Button
+            variant="outlined"
+            isFullWidth
+            icon={<WalletIcon fontSize={24} />}
+            href="/auth/restore-shares/create-confirmation">
             Create new wallet
           </Button>
         </>

--- a/src/routes/embedded/auth/restore-shares/auth-restore-shares.view.tsx
+++ b/src/routes/embedded/auth/restore-shares/auth-restore-shares.view.tsx
@@ -1,17 +1,81 @@
 import { QrCode02 } from "@untitled-ui/icons-react";
-import { Button, WalletIcon, SeedIcon, KeyIcon } from "~components/embed/ui";
+import { useMemo } from "react";
+import {
+  Button,
+  WalletIcon,
+  SeedIcon,
+  KeyIcon,
+  Text,
+  Snackbar,
+  type SnackbarVariant,
+  Divider,
+} from "~components/embed/ui";
 import { OnboardingCard } from "~components/embed/ui/molecules/card/onboarding-card/OnboardingCard";
 import { useEmbedded } from "~utils/embedded/embedded.hooks";
 import { signOut } from "~utils/embedded/embedded.utils";
 
 export function AuthRestoreSharesEmbeddedView() {
-  // TODO: Automatically retry loading wallets once before showing this screen?
+  const { wallets, unpartitionedStateStatus } = useEmbedded();
+  const hasMultipleWallets = wallets.length > 1;
+  const hasRecoverableWallets = wallets.some((wallet) => wallet.canBeRecovered) || true;
+
+  let createFirst = false;
+  let snackbarVariant: SnackbarVariant = "warning";
+  let title = "Using a new device?";
+  let message =
+    "This happens when you start using Wander on a new device or browser, or clear your browser data. If you've lost your backup options, you can create a new one instead.";
+  let unpartitionedStorageMessage = "";
+  let showSupportLinks = false;
+  let needsWalletCreationConfirmation = false;
+
+  // TODO: Let them know what type of backup/export they made and where? Let them check all available options?
+  const lastRecovery = useMemo(() => {
+    let lastRecovery = 0;
+
+    wallets.forEach(({ lastBackedUpAt, lastExportedAt }) => {
+      lastRecovery = Math.max(lastRecovery, lastBackedUpAt?.getTime() || 0, lastExportedAt?.getTime() || 0);
+    });
+  }, []);
+
+  // Keep in mind users could have seen the QR or seedphrase backup but then they might not scan or save it, respectively. Also, users might have exported
+  // a keyfile or recovery file, but they might have lost it.
+
+  if (!hasRecoverableWallets) {
+    createFirst = true;
+    showSupportLinks = true;
+    snackbarVariant = "error";
+    title = "No backups detected";
+    message = hasMultipleWallets
+      ? `It looks like your wallets are not recoverable. Unless you backed any of them up, they are lost forever. Create a new wallet instead.`
+      : `It looks like your wallet is not recoverable. Unless you backed it up, it's lost forever. Create a new wallet instead.`;
+  } else if (unpartitionedStateStatus !== "supported") {
+    // TODO: Let them know where they've previously signed in?
+    showSupportLinks = true;
+    snackbarVariant = "error";
+    unpartitionedStorageMessage =
+      "If you've previously used Wander on a different site, your might still be able to backup your wallet from it. Please, go back and try to backup your wallet.";
+  }
 
   return (
     <OnboardingCard
       headerText="Restore wallet"
       subtitle="Select a method for restoring your wallet."
       onBackButtonClick={() => signOut(false)}>
+      <Snackbar title={title} variant={snackbarVariant}>
+        <p>{message}</p>
+        {unpartitionedStorageMessage ? <p>{unpartitionedStorageMessage} </p> : null}
+      </Snackbar>
+
+      {createFirst ? (
+        <>
+          <Button variant="outlined" isFullWidth icon={<WalletIcon fontSize={24} />} href="/auth/add-wallet">
+            Create new wallet
+          </Button>
+
+          <Divider text={"OR"} />
+        </>
+      ) : null}
+
       {/* <Button
         variant="outlined"
         isFullWidth
@@ -61,6 +125,16 @@ export function AuthRestoreSharesEmbeddedView() {
         href="/auth/restore-shares/qrcode">
         Scan QR Code
       </Button>
+
+      {createFirst ? null : (
+        <>
+          <Divider text={"OR"} />
+
+          <Button variant="outlined" isFullWidth icon={<WalletIcon fontSize={24} />} href="/auth/add-wallet">
+            Create new wallet
+          </Button>
+        </>
+      )}
     </OnboardingCard>
   );
 }

--- a/src/routes/embedded/auth/restore-shares/create-confirmation/auth-restore-shares-create-confirmation.view.tsx
+++ b/src/routes/embedded/auth/restore-shares/create-confirmation/auth-restore-shares-create-confirmation.view.tsx
@@ -1,0 +1,40 @@
+import { Button, WalletIcon, Snackbar } from "~components/embed/ui";
+import { OnboardingCard } from "~components/embed/ui/molecules/card/onboarding-card/OnboardingCard";
+import browser from "webextension-polyfill";
+import { EmbeddedPaths } from "~wallets/router/iframe/iframe.routes";
+import { useLocation } from "~wallets/router/router.utils";
+
+export function AuthRestoreSharesCreateConfirmationEmbeddedView() {
+  const { navigate } = useLocation();
+
+  return (
+    <OnboardingCard
+      headerText="Restore Wallet"
+      subtitle="Are you sure you want to create a new wallet?"
+      onBackButtonClick={() => navigate(EmbeddedPaths.AuthRestoreShares)}>
+      <Snackbar title="Your old wallet will be replaced" variant="warning">
+        <p>You won't be able to access your old wallet again.</p>
+        <p>
+          Need help?{" "}
+          <Button
+            variant="link"
+            onClick={(e) => {
+              e.preventDefault();
+              browser.tabs.create({ url: "https://www.wander.app/help" });
+            }}>
+            {" "}
+            Learn more
+          </Button>
+        </p>
+      </Snackbar>
+
+      <Button variant="primary" isFullWidth icon={<WalletIcon fontSize={24} />} href={EmbeddedPaths.AuthAddWallet}>
+        Yes, create
+      </Button>
+
+      <Button variant="outlined" isFullWidth href={EmbeddedPaths.AuthRecoverAccount}>
+        No, cancel
+      </Button>
+    </OnboardingCard>
+  );
+}

--- a/src/utils/embedded/embedded.provider.tsx
+++ b/src/utils/embedded/embedded.provider.tsx
@@ -677,6 +677,10 @@ export function EmbeddedProvider({ children }: EmbeddedProviderProps) {
     async (sourceType: WalletSourceType) => {
       log(LOG_GROUP.WALLET_GENERATION, `registerWallet(${sourceType})`);
 
+      if (authStatus === "noShares") {
+        // TODO: Mark all wallets as lost first.
+      }
+
       const promise =
         sourceType === "GENERATED"
           ? generatedTempWalletPromiseRef.current?.promise

--- a/src/utils/embedded/embedded.provider.tsx
+++ b/src/utils/embedded/embedded.provider.tsx
@@ -680,7 +680,19 @@ export function EmbeddedProvider({ children }: EmbeddedProviderProps) {
       log(LOG_GROUP.WALLET_GENERATION, `registerWallet(${sourceType})`);
 
       if (authStatus === "noShares") {
-        // TODO: Mark all wallets as lost first.
+        await Promise.all(
+          wallets.map(({ id: walletId, status }) =>
+            status === "ENABLED" ? WalletService.updateWalletStatus({ walletId, status: "LOST" }) : null,
+          ),
+        );
+
+        setEmbeddedContextState((prevAuthContextState) => ({
+          ...prevAuthContextState,
+          wallets: prevAuthContextState.wallets.map((wallet) => ({
+            ...wallet,
+            status: wallet.status === "ENABLED" ? "LOST" : wallet.status,
+          })),
+        }));
       }
 
       const promise =
@@ -728,7 +740,7 @@ export function EmbeddedProvider({ children }: EmbeddedProviderProps) {
 
       return wallet;
     },
-    [userId],
+    [wallets, userId],
   );
 
   const clearLastRegisteredWallet = useCallback(() => {

--- a/src/utils/wallets/wallets.service.ts
+++ b/src/utils/wallets/wallets.service.ts
@@ -98,6 +98,12 @@ async function createPublicWallet(wallet: CreatePublicWalletParams) {
   });
 }
 
+export type UpdateWalletStatusData = Exclude<Parameters<typeof trpcVanilla.updateWalletStatus.mutate>[0], void>;
+
+async function updateWalletStatus(updateWalletStatusData: UpdateWalletStatusData) {
+  return trpcVanilla.updateWalletStatus.mutate(updateWalletStatusData);
+}
+
 export type DoNotAskAgainForBackupData = Exclude<Parameters<typeof trpcVanilla.doNotAskAgainForBackup.mutate>[0], void>;
 
 async function doNotAskAgainForBackup(doNotAskAgainForBackupData: DoNotAskAgainForBackupData) {
@@ -279,6 +285,7 @@ async function registerAuthShare(registerAuthShareData: RegisterAuthShareData) {
 
 export const WalletService = {
   fetchWallets,
+  updateWalletStatus,
   doNotAskAgainForBackup,
   createPublicWallet,
   registerRecoveryShare,

--- a/src/wallets/router/iframe/iframe-router.hook.ts
+++ b/src/wallets/router/iframe/iframe-router.hook.ts
@@ -78,13 +78,22 @@ export function useEmbeddedOverride(location?: RoutePath) {
   if (authStatus === "noShares") {
     return routeTrapMatches(
       location,
-      // TODO: Do we allow simply generating a new wallet? EmbeddedPaths.AuthAddWallet
       [
+        // Restore:
         EmbeddedPaths.AuthRestoreShares,
+        EmbeddedPaths.AuthRestoreSharesCreateConfirmation,
         EmbeddedPaths.AuthRestoreSharesRecoveryFile,
         EmbeddedPaths.AuthRestoreSharesSeedPhrase,
         EmbeddedPaths.AuthRestoreSharesKeyfile,
         EmbeddedPaths.AuthRestoreSharesQrCode,
+
+        // Add wallet:
+        EmbeddedPaths.AuthAddWallet,
+        EmbeddedPaths.AuthImportSeedPhrase,
+        EmbeddedPaths.AuthAddWithQRCode,
+        EmbeddedPaths.AuthQRCodeScanner,
+        EmbeddedPaths.AuthImportKeyfile,
+        EmbeddedPaths.AuthImportQrCode,
       ],
       EmbeddedPaths.AuthRestoreShares,
     );

--- a/src/wallets/router/iframe/iframe.routes.tsx
+++ b/src/wallets/router/iframe/iframe.routes.tsx
@@ -20,6 +20,7 @@ import { AuthAddAuthProviderEmbeddedView } from "~routes/embedded/auth/add-auth-
 
 // Shares Views:
 import { AuthRestoreSharesEmbeddedView } from "~routes/embedded/auth/restore-shares/auth-restore-shares.view";
+import { AuthRestoreSharesCreateConfirmationEmbeddedView } from "~routes/embedded/auth/restore-shares/create-confirmation/auth-restore-shares-create-confirmation.view";
 import { AuthRestoreSharesRecoveryFileEmbeddedView } from "~routes/embedded/auth/restore-shares/recovery-file/auth-restore-shares-recovery-file.view";
 import { AuthRestoreSharesSeedPhraseEmbeddedView } from "~routes/embedded/auth/restore-shares/seedphrase/auth-restore-shares-seedphrase.view";
 import { AuthRestoreSharesKeyfileEmbeddedView } from "~routes/embedded/auth/restore-shares/keyfile/auth-restore-shares-keyfile.view";
@@ -78,6 +79,7 @@ export type EmbeddedRoutePath =
   | "/auth/confirmation"
   | "/auth/add-auth-provider"
   | "/auth/restore-shares"
+  | "/auth/restore-shares/create-confirmation"
   | "/auth/restore-shares/recovery-file"
   | "/auth/restore-shares/seedphrase"
   | "/auth/restore-shares/keyfile"
@@ -145,6 +147,7 @@ export const EmbeddedPaths = {
 
   // Shares Recovery:
   AuthRestoreShares: "/auth/restore-shares",
+  AuthRestoreSharesCreateConfirmation: "/auth/restore-shares/create-confirmation",
   AuthRestoreSharesRecoveryFile: "/auth/restore-shares/recovery-file",
   AuthRestoreSharesSeedPhrase: "/auth/restore-shares/seedphrase",
   AuthRestoreSharesKeyfile: "/auth/restore-shares/keyfile",
@@ -249,6 +252,10 @@ const IFRAME_OWN_ROUTES = [
   {
     path: EmbeddedPaths.AuthRestoreShares,
     component: AuthRestoreSharesEmbeddedView,
+  },
+  {
+    path: EmbeddedPaths.AuthRestoreSharesCreateConfirmation,
+    component: AuthRestoreSharesCreateConfirmationEmbeddedView,
   },
   {
     path: EmbeddedPaths.AuthRestoreSharesRecoveryFile,


### PR DESCRIPTION
Wallet recovery screen 1) with backups 2) with no backups 3) with no backups in a browser without unpartitioned state, and 4) wallet creation confirmation:

<img src="https://github.com/user-attachments/assets/16527749-01ec-47bb-be19-cafaef352cc5" width="320px" />
<img src="https://github.com/user-attachments/assets/768fb636-bf1f-4243-a1cf-38fe578db97c" width="320px" />
<img src="https://github.com/user-attachments/assets/79092f6f-def9-42a6-b742-998a8367714d" width="320px" />
<img src="https://github.com/user-attachments/assets/2c68afa8-5bec-4374-8039-cb034e417fce" width="320px" />

Add / create wallet screens with updated messages on the recovery flow:

<img src="https://github.com/user-attachments/assets/797849c6-b242-4055-b9fc-dd6046ae5eef" width="320px" />
<img src="https://github.com/user-attachments/assets/97d131e3-ca64-4c27-94e5-a39910ec40a4" width="320px" />
<img src="https://github.com/user-attachments/assets/80f1e1e0-7866-4cd5-aa25-77a562f436dc" width="320px" />
<img src="https://github.com/user-attachments/assets/43a51c67-a7a2-4286-b997-ae2ea733e280" width="320px" />

Closes https://communitylabs.atlassian.net/browse/ARC-1332.
