### PR TITLE
fix: update incorrect type imports

### DIFF
--- a/src/components/popup/tier/TierTag.tsx
+++ b/src/components/popup/tier/TierTag.tsx
@@ -1,5 +1,5 @@
-import styled, { useTheme } from "styled-components";
-import { Loading, Text, DefaultTheme } from "@arconnect/components-rebrand";
+import styled, { useTheme, type DefaultTheme } from "styled-components";
+import { Loading, Text } from "@arconnect/components-rebrand";
 import { useActiveTier } from "~utils/tier/hooks";
 import { useLocation } from "~wallets/router/router.utils";
 import { WanderIcon } from "./WanderIcon";

--- a/src/components/popup/tier/WanderIcon.tsx
+++ b/src/components/popup/tier/WanderIcon.tsx
@@ -1,8 +1,7 @@
 import { type Tier } from "~utils/tier/types";
 import { TierTypes } from "~utils/tier/constants";
-import { useTheme } from "styled-components";
+import { useTheme, type DefaultTheme } from "styled-components";
 import { useId } from "react";
-import { type DefaultTheme } from "@arconnect/components-rebrand";
 
 interface WanderIconProps {
   tier: Tier;

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@
 
 "@arconnect/components-rebrand@https://github.com/wanderwallet/components-rebrand.git#master":
   version "1.0.0"
-  resolved "https://github.com/wanderwallet/components-rebrand.git#755398a39df5ee53b5426b411fefb7298554ed30"
+  resolved "https://github.com/wanderwallet/components-rebrand.git#40894b27a1d3a29f6e90b33bc0d1efe152ab3801"
   dependencies:
     "@iconicicons/react" "^1.5.1"
     "@untitled-ui/icons-react" "^0.1.4"


### PR DESCRIPTION
## Summary

This PR fixes import issues and updates the `@arconnect/components-rebrand` dependency to support proper type resolution with `moduleResolution: bundler` in `tsconfig`.