### PR TITLE
fix: Allow non email users to use email

### DIFF
--- a/src/routes/embedded/auth/auth/auth.view.tsx
+++ b/src/routes/embedded/auth/auth/auth.view.tsx
@@ -112,9 +112,12 @@ export function AuthEmbeddedView() {
           p_email: email,
         });
 
-        const isAlreadyRegistered = isAlreadyRegisteredParam === "0" ? false : !!data;
+        const isAlreadyRegistered =
+          isAlreadyRegisteredParam === "0"
+            ? false
+            : !!data || error?.message === "An account with this email already exists, but it is not using a password.";
 
-        if (error) {
+        if (error && error.message !== "An account with this email already exists, but it is not using a password.") {
           toast.error(getFriendlyAuthErrorMessage(error, error.message || "Error checking email"));
           return;
         }

--- a/src/routes/embedded/auth/recover-account/auth-recover-account.view.tsx
+++ b/src/routes/embedded/auth/recover-account/auth-recover-account.view.tsx
@@ -43,11 +43,14 @@ export function AuthRecoverAccountEmbeddedView() {
         return;
       }
 
-      const { data: isAlreadyRegistered, error } = await supabase.rpc("user_exists_by_email", {
+      const { data, error } = await supabase.rpc("user_exists_by_email", {
         p_email: email,
       });
 
-      if (error) {
+      const isAlreadyRegistered =
+        !!data || error?.message === "An account with this email already exists, but it is not using a password.";
+
+      if (error && error.message !== "An account with this email already exists, but it is not using a password.") {
         toast.error(getFriendlyAuthErrorMessage(error, error.message || "Error checking email"));
         return;
       }


### PR DESCRIPTION
Before OTP, the `user_exists_by_email` would only check whether a user linked to a given email exists, regardless of what authentication method it has used. We then updated that function to check whether an user with the Email provider exists for that email.

Now we actually want the old behavior, because any existing user can use OTP to authenticate regardless of whether they were created using OAuth.

This a quick client fix to get the old behavior, but the backend will be updated to use the old version of the function too.