### PR TITLE
fix: update collectibles query

### DIFF
--- a/src/tokens/aoTokens/sync.ts
+++ b/src/tokens/aoTokens/sync.ts
@@ -107,8 +107,7 @@ function getCollectiblesQuery() {
       tags: [
         { name: "Data-Protocol", values: ["ao"] },
         { name: "Type", values: ["Process"] },
-        { name: "Implements", values: ["ANS-110"] },
-        { name: "Content-Type" }
+        { name: "Implements", values: ["ANS-110"] }
       ]
       first: 100
     ) {


### PR DESCRIPTION
## Summary

This PR updates the collectibles query to check if it's a valid collectible as the collectible verification is not working now.