### PR TITLE
fix: improve swap history & others

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -4387,12 +4387,16 @@
     "description": "Network/Provider fee text"
   },
   "swap_error": {
-    "message": "Swap error. Please try again.",
+    "message": "Swap failed. Please try again.",
     "description": "Generic error message shown when a swap transaction fails" 
   },
   "swap_error_increase_slippage": {
     "message": "Swap failed due to a price change. Try again increasing slippage.",
     "description": "Error message shown when a swap transaction fails due to invalid amount out"
+  },
+  "swap_error_permaswap_order": {
+    "message": "Failed to create permaswap order. Please try again.",
+    "description": "Error shown when permaswap order creation fails"
   },
   "free": {
     "message": "Free!",

--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -4391,7 +4391,7 @@
     "description": "Generic error message shown when a swap transaction fails" 
   },
   "swap_error_increase_slippage": {
-    "message": "Swap error. Increase slippage and try again.",
+    "message": "Swap failed due to a price change. Try again increasing slippage.",
     "description": "Error message shown when a swap transaction fails due to invalid amount out"
   },
   "free": {

--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -4390,6 +4390,10 @@
     "message": "Swap error. Please try again.",
     "description": "Generic error message shown when a swap transaction fails" 
   },
+  "swap_error_increase_slippage": {
+    "message": "Swap error. Increase slippage and try again.",
+    "description": "Error message shown when a swap transaction fails due to invalid amount out"
+  },
   "free": {
     "message": "Free!",
     "description": "Free text"

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -4351,7 +4351,7 @@
       "description": "Swap error text"
     },
     "swap_error_increase_slippage": {
-      "message": "交换错误。请增加滑点并再试一次。",
+      "message": "兑换失败，原因是价格发生了变化。请尝试再次进行，并提高滑点。",
       "description": "Error message shown when a swap transaction fails due to invalid amount out"
     },
     "free": {

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -4350,6 +4350,10 @@
       "message": "交换错误。请再试一次。",
       "description": "Swap error text"
     },
+    "swap_error_increase_slippage": {
+      "message": "交换错误。请增加滑点并再试一次。",
+      "description": "Error message shown when a swap transaction fails due to invalid amount out"
+    },
     "free": {
       "message": "免费！",
       "description": "Free text"

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -4347,12 +4347,16 @@
       "description": "Network/Provider fee text"
     },
     "swap_error": {
-      "message": "交换错误。请再试一次。",
+      "message": "交换失败。请再试一次。",
       "description": "Swap error text"
     },
     "swap_error_increase_slippage": {
       "message": "兑换失败，原因是价格发生了变化。请尝试再次进行，并提高滑点。",
       "description": "Error message shown when a swap transaction fails due to invalid amount out"
+    },
+    "swap_error_permaswap_order": {
+      "message": "创建 permaswap 订单失败。请再试一次。",
+      "description": "Error shown when permaswap order creation fails"
     },
     "free": {
       "message": "免费！",

--- a/src/routes/popup/index.tsx
+++ b/src/routes/popup/index.tsx
@@ -21,7 +21,7 @@ import { scheduleSwapExecution } from "~utils/agents/swap";
 import { WandAnnouncementPopup } from "~components/popup/home/WandAnnouncementPopup";
 import { AnnouncementsCarousel } from "./swap/components/AnnouncementsCarousel";
 import { SwapAnnouncementPopup } from "./swap/components/SwapAnnouncementPopup";
-import { checkForCompletedSwapToShow } from "./swap/utils/swap.progress";
+import { checkForFinishedSwapToShow } from "./swap/utils/swap.progress";
 import { PopupPaths } from "~wallets/router/popup/popup.routes";
 
 export function HomeView() {
@@ -120,14 +120,18 @@ export function HomeView() {
   }, [wallet, announcement]);
 
   useAsyncEffect(async () => {
-    // Check for completed swaps to show on popup open
+    // Check for finished swaps to show on popup open
     try {
-      const completedSwap = await checkForCompletedSwapToShow();
+      const completedSwap = await checkForFinishedSwapToShow();
       if (completedSwap) {
-        navigate(PopupPaths.SwapComplete);
+        if (completedSwap.status === "completed") {
+          navigate(PopupPaths.SwapComplete);
+        } else {
+          navigate(PopupPaths.SwapFailed);
+        }
       }
     } catch (error) {
-      console.error("Error checking for completed swaps:", error);
+      console.error("Error checking for finished swaps:", error);
     }
   }, [navigate]);
 

--- a/src/routes/popup/swap/history.tsx
+++ b/src/routes/popup/swap/history.tsx
@@ -29,7 +29,7 @@ export function SwapHistoryView() {
 
       <Wrapper>
         <Flex gap={12} direction="column">
-          {!loading && transactions.length > 0 ? (
+          {transactions.length > 0 ? (
             transactions.map((tx, index) => <SwapHistoryListItem key={`${tx.txId}-${index}`} tx={tx} />)
           ) : (
             <Empty>

--- a/src/routes/popup/swap/history.tsx
+++ b/src/routes/popup/swap/history.tsx
@@ -17,7 +17,7 @@ import { TokenLogo } from "~components/popup/TokenLogo";
 import { PageType, trackPage } from "~utils/analytics";
 
 export function SwapHistoryView() {
-  const { transactions, loading, hasNextPage, fetchTransactions } = useSwapTransactions();
+  const { transactions, loading, hasNextPage, fetchNextPage } = useSwapTransactions();
 
   useEffect(() => {
     trackPage(PageType.SWAP_HISTORY);
@@ -49,7 +49,7 @@ export function SwapHistoryView() {
             disabled={!hasNextPage || loading}
             style={{ alignSelf: "center", marginTop: "5px" }}
             loading={loading}
-            onClick={() => fetchTransactions()}>
+            onClick={() => fetchNextPage()}>
             {browser.i18n.getMessage("load_more")}...
           </Button>
         )}

--- a/src/routes/popup/swap/history.tsx
+++ b/src/routes/popup/swap/history.tsx
@@ -29,7 +29,7 @@ export function SwapHistoryView() {
 
       <Wrapper>
         <Flex gap={12} direction="column">
-          {transactions.length > 0 ? (
+          {!loading && transactions.length > 0 ? (
             transactions.map((tx, index) => <SwapHistoryListItem key={`${tx.txId}-${index}`} tx={tx} />)
           ) : (
             <Empty>

--- a/src/routes/popup/swap/index.tsx
+++ b/src/routes/popup/swap/index.tsx
@@ -161,6 +161,7 @@ export function SwapView() {
       sendToken: { ...sendToken, Logo: sendTokenLogo },
       receiveToken: { ...receiveToken, Logo: receiveTokenLogo },
       wanderFee,
+      networkFee,
       amountIn,
       swapper: activeAddress,
       tier: defiFeeDetails.tier,

--- a/src/routes/popup/swap/review.tsx
+++ b/src/routes/popup/swap/review.tsx
@@ -43,9 +43,9 @@ import AnimatedQRPlayer from "~components/hardware/AnimatedQRPlayer";
 import { Spacer } from "~components/embed";
 import { SignType } from "@keystonehq/bc-ur-registry-arweave";
 import Arweave from "arweave";
-import { HARDWARE_WALLET_API_NOT_SUPPORTED_ERR_MSG } from "~utils/wallets/wallets.constants";
 import { AR_PROCESS_ID } from "~tokens/aoTokens/ao.constants";
 import { PoolTypeEnum } from "./utils/swap.constants";
+import { OrderError } from "./utils/dex/dex.utils";
 
 export function SwapReviewView() {
   const { navigate } = useLocation();
@@ -100,7 +100,7 @@ export function SwapReviewView() {
     amountIn,
     poolId: swapData?.selectedPoolInfo?.poolId,
     poolType: swapData?.selectedPoolInfo?.poolType,
-    stopFetching: isExecutingSwap || !!hardwareStatus,
+    stopFetching: isExecutingSwap,
     wanderFeePercent: +defiFeeDetails.finalFeePercent,
   });
 
@@ -244,14 +244,8 @@ export function SwapReviewView() {
       navigate(PopupPaths.SwapProgress);
     } catch (err) {
       log(LOG_GROUP.SWAP, "Error executing swap", err);
-      const errorMessage = err instanceof Error ? err.message : "Swap error. Please try again.";
-      setToast({
-        type: "error",
-        content: errorMessage.includes(HARDWARE_WALLET_API_NOT_SUPPORTED_ERR_MSG)
-          ? browser.i18n.getMessage("wallet_hardware_unsupported")
-          : browser.i18n.getMessage("swap_error"),
-        duration: 2400,
-      });
+      const errorMessage = err instanceof OrderError ? err.message : browser.i18n.getMessage("swap_error");
+      setToast({ type: "error", content: errorMessage, duration: 2400 });
     } finally {
       setIsExecutingSwap(false);
       setHardwareStatus(null);

--- a/src/routes/popup/swap/review.tsx
+++ b/src/routes/popup/swap/review.tsx
@@ -239,7 +239,7 @@ export function SwapReviewView() {
       await swapsArray.push(updatedSwapData);
 
       // Start background monitoring
-      await startSwapMonitoring();
+      await startSwapMonitoring(true);
 
       navigate(PopupPaths.SwapProgress);
     } catch (err) {

--- a/src/routes/popup/swap/review.tsx
+++ b/src/routes/popup/swap/review.tsx
@@ -217,7 +217,7 @@ export function SwapReviewView() {
         tokenIn: sendToken?.processId,
         tokenOut: receiveToken?.processId,
         amountIn: selectedPoolInfo.quoteOutput.transferAmountIn,
-        minAmountOut: selectedPoolInfo.quoteOutput.amountOut,
+        minAmountOut: selectedPoolInfo.quoteOutput.minAmountOut,
         poolId: selectedPoolInfo.poolId,
         tags,
         keystoneSigner: wallet?.type === "hardware" ? keystoneSigner : undefined,

--- a/src/routes/popup/swap/transaction-details.tsx
+++ b/src/routes/popup/swap/transaction-details.tsx
@@ -119,7 +119,11 @@ export function SwapTransactionDetailsView({ params: { id } }: SwapTransactionDe
                   </Text>
                   <Flex direction="row" align="center" gap={4}>
                     <TokenLogo size={24} token={transaction.tokenIn} fetchMissingLogo />
-                    <TokenValueWithTooltip formattedValue={valueInFormatted} ticker={transaction.tokenIn.Ticker} />
+                    <TokenValueWithTooltip
+                      formattedValue={valueInFormatted}
+                      ticker={transaction.tokenIn.Ticker}
+                      tooltipPosition="bottom"
+                    />
                   </Flex>
                 </Flex>
                 <Flex direction="column" gap={8}>
@@ -150,7 +154,12 @@ export function SwapTransactionDetailsView({ params: { id } }: SwapTransactionDe
                   />
                   <TransactionDetailItem
                     title={browser.i18n.getMessage("wander_fee")}
-                    value={`${transaction.wanderFee} ${transaction.tokenIn.Ticker}`}
+                    valueColor={transaction.wanderFee === "0" && "#9787FF"}
+                    value={
+                      transaction.wanderFee === "0"
+                        ? browser.i18n.getMessage("free")
+                        : `${transaction.wanderFee} ${transaction.tokenIn.Ticker}`
+                    }
                   />
                   <TransactionDetailItem title={browser.i18n.getMessage("slippage")} value={transaction.slippage} />
                   <TransactionDetailItem

--- a/src/routes/popup/swap/utils/alarms/swap-monitor/swap-fee-processor.ts
+++ b/src/routes/popup/swap/utils/alarms/swap-monitor/swap-fee-processor.ts
@@ -6,7 +6,7 @@ import { connect } from "@permaweb/aoconnect";
 import { defaultConfig } from "~tokens/aoTokens/config";
 import { queryClient } from "~utils/tanstack";
 import { defaultOptions } from "~tokens/hooks";
-import { createDataItemSigner, fetchTokenBalance, getBotegaPrice } from "~tokens/aoTokens/ao";
+import { createDataItemSigner, fetchTokenBalance, getBotegaPrice, getTagValue } from "~tokens/aoTokens/ao";
 import { isWalletUnlocked } from "~wallets/auth";
 import { AR_PROCESS_ID } from "~tokens/aoTokens/ao.constants";
 import { Mutex } from "~utils/mutex";
@@ -15,9 +15,17 @@ import { findGateway, retryWithGateways } from "~gateways/wayfinder";
 import { getSetting } from "~settings";
 import { EventType, trackDirect } from "~utils/analytics";
 import { getDefiFeeDetailsForTier } from "~utils/tier/utils";
-import { assertTransferResult, fromTokenBaseUnits, getFeeTransactionTags, toFixed } from "../../swap.utils";
+import {
+  assertTransferResult,
+  fromTokenBaseUnits,
+  getFeeTransactionTags,
+  toFixed,
+  validateGqlResponse,
+} from "../../swap.utils";
 import Arweave from "arweave";
 import { WANDER_FEE_RECIPIENT } from "../../swap.constants";
+import { gql } from "~gateways/api";
+import { retryWithDelay } from "~utils/promises/retry";
 
 const aoInstance = connect(defaultConfig);
 
@@ -59,6 +67,12 @@ export async function processWanderFee(swap: SwapData): Promise<boolean> {
     const feeValue = extractFeeValue(swap.wanderFee.finalFee);
     if (!feeValue || feeValue.isZero()) {
       log(LOG_GROUP.SWAP, "No Wander fee to process");
+      return true;
+    }
+
+    const isAlreadyProcessed = await checkIfWanderFeeAlreadyProcessed(swap);
+    if (isAlreadyProcessed) {
+      log(LOG_GROUP.SWAP, "Wander fee already processed");
       return true;
     }
 
@@ -296,5 +310,63 @@ export async function trackSwapAnalytics(swap: SwapData, status: "Success" | "Fa
     await trackDirect(EventType.SWAP_COMPLETED, swapCompletedData);
   } catch (error) {
     log(LOG_GROUP.SWAP, "Error tracking swap analytics", error);
+  }
+}
+
+function getSwapFeeQuery(isAo: boolean) {
+  return `
+query($swapTxId: String!) {
+  transactions(
+    first: 1,
+    tags: [
+      ${isAo ? `{ name: "Data-Protocol", values: ["ao"] },` : ""}
+      { name: "Fee-Type", values: ["Swap"] },
+      { name: "Swap-Tx-Id", values: [$swapTxId] },
+      { name: "Client", values: ["Wander"] },
+    ],
+  ) {
+    edges {
+      node {
+        id
+        ingested_at
+        recipient
+        owner { address }
+        block { timestamp, height }
+        tags { name, value }
+      }
+    }
+  }
+}`;
+}
+
+async function checkIfWanderFeeAlreadyProcessed(swap: SwapData): Promise<boolean> {
+  try {
+    const isAo = swap.sendToken.processId !== AR_PROCESS_ID;
+    const result = await retryWithDelay(
+      async () => {
+        const gateway = await findGateway({ random: true });
+        const result = await gql(getSwapFeeQuery(isAo), { swapTxId: swap.transferId }, gateway);
+        validateGqlResponse(result);
+        return result;
+      },
+      2,
+      1000,
+    );
+
+    const tx = result?.data?.transactions?.edges[0]?.node;
+    const txId = tx?.id;
+    if (!txId) return false;
+
+    const recipient = getTagValue("Recipient", tx?.tags || []);
+    if (recipient !== WANDER_FEE_RECIPIENT && tx?.recipient !== WANDER_FEE_RECIPIENT) return false;
+
+    if (isAo) {
+      await assertTransferResult(txId, swap.sendToken.processId);
+    }
+
+    return true;
+  } catch (error) {
+    log(LOG_GROUP.SWAP, "Error checking if wander fee already processed", error);
+    return false;
   }
 }

--- a/src/routes/popup/swap/utils/alarms/swap-monitor/swap-monitor-alarm.handler.ts
+++ b/src/routes/popup/swap/utils/alarms/swap-monitor/swap-monitor-alarm.handler.ts
@@ -424,8 +424,8 @@ async function scheduleNextSwapMonitorCheck() {
 
   // Continue monitoring if there are pending swaps OR (completed swaps needing fee processing AND wallet is unlocked)
   if (totalToMonitor > 0) {
-    // Calculate the next check interval based on pending swaps
-    const nextCheckInterval = calculateNextCheckInterval(pendingSwaps);
+    // Calculate the next check interval based on all swaps that need monitoring
+    const nextCheckInterval = calculateNextCheckInterval([...pendingSwaps, ...completedSwapsNeedingFees]);
 
     await browser.alarms.create(SWAP_MONITOR_ALARM_NAME, { when: Date.now() + nextCheckInterval });
     const monitoringNote = walletUnlocked

--- a/src/routes/popup/swap/utils/alarms/swap-monitor/swap-monitor-alarm.handler.ts
+++ b/src/routes/popup/swap/utils/alarms/swap-monitor/swap-monitor-alarm.handler.ts
@@ -14,6 +14,7 @@ import { getAoTokens } from "~tokens";
 
 const SWAP_MONITOR_ALARM_NAME = "swap-monitor";
 const SWAP_CHECK_INTERVAL_MS = 120_000;
+const MIN_TIME_BEFORE_RESTART_MS = 30000;
 let isSwapMonitoringActive = false;
 
 // Intervals for DEX swaps: 10s, 30s, 60s, 120s
@@ -361,7 +362,7 @@ export async function startSwapMonitoring(forceRestart: boolean = false) {
 
   if (existingAlarm && forceRestart) {
     const timeUntilNextCheck = existingAlarm.scheduledTime - Date.now();
-    if (timeUntilNextCheck > 30000 && !isSwapMonitoringActive) {
+    if (timeUntilNextCheck > MIN_TIME_BEFORE_RESTART_MS && !isSwapMonitoringActive) {
       log(LOG_GROUP.SWAP, "Force restarting swap monitoring (existing alarm will be cleared)");
       await browser.alarms.clear(SWAP_MONITOR_ALARM_NAME);
     } else {

--- a/src/routes/popup/swap/utils/alarms/swap-monitor/swap-monitor-alarm.handler.ts
+++ b/src/routes/popup/swap/utils/alarms/swap-monitor/swap-monitor-alarm.handler.ts
@@ -5,7 +5,6 @@ import { queryClient } from "~utils/tanstack";
 import { log, LOG_GROUP } from "~utils/log/log.utils";
 import type { SwapData } from "../../swap.types";
 import { processWanderFee, cleanupFeeProcessingMutex, trackSwapAnalytics } from "./swap-fee-processor";
-// import { sendSwapNotification } from "./swap-notifications";
 import { OrderError } from "../../dex/dex.utils";
 import { isWalletUnlocked } from "~wallets/auth";
 import { AR_PROCESS_ID } from "~tokens/aoTokens/ao.constants";
@@ -14,7 +13,16 @@ import { ExtensionStorage } from "~utils/storage";
 import { getAoTokens } from "~tokens";
 
 const SWAP_MONITOR_ALARM_NAME = "swap-monitor";
-const SWAP_CHECK_INTERVAL_MINUTES = 2; // Check every 2 minutes
+const SWAP_CHECK_INTERVAL_MS = 120_000;
+let isSwapMonitoringActive = false;
+
+// Intervals for DEX swaps: 10s, 30s, 60s, 120s
+const DEX_SWAP_CHECK_INTERVALS = [
+  10_000, // 1st interval: 10 seconds
+  30_000, // 2nd interval: 30 seconds
+  60_000, // 3rd interval: 60 seconds
+  120_000, // 4th+ interval: 120 seconds
+];
 
 /**
  * Background alarm handler for monitoring ongoing swaps.
@@ -22,6 +30,7 @@ const SWAP_CHECK_INTERVAL_MINUTES = 2; // Check every 2 minutes
  */
 export async function handleSwapMonitorAlarm(alarmInfo?: Alarms.Alarm) {
   if (alarmInfo?.name !== SWAP_MONITOR_ALARM_NAME) return;
+  isSwapMonitoringActive = true;
 
   try {
     await checkPendingSwaps();
@@ -30,7 +39,9 @@ export async function handleSwapMonitorAlarm(alarmInfo?: Alarms.Alarm) {
   }
 
   // Schedule next check
-  await scheduleNextSwapMonitorCheck();
+  await scheduleNextSwapMonitorCheck().finally(() => {
+    isSwapMonitoringActive = false;
+  });
 }
 
 /**
@@ -95,6 +106,37 @@ async function checkPendingSwaps() {
 }
 
 /**
+ * Get the check interval for a swap
+ * @param swap The swap data
+ */
+function getCheckInterval(swap: SwapData): number {
+  const poolType = swap.selectedPoolInfo.poolType;
+  const isDexSwap = poolType === "botega" || poolType === "permaswap";
+
+  // Non-DEX swaps: always 2 minutes
+  if (!isDexSwap) return SWAP_CHECK_INTERVAL_MS;
+
+  // DEX swaps: escalating intervals based on attempt count
+  const attempts = swap.checkAttempts || 0;
+  const intervalIndex = Math.min(attempts - 1, DEX_SWAP_CHECK_INTERVALS.length - 1);
+
+  return DEX_SWAP_CHECK_INTERVALS[intervalIndex];
+}
+
+/**
+ * Check if enough time has passed since the last check for this swap
+ */
+function shouldCheckSwapNow(swap: SwapData): boolean {
+  // First check - always allow immediately
+  if (!swap.lastCheckTime) return true;
+
+  const nextInterval = getCheckInterval(swap);
+  const timeSinceLastCheck = Date.now() - swap.lastCheckTime;
+
+  return timeSinceLastCheck >= nextInterval;
+}
+
+/**
  * Check the status of a single swap and process accordingly
  */
 async function checkSingleSwap(swap: SwapData) {
@@ -109,6 +151,45 @@ async function checkSingleSwap(swap: SwapData) {
     return;
   }
 
+  // Check if swap is a DEX swap
+  const isDexSwap = poolType === "botega" || poolType === "permaswap";
+
+  // Check if enough time has passed since the last check
+  if (!shouldCheckSwapNow(swap)) {
+    log(LOG_GROUP.SWAP, `Skipping ${isDexSwap ? "DEX" : "Bridge"} swap ${swap.transferId} - waiting for next check`);
+    return;
+  }
+
+  // Update check attempts and last check time
+  const updatedSwap = {
+    ...swap,
+    checkAttempts: (swap.checkAttempts || 0) + 1,
+    lastCheckTime: Date.now(),
+  };
+
+  // Update the swap in storage with new check metadata
+  await swapsArray.updateWhere(
+    (s) => s.transferId === swap.transferId,
+    (s) => ({
+      ...s,
+      checkAttempts: updatedSwap.checkAttempts,
+      lastCheckTime: updatedSwap.lastCheckTime,
+    }),
+  );
+
+  // Show next check timing for DEX swaps
+  let nextCheckMessage = "";
+  if (isDexSwap) {
+    const intervalMs = getCheckInterval(updatedSwap);
+    const intervalSeconds = Math.round(intervalMs / 1000);
+    nextCheckMessage = `, next check in ${intervalSeconds}s`;
+  }
+
+  log(
+    LOG_GROUP.SWAP,
+    `Checking ${isDexSwap ? "DEX" : "Bridge"} swap ${swap.transferId} (attempt ${updatedSwap.checkAttempts}${nextCheckMessage})`,
+  );
+
   try {
     const result = await readSwapResultFn(poolType, {
       orderId: swap.transferId,
@@ -118,19 +199,19 @@ async function checkSingleSwap(swap: SwapData) {
       isAo: swap.sendToken?.processId !== AR_PROCESS_ID,
     });
     const expectedOutput = swap.selectedPoolInfo.quoteOutput.amountOut;
-    swap.selectedPoolInfo.quoteOutput.amountOut = result?.amountOut || expectedOutput;
-    await handleSwapSuccess(swap);
+    updatedSwap.selectedPoolInfo.quoteOutput.amountOut = result?.amountOut || expectedOutput;
+    await handleSwapSuccess(updatedSwap);
   } catch (error) {
     if (error instanceof OrderError) {
-      await handleSwapFailure(swap);
+      await handleSwapFailure(updatedSwap);
     } else {
       // If there's an error checking status, treat as potential failure after timeout
-      const swapAge = Date.now() - (swap.timestamp || Date.now());
+      const swapAge = Date.now() - (updatedSwap.timestamp || Date.now());
       const SWAP_TIMEOUT_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
       if (swapAge > SWAP_TIMEOUT_MS) {
-        log(LOG_GROUP.SWAP, `Swap ${swap.transferId} timed out with error after 7 days`, error);
-        await handleSwapFailure(swap);
+        log(LOG_GROUP.SWAP, `Swap ${updatedSwap.transferId} timed out with error after 7 days`, error);
+        await handleSwapFailure(updatedSwap);
       }
     }
   }
@@ -279,8 +360,19 @@ export async function startSwapMonitoring(forceRestart: boolean = false) {
   }
 
   if (existingAlarm && forceRestart) {
-    log(LOG_GROUP.SWAP, "Force restarting swap monitoring (existing alarm will be cleared)");
-    await browser.alarms.clear(SWAP_MONITOR_ALARM_NAME);
+    const timeUntilNextCheck = existingAlarm.scheduledTime - Date.now();
+    if (timeUntilNextCheck > 30000 && !isSwapMonitoringActive) {
+      log(LOG_GROUP.SWAP, "Force restarting swap monitoring (existing alarm will be cleared)");
+      await browser.alarms.clear(SWAP_MONITOR_ALARM_NAME);
+    } else {
+      log(LOG_GROUP.SWAP, "Skipping restart - next check is too soon");
+      return;
+    }
+  }
+
+  if (isSwapMonitoringActive) {
+    log(LOG_GROUP.SWAP, "Swap monitoring is already active, skipping restart");
+    return;
   }
 
   // Schedule immediate check
@@ -289,6 +381,25 @@ export async function startSwapMonitoring(forceRestart: boolean = false) {
   });
 
   log(LOG_GROUP.SWAP, "Swap monitoring started");
+}
+
+/**
+ * Calculate the next check interval needed for all swaps
+ */
+function calculateNextCheckInterval(pendingSwaps: SwapData[]): number {
+  let shortestInterval = SWAP_CHECK_INTERVAL_MS; // Default 2 minutes in ms
+
+  for (const swap of pendingSwaps) {
+    const poolType = swap.selectedPoolInfo.poolType;
+    const isDexSwap = poolType === "botega" || poolType === "permaswap";
+
+    if (isDexSwap) {
+      const interval = getCheckInterval(swap);
+      shortestInterval = Math.min(shortestInterval, interval);
+    }
+  }
+
+  return shortestInterval;
 }
 
 /**
@@ -312,18 +423,21 @@ async function scheduleNextSwapMonitorCheck() {
 
   // Continue monitoring if there are pending swaps OR (completed swaps needing fee processing AND wallet is unlocked)
   if (totalToMonitor > 0) {
-    await browser.alarms.create(SWAP_MONITOR_ALARM_NAME, {
-      when: Date.now() + SWAP_CHECK_INTERVAL_MINUTES * 60 * 1000,
-    });
+    // Calculate the next check interval based on pending swaps
+    const nextCheckInterval = calculateNextCheckInterval(pendingSwaps);
+
+    await browser.alarms.create(SWAP_MONITOR_ALARM_NAME, { when: Date.now() + nextCheckInterval });
     const monitoringNote = walletUnlocked
       ? ""
       : completedSwapsNeedingFees.length > 0
         ? " (wallet locked - monitoring keystone transactions)"
         : " (wallet locked)";
 
+    const nextCheckIntervalSeconds = Math.round(nextCheckInterval / 1000);
+
     log(
       LOG_GROUP.SWAP,
-      `Next swap check scheduled in ${SWAP_CHECK_INTERVAL_MINUTES} minutes (${pendingSwaps.length} pending, ${completedSwapsNeedingFees.length} needing fees)${monitoringNote}`,
+      `Next swap check scheduled in ${nextCheckIntervalSeconds} seconds (${pendingSwaps.length} pending, ${completedSwapsNeedingFees.length} needing fees)${monitoringNote}`,
     );
   } else {
     if (walletUnlocked) {

--- a/src/routes/popup/swap/utils/bridge/bridge.utils.ts
+++ b/src/routes/popup/swap/utils/bridge/bridge.utils.ts
@@ -176,51 +176,49 @@ export function validateVentoBridgeTransaction(
 }
 
 export async function getAoxBridgeTransactions(address: string, cursor = "0") {
-  const result = await retryWithDelay(async () => {
+  const result = await retryWithDelay<AoxBridgeTransactionResponse>(async () => {
     const data = await fetch(`https://api.aox.xyz/txs?address=${address}&count=10&cursor=${cursor}`);
     if (!data.ok) throw new Error("Failed to fetch bridge transaction");
-
-    const { txs, hasNextPage } = (await data.json()) as AoxBridgeTransactionResponse;
-
-    if (txs.length === 0) return { txs: [], hasNextPage, cursor };
-
-    cursor = txs[txs.length - 1].rawId.toString();
-
-    const arweaveTxs = txs.filter((tx) => tx.chainType === "arweave" && aoxBridgeTxTypes.has(tx.txType));
-
-    const txMap = new Map<string, AoxBridgeTransaction>();
-
-    for (const tx of arweaveTxs) {
-      txMap.set(tx.txId, tx);
-    }
-
-    const txIds = Array.from(txMap.keys());
-    const transactions = await retryWithDelay(async () => {
-      const data = await gql(SWAP_TXS_QUERY, { txIds }, goldskyGateway);
-
-      validateGqlResponse(data);
-
-      const edges = data?.data?.transactions?.edges || [];
-      for (const edge of edges) {
-        const swapTx = txMap.get(edge.node.id);
-        if (swapTx) {
-          edge.node.tags.push(
-            ...[
-              { name: "Bridge-Status", value: swapTx.status },
-              { name: "To-Quantity", value: swapTx.quantity },
-            ],
-          );
-        }
-      }
-
-      return edges;
-    }, 2);
-
-    const parsedTransactions = transactions.map(parseSwapTransaction).filter(Boolean);
-    return { txs: parsedTransactions, hasNextPage, cursor };
+    return data.json();
   }, 2);
 
-  return result;
+  const { txs, hasNextPage } = result;
+  if (txs.length === 0) return { txs: [], hasNextPage, cursor };
+
+  cursor = txs[txs.length - 1].rawId.toString();
+
+  const arweaveTxs = txs.filter((tx) => tx.chainType === "arweave" && aoxBridgeTxTypes.has(tx.txType));
+
+  const txMap = new Map<string, AoxBridgeTransaction>();
+
+  for (const tx of arweaveTxs) {
+    txMap.set(tx.txId, tx);
+  }
+
+  const txIds = Array.from(txMap.keys());
+  const transactions = await retryWithDelay(async () => {
+    const data = await gql(SWAP_TXS_QUERY, { txIds }, goldskyGateway);
+
+    validateGqlResponse(data);
+
+    const edges = data?.data?.transactions?.edges || [];
+    for (const edge of edges) {
+      const swapTx = txMap.get(edge.node.id);
+      if (swapTx) {
+        edge.node.tags.push(
+          ...[
+            { name: "Bridge-Status", value: swapTx.status },
+            { name: "To-Quantity", value: swapTx.quantity },
+          ],
+        );
+      }
+    }
+
+    return edges;
+  }, 2);
+
+  const parsedTransactions = transactions.map(parseSwapTransaction).filter(Boolean);
+  return { txs: parsedTransactions, hasNextPage, cursor };
 }
 
 export async function getVentoBridgeTransactions(address: string, cursor = "") {

--- a/src/routes/popup/swap/utils/dex/dex.botega.ts
+++ b/src/routes/popup/swap/utils/dex/dex.botega.ts
@@ -72,7 +72,7 @@ export async function getExpectedOutput({
   const protocolFeeQuantity = getTagValue("Protocol-Fee-Quantity", tags) || "0";
   const tokenInFee = BigNumber(lpFeeQuantity).plus(protocolFeeQuantity).toFixed(0, BigNumber.ROUND_DOWN);
   const minAmountOut = BigNumber(amountOut)
-    .multipliedBy(BigNumber(1).minus(slippage || 0))
+    .multipliedBy(BigNumber(100).minus(slippage || 0))
     .div(100)
     .toFixed(0, BigNumber.ROUND_DOWN);
   const poolAmountIn = amountInWithoutWanderFee;

--- a/src/routes/popup/swap/utils/dex/dex.constants.ts
+++ b/src/routes/popup/swap/utils/dex/dex.constants.ts
@@ -1,45 +1,15 @@
-export const PERMASWAP_ORDERBOOK = "rKpOUxssKxgfXQOpaCq22npHno6oRw66L3kZeoo_Ndk" as const;
-export const BOTEGA_AMM_FACTORY = "3XBGLrygs11K63F_7mldWz4veNx6Llg6hI2yZs8LKHo" as const;
-
-export const BOTEGA_SWAP_CONFIRMATION_QUERY_WITH_CURSOR = `
-query($address: String!, $after: String) {
-  transactions(
-    first: 10,
-    tags: [
-      {name: "Data-Protocol", values: ["ao"]},
-      {name: "Action", values: ["Order-Confirmation", "Order-Error"]},
-      { name: "X-Client", values: ["Wander"]},
-      { name: "X-Type", values: ["Swap"]} 
-    ],
-    recipients: [$address],
-    after: $after
-  ) {
-    pageInfo {
-      hasNextPage
-    }
-    edges {
-      cursor
-      node {
-        id
-        recipient
-        owner { address }
-        block { timestamp, height }
-        tags { name, value }
-      }
-    }
-  }
-}`;
-
-export const PERMASWAP_SWAP_QUERY_WITH_CURSOR = `
-query($address: String!, $after: String) {
+export const DEX_SWAP_QUERY_WITH_CURSOR = `
+query($address: String!, $provider: String!, $after: String) {
   transactions(
     first: 10,
     tags: [
       {name: "Data-Protocol", values: ["ao"]},
       {name: "Action", values: ["Transfer"]},
       { name: "X-Client", values: ["Wander"]},
-      { name: "X-Type", values: ["Swap"]} 
+      { name: "X-Type", values: ["Swap"]},
+      { name: "X-Provider", values: [$provider] },
     ],
+    sort: INGESTED_AT_DESC,
     owners: [$address],
     after: $after
   ) {
@@ -50,6 +20,33 @@ query($address: String!, $after: String) {
       cursor
       node {
         id
+        ingested_at
+        recipient
+        owner { address }
+        block { timestamp, height }
+        tags { name, value }
+      }
+    }
+  }
+}`;
+
+export const BOTEGA_SWAP_CONFIRMATION_QUERY = `
+query($address: String!, $pushedFors: [String!]!) {
+  transactions(
+    first: 100,
+    tags: [
+      { name: "Data-Protocol", values: ["ao"]},
+      { name: "Action", values: ["Order-Confirmation", "Order-Error"]},
+      { name: "X-Client", values: ["Wander"]},
+      { name: "X-Type", values: ["Swap"]},
+      { name: "Relay-To", values: [$address] },
+      { name: "Pushed-For", values: $pushedFors },
+    ],
+  ) {
+    edges {
+      node {
+        id
+        ingested_at
         recipient
         owner { address }
         block { timestamp, height }
@@ -71,34 +68,9 @@ query($address: String!, $pushedFors: [String!]!) {
     ],
   ) {
     edges {
-      cursor
       node {
         id
-        recipient
-        owner { address }
-        block { timestamp, height }
-        tags { name, value }
-      }
-    }
-  }
-}`;
-
-export const SWAP_TRANSFER_QUERY = `
-query($address: String!, $pushedFors: [String!]!) {
-  transactions(
-    first: 10,
-    tags: [
-      {name: "Data-Protocol", values: ["ao"]},
-      {name: "Action", values: ["Transfer"]},
-      { name: "X-Client", values: ["Wander"]},
-      { name: "X-Type", values: ["Swap"]},
-      { name: "Pushed-For", values: $pushedFors },
-    ],
-    owners: [$address],
-  ) {
-    edges {
-      node {
-        id
+        ingested_at
         recipient
         owner { address }
         block { timestamp, height }
@@ -121,6 +93,7 @@ query($txId: ID!) {
     edges {
       node {
         id
+        ingested_at
         recipient
         owner { address }
         block { timestamp, height }
@@ -144,6 +117,7 @@ query($txId: ID!) {
     edges {
       node {
         id
+        ingested_at
         recipient
         owner { address }
         block { timestamp, height }
@@ -166,6 +140,7 @@ query($pushedFor: String!) {
     edges {
       node {
         id
+        ingested_at
         recipient
         owner { address }
         block { timestamp, height }
@@ -188,6 +163,7 @@ query($txIds: [ID!]!) {
     edges {
       node {
         id
+        ingested_at
         recipient
         owner { address }
         block { timestamp, height }
@@ -206,6 +182,7 @@ query($address: String!, $after: String) {
       { name: "X-Type", values: ["Swap"]},
       { name: "X-Provider", values: ["Vento"] },
     ],
+    sort: INGESTED_AT_DESC,
     owners: [$address],
     after: $after
   ) {
@@ -216,6 +193,7 @@ query($address: String!, $after: String) {
       cursor
       node {
         id
+        ingested_at
         recipient
         owner { address }
         block { timestamp, height }
@@ -238,6 +216,7 @@ query($pushedFors: [String!]!) {
     edges {
       node {
         id
+        ingested_at
         recipient
         owner { address }
         block { timestamp, height }

--- a/src/routes/popup/swap/utils/dex/dex.permaswap.ts
+++ b/src/routes/popup/swap/utils/dex/dex.permaswap.ts
@@ -21,6 +21,7 @@ import { freeDecryptedWallet } from "~wallets/encryption";
 import { getLinkedMessages, OrderError } from "./dex.utils";
 import { queryClient } from "~utils/tanstack";
 import { assertTransferResult, createSwapMessage } from "../swap.utils";
+import browser from "webextension-polyfill";
 
 const aoInstance = connect(defaultConfig);
 
@@ -217,6 +218,17 @@ export async function executeSwap({
         { name: "AmountOut", value: minAmountOut },
       ],
     });
+
+    try {
+      const result = await aoInstance.result({ process: poolId, message: requestMessageId });
+      const tags = result?.Messages?.[0]?.Tags || [];
+      const error = getTagValue("Error", tags);
+      if (error?.trim() === "err_invalid_amount_out") {
+        throw new OrderError(browser.i18n.getMessage("swap_error_increase_slippage"));
+      }
+    } catch (err) {
+      if (err instanceof OrderError) throw err;
+    }
 
     const { noteId, noteSettle } = await retryWithDelay(
       () => readRequestOrderResult(poolId, requestMessageId),

--- a/src/routes/popup/swap/utils/dex/dex.permaswap.ts
+++ b/src/routes/popup/swap/utils/dex/dex.permaswap.ts
@@ -162,7 +162,7 @@ export async function getExpectedOutput({
   const tokenInFee = BigNumber(issuerFeeQuantity).plus(poolFeeQuantity).toFixed(0, BigNumber.ROUND_DOWN);
   const tokenOutFee = BigNumber(holderFeeQuantity).toFixed(0, BigNumber.ROUND_DOWN);
   const minAmountOut = BigNumber(amountOut)
-    .multipliedBy(BigNumber(1).minus(slippage))
+    .multipliedBy(BigNumber(100).minus(slippage))
     .div(100)
     .toFixed(0, BigNumber.ROUND_DOWN);
   const poolAmountIn = BigNumber(amountInWithoutWanderFee).minus(tokenInFee).toFixed(0, BigNumber.ROUND_DOWN);

--- a/src/routes/popup/swap/utils/dex/dex.permaswap.ts
+++ b/src/routes/popup/swap/utils/dex/dex.permaswap.ts
@@ -237,7 +237,7 @@ export async function executeSwap({
       (attemptIndex: number) => Math.min(1000 * 2 ** attemptIndex, 30000),
     );
 
-    if (!noteId || !noteSettle) throw new Error("Failed to create Permaswap order");
+    if (!noteId || !noteSettle) throw new OrderError(browser.i18n.getMessage("swap_error_permaswap_order"));
 
     const { keystoneTx, sendMessage } = await createSwapMessage({
       process: tokenIn,

--- a/src/routes/popup/swap/utils/dex/dex.utils.ts
+++ b/src/routes/popup/swap/utils/dex/dex.utils.ts
@@ -4,10 +4,9 @@ import { gql } from "~gateways/api";
 import type { AoMessage } from "./dex.types";
 import { retryWithDelay } from "~utils/promises/retry";
 import {
-  BOTEGA_SWAP_CONFIRMATION_QUERY_WITH_CURSOR,
+  BOTEGA_SWAP_CONFIRMATION_QUERY,
+  DEX_SWAP_QUERY_WITH_CURSOR,
   PERMASWAP_SWAP_CONFIRMATION_QUERY,
-  PERMASWAP_SWAP_QUERY_WITH_CURSOR,
-  SWAP_TRANSFER_QUERY,
 } from "./dex.constants";
 import { getTagValue } from "~tokens/aoTokens/ao";
 import { parseSwapTransaction, validateGqlResponse } from "../swap.utils";
@@ -188,11 +187,8 @@ export async function getLinkedMessages(
 
 export async function getBotegaTransactions(address: string, cursor = "") {
   const result = await retryWithDelay(async () => {
-    const data = await gql(BOTEGA_SWAP_CONFIRMATION_QUERY_WITH_CURSOR, { address, after: cursor }, goldskyGateway);
-
-    // validate the response
+    const data = await gql(DEX_SWAP_QUERY_WITH_CURSOR, { address, after: cursor, provider: "Botega" }, goldskyGateway);
     validateGqlResponse(data);
-
     return data.data;
   }, 2);
 
@@ -202,47 +198,43 @@ export async function getBotegaTransactions(address: string, cursor = "") {
   cursor = edges[edges.length - 1].cursor;
   const hasNextPage = result?.transactions?.pageInfo?.hasNextPage || false;
 
-  let successfulTxs = [];
-  let failedTxs = [];
+  const pushedFors = edges.map((e) => e.node.id);
+  const swapTransferResult = await retryWithDelay(async () => {
+    const data = await gql(BOTEGA_SWAP_CONFIRMATION_QUERY, { address, pushedFors }, goldskyGateway);
+    validateGqlResponse(data);
+    return data.data;
+  }, 2);
 
-  for (const edge of edges) {
-    const tags = edge.node.tags || [];
-    const action = getTagValue("Action", tags);
-    if (action === "Order-Confirmation") {
-      successfulTxs.push(edge);
+  const swapResultMap = new Map<string, string>();
+  const swapResultTxs = swapTransferResult?.transactions?.edges || [];
+  for (const edge of swapResultTxs) {
+    const pushedFor = getTagValue("Pushed-For", edge.node.tags);
+    const action = getTagValue("Action", edge.node.tags);
+    swapResultMap.set(pushedFor, action);
+  }
+
+  edges.forEach((e) => {
+    const pushedFor = e.node.id;
+    const action = swapResultMap.get(pushedFor);
+    if (action) {
+      e.node.tags.push({ name: "Action", value: action });
     } else {
-      failedTxs.push(edge);
+      e.node.tags.push({ name: "OrderStatus", value: "Pending" });
     }
-  }
+  });
 
-  if (failedTxs.length > 0) {
-    const pushedFors = failedTxs.map((e) => e.node.id);
-    const swapTransferResult = await retryWithDelay(async () => {
-      const data = await gql(SWAP_TRANSFER_QUERY, { address, pushedFors }, goldskyGateway);
-
-      // validate the response
-      validateGqlResponse(data);
-
-      return data;
-    }, 2);
-
-    const swapTransferTxs = swapTransferResult?.data?.transactions?.edges || [];
-    const allTxs = [...successfulTxs, ...swapTransferTxs];
-    const parsedTransactions = allTxs.map(parseSwapTransaction).filter(Boolean);
-    return { txs: parsedTransactions, hasNextPage, cursor };
-  }
-
-  const parsedTransactions = successfulTxs.map(parseSwapTransaction).filter(Boolean);
+  const parsedTransactions = edges.map(parseSwapTransaction).filter(Boolean);
   return { txs: parsedTransactions, hasNextPage, cursor };
 }
 
 export async function getPermaswapTransactions(address: string, cursor = "") {
   const result = await retryWithDelay(async () => {
-    const data = await gql(PERMASWAP_SWAP_QUERY_WITH_CURSOR, { address, after: cursor }, goldskyGateway);
-
-    // validate the response
+    const data = await gql(
+      DEX_SWAP_QUERY_WITH_CURSOR,
+      { address, after: cursor, provider: "Permaswap" },
+      goldskyGateway,
+    );
     validateGqlResponse(data);
-
     return data.data;
   }, 2);
 
@@ -261,8 +253,6 @@ export async function getPermaswapTransactions(address: string, cursor = "") {
   const pushedFors = Array.from(txMap.keys());
   const orderNotices = await retryWithDelay(async () => {
     const data = await gql(PERMASWAP_SWAP_CONFIRMATION_QUERY, { address, pushedFors }, goldskyGateway);
-
-    // validate the response
     validateGqlResponse(data);
 
     const edges = data?.data?.transactions?.edges || [];

--- a/src/routes/popup/swap/utils/dex/dex.utils.ts
+++ b/src/routes/popup/swap/utils/dex/dex.utils.ts
@@ -193,47 +193,47 @@ export async function getBotegaTransactions(address: string, cursor = "") {
     // validate the response
     validateGqlResponse(data);
 
-    const edges = data?.data?.transactions?.edges || [];
-    if (edges.length === 0) return { txs: [], hasNextPage: false, cursor };
-
-    cursor = edges[edges.length - 1].cursor;
-    const hasNextPage = data?.data?.transactions?.pageInfo?.hasNextPage || false;
-
-    let successfulTxs = [];
-    let failedTxs = [];
-
-    for (const edge of edges) {
-      const tags = edge.node.tags || [];
-      const action = getTagValue("Action", tags);
-      if (action === "Order-Confirmation") {
-        successfulTxs.push(edge);
-      } else {
-        failedTxs.push(edge);
-      }
-    }
-
-    if (failedTxs.length > 0) {
-      const pushedFors = failedTxs.map((e) => e.node.id);
-      const swapTransferResult = await retryWithDelay(async () => {
-        const data = await gql(SWAP_TRANSFER_QUERY, { address, pushedFors }, goldskyGateway);
-
-        // validate the response
-        validateGqlResponse(data);
-
-        return data;
-      }, 2);
-
-      const swapTransferTxs = swapTransferResult?.data?.transactions?.edges || [];
-      const allTxs = [...successfulTxs, ...swapTransferTxs];
-      const parsedTransactions = allTxs.map(parseSwapTransaction).filter(Boolean);
-      return { txs: parsedTransactions, hasNextPage, cursor };
-    }
-
-    const parsedTransactions = successfulTxs.map(parseSwapTransaction).filter(Boolean);
-    return { txs: parsedTransactions, hasNextPage, cursor };
+    return data.data;
   }, 2);
 
-  return result;
+  const edges = result?.transactions?.edges || [];
+  if (edges.length === 0) return { txs: [], hasNextPage: false, cursor };
+
+  cursor = edges[edges.length - 1].cursor;
+  const hasNextPage = result?.transactions?.pageInfo?.hasNextPage || false;
+
+  let successfulTxs = [];
+  let failedTxs = [];
+
+  for (const edge of edges) {
+    const tags = edge.node.tags || [];
+    const action = getTagValue("Action", tags);
+    if (action === "Order-Confirmation") {
+      successfulTxs.push(edge);
+    } else {
+      failedTxs.push(edge);
+    }
+  }
+
+  if (failedTxs.length > 0) {
+    const pushedFors = failedTxs.map((e) => e.node.id);
+    const swapTransferResult = await retryWithDelay(async () => {
+      const data = await gql(SWAP_TRANSFER_QUERY, { address, pushedFors }, goldskyGateway);
+
+      // validate the response
+      validateGqlResponse(data);
+
+      return data;
+    }, 2);
+
+    const swapTransferTxs = swapTransferResult?.data?.transactions?.edges || [];
+    const allTxs = [...successfulTxs, ...swapTransferTxs];
+    const parsedTransactions = allTxs.map(parseSwapTransaction).filter(Boolean);
+    return { txs: parsedTransactions, hasNextPage, cursor };
+  }
+
+  const parsedTransactions = successfulTxs.map(parseSwapTransaction).filter(Boolean);
+  return { txs: parsedTransactions, hasNextPage, cursor };
 }
 
 export async function getPermaswapTransactions(address: string, cursor = "") {
@@ -243,41 +243,41 @@ export async function getPermaswapTransactions(address: string, cursor = "") {
     // validate the response
     validateGqlResponse(data);
 
-    const edges = data?.data?.transactions?.edges || [];
-    if (edges.length === 0) return { txs: [], hasNextPage: false, cursor };
-
-    cursor = edges[edges.length - 1].cursor;
-    const hasNextPage = data?.data?.transactions?.pageInfo?.hasNextPage || false;
-
-    const txMap = new Map<string, GQLEdgeInterface>();
-
-    for (const edge of edges) {
-      txMap.set(edge.node.id, edge);
-    }
-
-    const pushedFors = Array.from(txMap.keys());
-    const orderNotices = await retryWithDelay(async () => {
-      const data = await gql(PERMASWAP_SWAP_CONFIRMATION_QUERY, { address, pushedFors }, goldskyGateway);
-
-      // validate the response
-      validateGqlResponse(data);
-
-      const edges = data?.data?.transactions?.edges || [];
-      for (const edge of edges) {
-        const tags = edge?.node?.tags || [];
-        const pushedFor = getTagValue("Pushed-For", tags);
-        const swapTx = txMap.get(pushedFor);
-        if (swapTx) {
-          edge.node.tags.push(...swapTx.node.tags);
-        }
-      }
-
-      return edges;
-    }, 2);
-
-    const parsedTransactions = orderNotices.map(parseSwapTransaction).filter(Boolean);
-    return { txs: parsedTransactions, hasNextPage, cursor };
+    return data.data;
   }, 2);
 
-  return result;
+  const edges = result?.transactions?.edges || [];
+  if (edges.length === 0) return { txs: [], hasNextPage: false, cursor };
+
+  cursor = edges[edges.length - 1].cursor;
+  const hasNextPage = result?.transactions?.pageInfo?.hasNextPage || false;
+
+  const txMap = new Map<string, GQLEdgeInterface>();
+
+  for (const edge of edges) {
+    txMap.set(edge.node.id, edge);
+  }
+
+  const pushedFors = Array.from(txMap.keys());
+  const orderNotices = await retryWithDelay(async () => {
+    const data = await gql(PERMASWAP_SWAP_CONFIRMATION_QUERY, { address, pushedFors }, goldskyGateway);
+
+    // validate the response
+    validateGqlResponse(data);
+
+    const edges = data?.data?.transactions?.edges || [];
+    for (const edge of edges) {
+      const tags = edge?.node?.tags || [];
+      const pushedFor = getTagValue("Pushed-For", tags);
+      const swapTx = txMap.get(pushedFor);
+      if (swapTx) {
+        edge.node.tags.push(...swapTx.node.tags);
+      }
+    }
+
+    return edges;
+  }, 2);
+
+  const parsedTransactions = orderNotices.map(parseSwapTransaction).filter(Boolean);
+  return { txs: parsedTransactions, hasNextPage, cursor };
 }

--- a/src/routes/popup/swap/utils/swap.hooks.ts
+++ b/src/routes/popup/swap/utils/swap.hooks.ts
@@ -1,5 +1,16 @@
 import { useQuery, useInfiniteQuery } from "@tanstack/react-query";
-import { getExpectedOutputFn, getPools, getPriceImpact, getSwapTransaction, processToken, toFixed } from "./swap.utils";
+import {
+  getExpectedOutputFn,
+  getPools,
+  getPriceImpact,
+  getSwapTransaction,
+  processToken,
+  toFixed,
+  convertSwapsArrayToParsedTransactions,
+  calculateNetworkProviderFee,
+  calculateRate,
+  sortTransactionsByTimestamp,
+} from "./swap.utils";
 import { defaultOptions, useAoTokens } from "~tokens/hooks";
 import { useMemo, useCallback, useState, useRef, useEffect } from "react";
 import type {
@@ -679,12 +690,6 @@ interface TransactionPage {
   nextPageParam?: PageParam;
 }
 
-const sortTransactionsByTimestamp = (a: ParsedSwapTransaction, b: ParsedSwapTransaction) => {
-  const timestampA = a.timestamp || Number.MAX_SAFE_INTEGER;
-  const timestampB = b.timestamp || Number.MAX_SAFE_INTEGER;
-  return timestampB - timestampA;
-};
-
 const hasChangedCursor = (newCursor: string, oldCursor: string) => newCursor !== oldCursor;
 
 const hasNextPageData = (data: any, newCursor: string, oldCursor: string) =>
@@ -692,6 +697,7 @@ const hasNextPageData = (data: any, newCursor: string, oldCursor: string) =>
 
 export const useSwapTransactions = () => {
   const activeAddress = useActiveAddress();
+  const [swaps = []] = useStorage<SwapData[]>({ key: "swaps", instance: ExtensionStorage }, []);
 
   const { data, fetchNextPage, hasNextPage, isLoading, isFetching, isFetchingNextPage } =
     useInfiniteQuery<TransactionPage>({
@@ -781,34 +787,29 @@ export const useSwapTransactions = () => {
       ...defaultOptions,
     });
 
+  const recentSwaps = useMemo(() => convertSwapsArrayToParsedTransactions(swaps), [swaps]);
+
   const transactions = useMemo(() => {
-    if (!data?.pages) return [];
+    if (!data?.pages?.length && !recentSwaps.length) return [];
+    if (!data?.pages?.length) return recentSwaps;
 
     const seenIds = new Set<string>();
-    return data.pages
-      .flatMap((page) => page.transactions)
+    const allTransactions = [...data.pages.flatMap((page) => page.transactions), ...recentSwaps];
+
+    return allTransactions
       .filter((tx) => {
-        if (seenIds.has(tx.txId)) return false;
+        const isDuplicate = seenIds.has(tx.txId);
         seenIds.add(tx.txId);
-        return true;
+        return !isDuplicate;
       })
       .sort(sortTransactionsByTimestamp);
-  }, [data]);
-
-  const count = useMemo(() => {
-    if (!data?.pages) return { current: 0, actual: 0 };
-    return {
-      current: transactions.length,
-      actual: data.pages.reduce((sum, page) => sum + page.actualCount, 0),
-    };
-  }, [data, transactions]);
+  }, [data?.pages, recentSwaps]);
 
   return {
     transactions,
     loading: isLoading || isFetching || isFetchingNextPage,
     hasNextPage: !!hasNextPage,
-    count,
-    fetchTransactions: fetchNextPage,
+    fetchNextPage,
   };
 };
 
@@ -875,38 +876,10 @@ export function useProviderNetworkFee({
   receiveToken: TokenInfo;
   networkFee: string;
 }) {
-  return useMemo(() => {
-    if (!selectedPoolInfo?.quoteOutput || !sendToken || !receiveToken) return "--";
-
-    let tokenInFee = BigNumber(selectedPoolInfo.quoteOutput.tokenInFee || "0");
-    let tokenOutFee = BigNumber(selectedPoolInfo.quoteOutput.tokenOutFee || "0");
-
-    if (selectedPoolInfo.poolType === "aox" || selectedPoolInfo.poolType === "vento") {
-      if (sendToken.processId === AR_PROCESS_ID) {
-        tokenInFee = tokenInFee.plus(networkFee);
-      } else {
-        tokenOutFee = tokenOutFee.plus(networkFee);
-      }
-    }
-
-    const formatFee = (amount: BigNumber, token: TokenInfo) =>
-      `${toFixed(amount.shiftedBy(-token.Denomination), 8)} ${token.Ticker}`;
-
-    if (tokenInFee.isZero() && tokenOutFee.isZero()) {
-      return `0 ${sendToken.Ticker}`;
-    }
-
-    const fees = [];
-    if (!tokenInFee.isZero()) {
-      fees.push(formatFee(tokenInFee, sendToken));
-    }
-
-    if (!tokenOutFee.isZero()) {
-      fees.push(formatFee(tokenOutFee, receiveToken));
-    }
-
-    return fees.join(" + ");
-  }, [selectedPoolInfo, sendToken, receiveToken, networkFee]);
+  return useMemo(
+    () => calculateNetworkProviderFee(selectedPoolInfo, sendToken, receiveToken, networkFee),
+    [selectedPoolInfo, sendToken, receiveToken, networkFee],
+  );
 }
 
 export function useSwapRate({
@@ -920,15 +893,10 @@ export function useSwapRate({
   receiveToken: TokenInfo;
   amountIn: string;
 }) {
-  return useMemo(() => {
-    if (!selectedPoolInfo?.quoteOutput || !sendToken || !receiveToken || !amountIn) return "--";
-
-    const valueIn = BigNumber(amountIn).shiftedBy(-sendToken.Denomination);
-    const valueOut = BigNumber(selectedPoolInfo.quoteOutput.amountOut || "0").shiftedBy(-receiveToken.Denomination);
-
-    const valueOutForUnitValueIn = valueOut.dividedBy(valueIn);
-    return `1 ${sendToken.Ticker} ≈ ${toFixed(valueOutForUnitValueIn, 8)} ${receiveToken.Ticker}`;
-  }, [selectedPoolInfo, sendToken, receiveToken, amountIn]);
+  return useMemo(
+    () => calculateRate(selectedPoolInfo, sendToken, receiveToken, amountIn),
+    [selectedPoolInfo, sendToken, receiveToken, amountIn],
+  );
 }
 
 export function useIsSwapGated() {

--- a/src/routes/popup/swap/utils/swap.hooks.ts
+++ b/src/routes/popup/swap/utils/swap.hooks.ts
@@ -787,7 +787,10 @@ export const useSwapTransactions = () => {
       ...defaultOptions,
     });
 
-  const recentSwaps = useMemo(() => convertSwapsArrayToParsedTransactions(swaps), [swaps]);
+  const recentSwaps = useMemo(
+    () => convertSwapsArrayToParsedTransactions(swaps, activeAddress),
+    [swaps, activeAddress],
+  );
 
   const transactions = useMemo(() => {
     if (!data?.pages?.length && !recentSwaps.length) return [];

--- a/src/routes/popup/swap/utils/swap.hooks.ts
+++ b/src/routes/popup/swap/utils/swap.hooks.ts
@@ -793,8 +793,7 @@ export const useSwapTransactions = () => {
   );
 
   const transactions = useMemo(() => {
-    if (!data?.pages?.length && !recentSwaps.length) return [];
-    if (!data?.pages?.length) return recentSwaps;
+    if (!data?.pages?.length) return [];
 
     const seenIds = new Set<string>();
     const allTransactions = [...data.pages.flatMap((page) => page.transactions), ...recentSwaps];

--- a/src/routes/popup/swap/utils/swap.progress.ts
+++ b/src/routes/popup/swap/utils/swap.progress.ts
@@ -35,7 +35,7 @@ export async function initializeSwapMonitoring() {
  * Check for completed or failed swaps that need to show completion screen
  * Returns the swap data of the first swap that should be shown
  */
-export async function checkForCompletedSwapToShow(): Promise<SwapData | null> {
+export async function checkForFinishedSwapToShow(): Promise<SwapData | null> {
   try {
     // Find the first swap that needs to show completion screen (completed OR failed)
     const swapToShow = await swapsArray.find(

--- a/src/routes/popup/swap/utils/swap.types.ts
+++ b/src/routes/popup/swap/utils/swap.types.ts
@@ -164,6 +164,7 @@ export interface SwapData {
   sendToken: TokenInfo;
   receiveToken: TokenInfo;
   wanderFee: WanderFee;
+  networkFee: string;
   slippage: number;
   amountIn: string;
   swapper: string;

--- a/src/routes/popup/swap/utils/swap.types.ts
+++ b/src/routes/popup/swap/utils/swap.types.ts
@@ -180,6 +180,8 @@ export interface SwapData {
   showCompletionScreen?: boolean;
   monitoringStarted?: boolean;
   keystoneTx?: Partial<KeystoneTx>;
+  checkAttempts?: number; // Status check attempts count
+  lastCheckTime?: number; // Last check timestamp
 }
 
 export interface TokenPools {

--- a/src/routes/popup/swap/utils/swap.utils.ts
+++ b/src/routes/popup/swap/utils/swap.utils.ts
@@ -40,12 +40,7 @@ import { aox } from "./bridge/bridge.aox";
 import { botega } from "./dex/dex.botega";
 import { permaswap } from "./dex/dex.permaswap";
 import { vento } from "./bridge/bridge.vento";
-import type {
-  GetExpectedOutputParams,
-  GetExpectedOutputResponse,
-  ReadSwapResult,
-  SwapExecutionParams,
-} from "./dex/dex.types";
+import type { GetExpectedOutputParams, ReadSwapResult, SwapExecutionParams } from "./dex/dex.types";
 import { getAoxBridgeTransaction, getVentoBridgeTransaction } from "./bridge/bridge.utils";
 import { getLinkedMessages } from "./dex/dex.utils";
 import { createData, DataItem, type Tag } from "@dha-team/arbundles";
@@ -303,7 +298,9 @@ export function parseSwapTransaction(transaction: GQLEdgeInterface): ParsedSwapT
     const getTagValue = (name: string): string => tagValueMap.get(name) || "";
 
     // Parse basic transaction data
-    const timestamp = node.block?.timestamp ? node.block.timestamp * 1000 : Date.now();
+    // @ts-ignore
+    const blockTimestamp = node.block?.timestamp || node?.ingested_at;
+    const timestamp = blockTimestamp ? blockTimestamp * 1000 : Date.now();
     const pushedFor = getTagValue("Pushed-For");
     const txId = pushedFor || node.id;
     const isAo = getTagValue("Data-Protocol") === "ao";
@@ -328,7 +325,7 @@ export function parseSwapTransaction(transaction: GQLEdgeInterface): ParsedSwapT
     const tokenOut = JSON.parse(getTagValue("X-Token-Out"));
 
     const isError = action === "Order-Error" || (orderStatus && orderStatus !== "Swapped");
-    const isPending = bridgeStatus && bridgeStatus !== "success" && bridgeStatus !== "filled";
+    const isPending = orderStatus === "Pending" || (bridgeStatus && !["success", "filled"].includes(bridgeStatus));
     const status = isError ? "Failed" : isPending ? "Pending" : "Completed";
 
     return {
@@ -566,9 +563,9 @@ export function convertSwapDataToParsedTransaction(swapData: SwapData): ParsedSw
  * Converts an array of SwapData to ParsedSwapTransaction array
  * Filters out invalid entries and sorts by timestamp (newest first)
  */
-export function convertSwapsArrayToParsedTransactions(swaps: SwapData[]): ParsedSwapTransaction[] {
+export function convertSwapsArrayToParsedTransactions(swaps: SwapData[], swapper: string): ParsedSwapTransaction[] {
   return swaps
-    .filter((swap) => swap && swap.selectedPoolInfo && swap.sendToken && swap.receiveToken)
+    .filter((swap) => swap && swap.selectedPoolInfo && swap.sendToken && swap.receiveToken && swap.swapper === swapper)
     .map(convertSwapDataToParsedTransaction)
     .sort(sortTransactionsByTimestamp);
 }

--- a/src/routes/popup/swap/utils/swap.utils.ts
+++ b/src/routes/popup/swap/utils/swap.utils.ts
@@ -14,6 +14,7 @@ import {
   type Pool,
   type PoolType,
   type Provider,
+  type SelectedPoolInfo,
 } from "./swap.types";
 import BigNumber from "bignumber.js";
 import { BOTEGA_API_KEY, BOTEGA_SUPABASE_URL } from "./data-source/data-source.constants";
@@ -39,7 +40,12 @@ import { aox } from "./bridge/bridge.aox";
 import { botega } from "./dex/dex.botega";
 import { permaswap } from "./dex/dex.permaswap";
 import { vento } from "./bridge/bridge.vento";
-import type { GetExpectedOutputParams, ReadSwapResult, SwapExecutionParams } from "./dex/dex.types";
+import type {
+  GetExpectedOutputParams,
+  GetExpectedOutputResponse,
+  ReadSwapResult,
+  SwapExecutionParams,
+} from "./dex/dex.types";
 import { getAoxBridgeTransaction, getVentoBridgeTransaction } from "./bridge/bridge.utils";
 import { getLinkedMessages } from "./dex/dex.utils";
 import { createData, DataItem, type Tag } from "@dha-team/arbundles";
@@ -451,6 +457,122 @@ export const swapsArray = createStorageArray<SwapData>("swaps", {
   uniqueKey: "transferId",
 });
 
+const getSwapStatus = (status?: string): ParsedSwapTransaction["status"] => {
+  switch (status) {
+    case "pending":
+      return "Pending";
+    case "completed":
+      return "Completed";
+    case "failed":
+      return "Failed";
+    default:
+      return "Pending";
+  }
+};
+
+export function calculateRate(
+  selectedPoolInfo: SelectedPoolInfo,
+  sendToken: TokenInfo,
+  receiveToken: TokenInfo,
+  amountIn: string,
+): string {
+  if (!selectedPoolInfo?.quoteOutput || !sendToken || !receiveToken || !amountIn) return "--";
+
+  const valueIn = BigNumber(amountIn).shiftedBy(-sendToken.Denomination);
+  const valueOut = BigNumber(selectedPoolInfo.quoteOutput.amountOut || "0").shiftedBy(-receiveToken.Denomination);
+
+  const valueOutForUnitValueIn = valueOut.dividedBy(valueIn);
+  return `1 ${sendToken.Ticker} ≈ ${toFixed(valueOutForUnitValueIn, 8)} ${receiveToken.Ticker}`;
+}
+
+export function calculateNetworkProviderFee(
+  selectedPoolInfo: SelectedPoolInfo,
+  sendToken: TokenInfo,
+  receiveToken: TokenInfo,
+  networkFee: string,
+): string {
+  if (!selectedPoolInfo?.quoteOutput || !sendToken || !receiveToken) return "--";
+
+  let tokenInFee = BigNumber(selectedPoolInfo.quoteOutput.tokenInFee || "0");
+  let tokenOutFee = BigNumber(selectedPoolInfo.quoteOutput.tokenOutFee || "0");
+
+  if (selectedPoolInfo.poolType === "aox" || selectedPoolInfo.poolType === "vento") {
+    if (sendToken.processId === AR_PROCESS_ID) {
+      tokenInFee = tokenInFee.plus(networkFee);
+    } else {
+      tokenOutFee = tokenOutFee.plus(networkFee);
+    }
+  }
+
+  const formatFee = (amount: BigNumber, token: TokenInfo) =>
+    `${toFixed(amount.shiftedBy(-token.Denomination), 8)} ${token.Ticker}`;
+
+  if (tokenInFee.isZero() && tokenOutFee.isZero()) {
+    return `0 ${sendToken.Ticker}`;
+  }
+
+  const fees = [];
+  if (!tokenInFee.isZero()) {
+    fees.push(formatFee(tokenInFee, sendToken));
+  }
+
+  if (!tokenOutFee.isZero()) {
+    fees.push(formatFee(tokenOutFee, receiveToken));
+  }
+
+  return fees.join(" + ");
+}
+
+/**
+ * Converts SwapData to ParsedSwapTransaction format
+ * This allows stored swap data to be displayed in the same format as fetched transactions
+ *
+ * @param swapData - The SwapData object to convert
+ * @returns ParsedSwapTransaction - Formatted transaction object compatible with UI components
+ */
+export function convertSwapDataToParsedTransaction(swapData: SwapData): ParsedSwapTransaction {
+  const {
+    selectedPoolInfo,
+    sendToken,
+    receiveToken,
+    wanderFee,
+    slippage,
+    amountIn,
+    timestamp,
+    status,
+    networkFee = "0",
+  } = swapData;
+  const { quoteOutput, priceImpact, poolType } = selectedPoolInfo;
+
+  return {
+    txId: swapData.transferId || `swap-${timestamp || Date.now()}`,
+    isAo: sendToken.processId !== AR_PROCESS_ID,
+    rate: calculateRate(selectedPoolInfo, sendToken, receiveToken, amountIn),
+    timestamp: timestamp || Date.now(),
+    provider: getProviderName(poolType) || "Botega",
+    networkProviderFee: calculateNetworkProviderFee(selectedPoolInfo, sendToken, receiveToken, networkFee),
+    wanderFee: wanderFee?.finalFee || "0",
+    slippage: slippage.toString(),
+    priceImpact: priceImpact || "0",
+    tokenIn: sendToken,
+    tokenOut: receiveToken,
+    amountIn: amountIn || "0",
+    amountOut: quoteOutput?.amountOut || "0",
+    status: getSwapStatus(status),
+  };
+}
+
+/**
+ * Converts an array of SwapData to ParsedSwapTransaction array
+ * Filters out invalid entries and sorts by timestamp (newest first)
+ */
+export function convertSwapsArrayToParsedTransactions(swaps: SwapData[]): ParsedSwapTransaction[] {
+  return swaps
+    .filter((swap) => swap && swap.selectedPoolInfo && swap.sendToken && swap.receiveToken)
+    .map(convertSwapDataToParsedTransaction)
+    .sort(sortTransactionsByTimestamp);
+}
+
 export function executeSwapFn(poolType: PoolType, params: SwapExecutionParams) {
   switch (poolType) {
     case PoolTypeEnum.BOTEGA:
@@ -733,4 +855,10 @@ export async function assertTransferResult(
     log(LOG_GROUP.SWAP, transferError);
     throw new Error(transferError);
   }
+}
+
+export function sortTransactionsByTimestamp(a: ParsedSwapTransaction, b: ParsedSwapTransaction) {
+  const timestampA = a.timestamp || Number.MAX_SAFE_INTEGER;
+  const timestampB = b.timestamp || Number.MAX_SAFE_INTEGER;
+  return timestampB - timestampA;
 }


### PR DESCRIPTION
## Summary

This PR introduces the following improvements:

- **Swap History**: Improve swap history. Uses local saved swaps data as well.
- **Swap Error Handling**: Detect swap errors and shows either the failed or completed screen accordingly. Added check for Permaswap invalid amount out errors.
- **Slippage Fix**: Corrects slippage calculation and use `minAmountOut` (which accounts for slippage) during swap execution — previously not used.  
- **Fee Processing**: Adds a safeguard to ensure Wander swap fees are processed only once, avoiding duplicate fee processing.