### PR TITLE
chore: add blocked OTP domains toast

### DIFF
--- a/src/routes/embedded/auth/auth/auth.view.tsx
+++ b/src/routes/embedded/auth/auth/auth.view.tsx
@@ -16,7 +16,7 @@ import {
 import React, { useCallback, useRef, useState } from "react";
 import { getSupabaseClient } from "~utils/embedded/embedded.utils";
 import { useLocation, useSearchParams } from "~wallets/router/router.utils";
-import { isValidEmail } from "~utils/email";
+import { isOTPBlocked, isValidEmail } from "~utils/email";
 import { EmbeddedPaths } from "~wallets/router/iframe/iframe.routes";
 import { postEmbeddedMessage } from "~utils/embedded/utils/messages/embedded-messages.utils";
 import { sleep } from "~utils/promises/sleep";
@@ -148,6 +148,18 @@ export function AuthEmbeddedView() {
 
         if (!email || !isValidEmail(email)) {
           toast.error("Please enter a valid email address");
+          return;
+        }
+
+        if (isOTPBlocked(email)) {
+          const blockedDomains = ["@icloud.com", "@me.com", "@mac.com"].join(", ");
+          const blockedMessage = (
+            <div style={{ display: "flex", flexDirection: "column", gap: ".5rem" }}>
+              <span>Email domains {blockedDomains} are not supported.</span>
+              <span>Please try a different email or sign in method.</span>
+            </div>
+          );
+          toast.error(blockedMessage);
           return;
         }
 

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -46,3 +46,26 @@ export function isValidEmailSimple(email: string): boolean {
 
   return simpleEmailRegex.test(email);
 }
+
+/**
+ * Verifies if an email address is part of the OTP blocked list
+ *
+ * Basic validation checks:
+ * - belongs to the OTP blocked list
+ *
+ * @param email The email address to validate
+ * @returns boolean - true if valid, false if invalid
+ */
+export function isOTPBlocked(email: string): boolean {
+  if (!email) return false;
+
+  // Domains that are part of the OTP blocked list
+  // This pattern checks:
+  // - the domain part of the email address is one of:
+  // - icloud.com
+  // - me.com
+  // - mac.com
+  const emailRegex = /@(?:icloud|me|mac)\.com$/i;
+
+  return emailRegex.test(email);
+}


### PR DESCRIPTION
This PR adds a notice for the email domains that have been blocking our OTP codes

<img width="409" height="406" alt="Screenshot 2025-09-09 at 8 02 29 PM" src="https://github.com/user-attachments/assets/52c2b84e-8a33-4933-ae09-fab16359b4ec" />
