### PR TITLE
Fix transferable pi + update Astro announcement copy

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -2042,10 +2042,6 @@
     "message": "The EXP Token is non transferable",
     "description": "Popup description about ao token transfer"
   },
-  "PI_token_send_popup": {
-    "message": "The PI Token is non transferable",
-    "description": "Popup description about pi token transfer"
-  },
   "WNDR_token_send_popup": {
     "message": "The WNDR Token is non transferable until October 7th, 2025",
     "description": "Popup description about wndr token transfer"

--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -3836,9 +3836,9 @@
     "message": "Get access",
     "description": "Get access text"
   },
-  "community_phase": {
-    "message": "Community Phase",
-    "description": "Community phase text"
+  "wndr_member_benefits": {
+    "message": "$$WNDR Member Benefits",
+    "description": "WNDR member benefits text"
   },
   "beta_access": {
     "message": "Beta Access",

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -2042,10 +2042,6 @@
     "message": "EXP代币无法转账",
     "description": "Popup description about ao token transfer"
   },
-  "PI_token_send_popup": {
-    "message": "PI代币无法转账",
-    "description": "Popup description about pi token transfer"
-  },
   "WNDR_token_send_popup": {
     "message": "WNDR代币无法转账，直到2025年10月7日",
     "description": "Popup description about wndr token transfer"

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -3796,9 +3796,9 @@
       "message": "获取访问",
       "description": "Get access text"
     },
-    "community_phase": {
-      "message": "社区阶段",
-      "description": "Community phase text"
+    "wndr_member_benefits": {
+        "message": "$$WNDR 会员福利",
+        "description": "WNDR member benefits text"
     },
     "beta_access": {
       "message": "测试版访问",

--- a/src/components/popup/home/AstroBetaAccessAnnouncementPopup.tsx
+++ b/src/components/popup/home/AstroBetaAccessAnnouncementPopup.tsx
@@ -48,7 +48,7 @@ export const AstroBetaAccessAnnouncementPopup = ({ isOpen, setOpen }) => {
                 color: "#EEE",
               }}
               noMargin>
-              {browser.i18n.getMessage("community_phase")}
+              {browser.i18n.getMessage("wndr_member_benefits")}
             </Text>
             <Title>
               <span>USDA</span> {browser.i18n.getMessage("beta_access")}

--- a/src/routes/popup/send/announcement.tsx
+++ b/src/routes/popup/send/announcement.tsx
@@ -2,7 +2,6 @@ import { ButtonV2, ModalV2, Spacer } from "@arconnect/components";
 import { useRef } from "react";
 import browser from "webextension-polyfill";
 import expLogo from "url:/assets/ecosystem/exp-token-logo.png";
-import piLogo from "url:/assets/ecosystem/pi-token-logo.png";
 import wndrLogo from "url:/assets/ecosystem/wndr-token-logo.svg";
 import { HeaderText, CenterText, Content, ContentWrapper } from "~components/modals/Components";
 import { useTheme } from "styled-components";
@@ -17,10 +16,6 @@ const tokenData: Record<string, TokenData> = {
   EXP: {
     learnMoreLink: "https://x.com/ar_io_network/status/1879961321170706490",
     image: expLogo,
-  },
-  PI: {
-    learnMoreLink: "https://www.autonomous.finance/research/en-US/permaweb-index",
-    image: piLogo,
   },
   WNDR: {
     learnMoreLink: "https://www.wander.app/blog/wander-network-and-the-wndr-token",

--- a/src/tokens/aoTokens/ao.ts
+++ b/src/tokens/aoTokens/ao.ts
@@ -81,7 +81,7 @@ export const defaultTokens = [
   },
 ] as const satisfies TokenInfo[];
 
-export const nonTransferableTokenIds: Array<string> = [EXP_PROCESS_ID, PI_PROCESS_ID, WNDR_PROCESS_ID];
+export const nonTransferableTokenIds: Array<string> = [EXP_PROCESS_ID, WNDR_PROCESS_ID];
 
 /**
  * Dummy ID


### PR DESCRIPTION
This PR updates the copy for the Astro announcement and removes PI from the non-transferable token list