### PR TITLE
feat: ARC-1198: Hash based challenges flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ VITE_PROD_EMBEDDED_SERVER_BASE_URL="https://connect-api.wander.app"
 VITE_TEST_DEFAULT_EMBEDDED_CLIENT_ID="test"
 VITE_TEST_DEFAULT_EMBEDDED_SERVER_BASE_URL="https://test.com"
 
+# Temp. Will be removed once activation is done on wallet usage and we implement AES challenges.
+VITE_SKIP_RSA_PRIVATE_KEY_DERIVATION=1
+
 # DEVELOPMENT
 VITE_SUPABASE_URL=""
 VITE_SUPABASE_ANON_KEY=""

--- a/src/utils/wallets/wallets.service.ts
+++ b/src/utils/wallets/wallets.service.ts
@@ -141,7 +141,10 @@ async function fetchFirstAvailableAuthShare(
         }
 
         const { shareHash: deviceShareHash, sharePrivateKeyJWK: deviceSharePrivateKeyJWK } =
-          await WalletUtils.generateShareHashAndPrivateKey(deviceShare);
+          await WalletUtils.generateShareHashAndPrivateKey(
+            deviceShare,
+            import.meta.env?.VITE_SKIP_RSA_PRIVATE_KEY_DERIVATION === "1",
+          );
 
         const { activationChallenge } = await trpcVanilla.generateWalletActivationChallenge.mutate({
           walletId,

--- a/src/utils/wallets/wallets.utils.ts
+++ b/src/utils/wallets/wallets.utils.ts
@@ -218,7 +218,7 @@ async function generateShareHashAndPublicKey(share: string): Promise<GenerateSha
 
 export interface GenerateShareHashAndPrivateKeyReturn {
   shareHash: string;
-  sharePrivateKeyJWK: JWKInterface;
+  sharePrivateKeyJWK: null | JWKInterface;
 }
 
 /**
@@ -226,11 +226,23 @@ export interface GenerateShareHashAndPrivateKeyReturn {
  * - https://github.com/framp/zero-knowledge-node/blob/master/keypair-auth/crypto-utils.js
  * - https://www.youtube.com/watch?v=cMoD0wIxIpQ
  */
-async function generateShareHashAndPrivateKey(share: string): Promise<GenerateShareHashAndPrivateKeyReturn> {
+async function generateShareHashAndPrivateKey(
+  share: string,
+  skipKeyGeneration = false,
+): Promise<GenerateShareHashAndPrivateKeyReturn> {
   log(LOG_GROUP.WALLET_GENERATION, "generateShareHashAndPrivateKey()");
 
   if (!share) {
     throw new Error("Share is missing — unable to generate share hash and private key.");
+  }
+
+  if (skipKeyGeneration) {
+    const shareHash = await generateShareHash(share);
+
+    return {
+      shareHash,
+      sharePrivateKeyJWK: null,
+    };
   }
 
   const sharePrng = random.createInstance();

--- a/src/utils/wallets/wallets.utils.ts
+++ b/src/utils/wallets/wallets.utils.ts
@@ -170,7 +170,7 @@ export interface GenerateShareHashAndPublicKeyReturn {
  * - https://www.youtube.com/watch?v=cMoD0wIxIpQ
  */
 async function generateShareHashAndPublicKey(share: string): Promise<GenerateShareHashAndPublicKeyReturn> {
-  log(LOG_GROUP.WALLET_GENERATION, "generateShareHashAndPublicKey()");
+  log(LOG_GROUP.WALLET_GENERATION, "generateShareHashAndPublicKey(🐌)");
 
   if (!share) {
     throw new Error("Share is missing — unable to generate share hash and public key.");
@@ -230,7 +230,7 @@ async function generateShareHashAndPrivateKey(
   share: string,
   skipKeyGeneration = false,
 ): Promise<GenerateShareHashAndPrivateKeyReturn> {
-  log(LOG_GROUP.WALLET_GENERATION, "generateShareHashAndPrivateKey()");
+  log(LOG_GROUP.WALLET_GENERATION, `generateShareHashAndPrivateKey(${skipKeyGeneration ? "⚡" : "🐌"})`);
 
   if (!share) {
     throw new Error("Share is missing — unable to generate share hash and private key.");


### PR DESCRIPTION
Add a flag to skip the generation of the private key, once the backend switches to hash-based challenges.

Note the public keys are still generated, as not generating them means we cannot easily go back to the signature-based system, because the wallets in the DB won't have a public key stored. Later on, with some changes on the backend as well, we can update the system so that switching from one method to the other is possible at any point, even with public key generation is also disabled and some wallets end up missing their public key.

Note currently `SHARE_ACTIVE_TTL_MS` = 10 minutes, so the public key still needs to be generated relatively often. Changing that value to a few hours will also help speed things up.

Eventually, it could make sense to allow users to tweak these and some other security-related options to balance speed, convenience and security.

Closes https://communitylabs.atlassian.net/browse/ARC-1198.