### PR TITLE
fix: keystone dataitem sign issue

### DIFF
--- a/src/api/modules/sign_data_item/sign_data_item.background.ts
+++ b/src/api/modules/sign_data_item/sign_data_item.background.ts
@@ -12,6 +12,7 @@ import { createDataItem } from "~utils/data_item";
 import { EventType, trackDirect } from "~utils/analytics";
 import { checkIfUserNeedsToSign } from "../sign/sign_policy";
 import { createArweaveSignerWithOptions } from "~utils/signer.utils";
+import { generateAnchor } from "~wallets/hardware/keystone";
 
 const background: BackgroundModuleFunction<number[]> = async (
   appData,
@@ -114,6 +115,10 @@ const background: BackgroundModuleFunction<number[]> = async (
       ownerLength: 512,
       publicKey: Buffer.from(Arweave.utils.b64UrlToBuffer(activeWallet.publicKey)),
     };
+    if (!options?.anchor) {
+      // @ts-expect-error - anchor can be uint8array or string
+      options.anchor = generateAnchor();
+    }
     const dataEntry = createDataItem(binaryData, signerConfig, options);
     try {
       const data: AuthKeystoneData = {

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -14,7 +14,7 @@ interface Props {
 const Wrapper = styled.div`
   position: relative;
   height: 18px;
-  background-color: ${(props) => props.theme.theme}1A;
+  background-color: ${(props) => props.theme.theme}26;
   border-radius: 9px;
   overflow: hidden;
 `;

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -14,7 +14,7 @@ interface Props {
 const Wrapper = styled.div`
   position: relative;
   height: 18px;
-  background-color: rgba(${(props) => props.theme.theme}, 0.15);
+  background-color: ${(props) => props.theme.theme}1A;
   border-radius: 9px;
   overflow: hidden;
 `;
@@ -25,7 +25,7 @@ const Line = styled.div`
   left: 0;
   bottom: 0;
   height: 100%;
-  background-color: rgb(${(props) => props.theme.theme});
+  background-color: ${(props) => props.theme.theme};
   border-radius: 9px;
   transition: all 0.23s ease-in-out;
 `;

--- a/src/components/hardware/AnimatedQRPlayer.tsx
+++ b/src/components/hardware/AnimatedQRPlayer.tsx
@@ -1,6 +1,7 @@
 import { AnimatedQRPlayer as Player } from "@arconnect/keystone-sdk";
 import styled, { useTheme } from "styled-components";
 import { type ComponentProps, useMemo } from "react";
+import { Loading } from "@arconnect/components-rebrand";
 
 export default function AnimatedQRPlayer(props: ComponentProps<typeof Player>) {
   // global theme
@@ -21,7 +22,20 @@ export default function AnimatedQRPlayer(props: ComponentProps<typeof Player>) {
 
   return (
     <Wrapper>
-      <Player {...config} {...props} />
+      {props.data ? (
+        <Player {...config} {...props} />
+      ) : (
+        <Loading
+          style={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            width: "24px",
+            height: "24px",
+            color: theme.secondaryText,
+          }}
+        />
+      )}
     </Wrapper>
   );
 }

--- a/src/routes/auth/signKeystone.tsx
+++ b/src/routes/auth/signKeystone.tsx
@@ -1,5 +1,5 @@
 import { dataItemToUR, decodeSignature, messageToUR } from "~wallets/hardware/keystone";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useScanner } from "@arconnect/keystone-sdk";
 import { useActiveWallet } from "~wallets/hooks";
 import type { UR } from "@ngraveio/bc-ur";
@@ -20,13 +20,6 @@ export function SignKeystoneAuthRequestView() {
 
   const { keystoneSignType, data: dataToSign } = authRequest;
 
-  useAsyncEffect(async () => {
-    if (keystoneSignType === "DataItem" && !!dataToSign) {
-      await loadTransactionUR();
-      setPage("qr");
-    }
-  }, [keystoneSignType, dataToSign]);
-
   /**
    * Hardware wallet logic
    */
@@ -39,18 +32,6 @@ export function SignKeystoneAuthRequestView() {
 
   // load tx UR
   const [transactionUR, setTransactionUR] = useState<UR>();
-
-  async function loadTransactionUR() {
-    if (wallet.type !== "hardware" || !dataToSign) return;
-    // load the ur data
-    if (keystoneSignType === "DataItem") {
-      const ur = await dataItemToUR(dataToSign, wallet.xfp);
-      setTransactionUR(ur);
-    } else {
-      const ur = await messageToUR(dataToSign, wallet.xfp);
-      setTransactionUR(ur);
-    }
-  }
 
   // loading
   const [loading, setLoading] = useState(false);
@@ -88,6 +69,26 @@ export function SignKeystoneAuthRequestView() {
   // toast
   const { setToast } = useToasts();
 
+  const loadTransactionUR = useCallback(async () => {
+    if (wallet.type !== "hardware" || !dataToSign) return;
+
+    // load the ur data
+    if (keystoneSignType === "DataItem") {
+      const ur = await dataItemToUR(dataToSign, wallet.xfp);
+      setTransactionUR(ur);
+    } else {
+      const ur = await messageToUR(dataToSign, wallet.xfp);
+      setTransactionUR(ur);
+    }
+  }, [keystoneSignType, dataToSign, wallet]);
+
+  useAsyncEffect(async () => {
+    if (keystoneSignType === "DataItem" && !!dataToSign) {
+      await loadTransactionUR();
+      setPage("qr");
+    }
+  }, [keystoneSignType, dataToSign, loadTransactionUR]);
+
   // TODO: Could large `data` values cause issues with this component or `<Message>` below?
 
   return (
@@ -117,6 +118,7 @@ export function SignKeystoneAuthRequestView() {
                 />
                 <Spacer y={1} />
                 <Text>{browser.i18n.getMessage("keystone_scan_progress", `${scanner.progress.toFixed(0)}%`)}</Text>
+                <Spacer y={0.5} />
                 <Progress percentage={scanner.progress} />
               </>
             )}

--- a/src/routes/auth/signKeystone.tsx
+++ b/src/routes/auth/signKeystone.tsx
@@ -101,7 +101,7 @@ export function SignKeystoneAuthRequestView() {
             <Message message={[...dataToSign]} />
           </Section>
         )) || (
-          <Section>
+          <Section showPaddingVertical={false}>
             <Text noMargin>{browser.i18n.getMessage("sign_scan_qr")}</Text>
             <Spacer y={1.5} />
             {(page === "qr" && <AnimatedQRPlayer data={transactionUR} />) || (

--- a/src/utils/messaging/strategies/extension/extension-messaging.strategy.ts
+++ b/src/utils/messaging/strategies/extension/extension-messaging.strategy.ts
@@ -133,7 +133,7 @@ export async function isomorphicSendMessage<K extends MessageID>(messageData: Me
 export function isomorphicOnMessage<K extends MessageID>(messageId: K, callback: OnMessageCallback<K>): void {
   webExtBridgeOnMessage(messageId, callback as any);
 
-  if (messageId === "auth_request") {
+  if (messageId === "auth_request" || messageId === "auth_chunk") {
     isomorphicSendMessage({
       destination: "background",
       messageId: `${messageId}${READY_MESSAGE_SUFFIX}` as any,

--- a/src/wallets/hardware/keystone.ts
+++ b/src/wallets/hardware/keystone.ts
@@ -190,3 +190,11 @@ export interface KeystoneAccount {
   owner: string;
   xfp: string;
 }
+
+/**
+ * Generate a random anchor for a data item
+ * Returns a 32 byte Buffer
+ */
+export function generateAnchor() {
+  return crypto.getRandomValues(new Uint8Array(32));
+}


### PR DESCRIPTION
## Summary

This PR fixes the issue where the animated QR code wouldn’t show when signing a `DataItem` using Keystone account, and ensures transactions for identical data are unique by adding a random `anchor`. Closes [ARC-1500](https://communitylabs.atlassian.net/browse/ARC-1500)

## How to Test

1. Set **Keystone** as the active wallet in **Wander**.
2. Visit: [https://ao.arweave.net/#/delegate/](https://ao.arweave.net/#/delegate/)
3. Attempt to modify the delegation for your Keystone wallet.
4. **Expected behavior**: Wander should now correctly generate a QR code for Keystone to scan and sign, completing the signing process without skipping.
5. Also, if you are signing the same piece of data, AO MU should not return error like `Message already exists` error.

[ARC-1500]: https://communitylabs.atlassian.net/browse/ARC-1500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ