### PR TITLE
fix: discord logo stretch issue

### DIFF
--- a/src/routes/popup/settings/help/index.tsx
+++ b/src/routes/popup/settings/help/index.tsx
@@ -158,6 +158,7 @@ const Wrapper = styled.div`
 const DiscordImage = styled.img`
   height: 24px;
   width: 24px;
+  object-fit: contain;
   filter: ${(props) => (props.theme.displayTheme === "light" ? "invert(1)" : "none")};
 `;
 


### PR DESCRIPTION
## Summary

This PR fixes the issue with discord logo being stretched. Closes [ARC-1486](https://communitylabs.atlassian.net/browse/ARC-1486)

## How to Test
- Please check if the discord logo is not stretched in production build as in development it was fine before as well.

[ARC-1486]: https://communitylabs.atlassian.net/browse/ARC-1486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ