### PR TITLE
fix: prevent token activity logo from shrinking

### DIFF
--- a/src/components/popup/home/Transactions.tsx
+++ b/src/components/popup/home/Transactions.tsx
@@ -306,7 +306,11 @@ export const TierTransactionItemComponent = ({ transaction }: { transaction: Ext
     <TransactionItem showBackground={false}>
       <Transaction padding="8px" onClick={() => navigate(`/transaction/${transaction.node.id}?back=/tier`)}>
         <FlexContainer>
-          <TokenLogo token={transaction.aoInfo?.logo || "AR"} name={transaction.aoInfo?.tickerName} />
+          <TokenLogo
+            style={{ flexShrink: 0 }}
+            token={transaction.aoInfo?.logo || "AR"}
+            name={transaction.aoInfo?.tickerName}
+          />
           <Section>
             <Main>{getTransactionDescription(transaction)}</Main>
             <Secondary>


### PR DESCRIPTION
## Summary

This PR prevents some token activity logo from shrinking.

| Before | After |
|--------|-------|
| <img width="504" height="274" alt="image" src="https://github.com/user-attachments/assets/84306420-70d7-44c5-8f07-c7942271428c" /> | <img width="476" height="278" alt="image" src="https://github.com/user-attachments/assets/6ff45136-1a00-437a-86ac-eb033cbcaaa7" /> |

