### PR TITLE
fix: exclude Reddit domains from content script matches

### DIFF
--- a/src/contents/api.ts
+++ b/src/contents/api.ts
@@ -8,6 +8,7 @@ log(LOG_GROUP.SETUP, "api.ts");
 
 export const config: PlasmoCSConfig = {
   matches: ["file://*/*", "http://*/*", "https://*/*"],
+  exclude_matches: ["*://reddit.com/*", "*://*.reddit.com/*"],
   run_at: "document_start",
   all_frames: true,
 };

--- a/src/contents/events.ts
+++ b/src/contents/events.ts
@@ -6,6 +6,7 @@ log(LOG_GROUP.SETUP, "events.content-script.ts");
 
 export const config: PlasmoCSConfig = {
   matches: ["file://*/*", "http://*/*", "https://*/*"],
+  exclude_matches: ["*://reddit.com/*", "*://*.reddit.com/*"],
   run_at: "document_end",
   all_frames: true,
 };


### PR DESCRIPTION
## Summary

This PR resolves the issue where Reddit login was not loading by excluding it from content script matches. Closes [ARC-1567](https://communitylabs.atlassian.net/browse/ARC-1567).

## How to Test

1. Build the production build of this PR.
2. Visit [Reddit Login](https://www.reddit.com/login/) and check the login UI issue with the actual production build from store.
3. Test with the this PR production build to confirm that the issue does not occur.

## Login Error
<img width="3020" height="1664" alt="image" src="https://github.com/user-attachments/assets/2e828d9b-f9dd-4379-9025-e4cf99f1440c" />


[ARC-1567]: https://communitylabs.atlassian.net/browse/ARC-1567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ