### PR TITLE
feat: add skip storage access warning functionality

### DIFF
--- a/src/components/embed/ui/templates/no-unpartitioned-state-banner/NoUnpartitionedStateBanner.tsx
+++ b/src/components/embed/ui/templates/no-unpartitioned-state-banner/NoUnpartitionedStateBanner.tsx
@@ -3,7 +3,7 @@ import { Link } from "~wallets/router/components/link/Link";
 import { EmbeddedPaths } from "~wallets/router/iframe/iframe.routes";
 import { AlertTriangle } from "@untitled-ui/icons-react";
 import { useLocation } from "~wallets/router/router.utils";
-import { EMBEDDED_SKIP_UNPARTITIONED_STATE_UI_CHECK } from "~utils/embedded/iframe.utils";
+import { EMBEDDED_SKIP_STORAGE_ACCESS_WARNING } from "~utils/embedded/iframe.utils";
 import clsx from "clsx";
 
 import styles from "./NoUnpartitionedStateBanner.module.scss";
@@ -17,7 +17,7 @@ export function NoUnpartitionedStateBanner({ className, disableLink }: NoUnparti
   const { location } = useLocation();
   const { unpartitionedStateStatus } = useEmbedded();
 
-  return !EMBEDDED_SKIP_UNPARTITIONED_STATE_UI_CHECK &&
+  return !EMBEDDED_SKIP_STORAGE_ACCESS_WARNING &&
     unpartitionedStateStatus !== "supported" &&
     location !== EmbeddedPaths.SupportUnpartitionedStateMissing ? (
     <div className={clsx(styles.root, className)}>

--- a/src/components/embed/ui/templates/no-unpartitioned-state-banner/NoUnpartitionedStateBanner.tsx
+++ b/src/components/embed/ui/templates/no-unpartitioned-state-banner/NoUnpartitionedStateBanner.tsx
@@ -3,6 +3,7 @@ import { Link } from "~wallets/router/components/link/Link";
 import { EmbeddedPaths } from "~wallets/router/iframe/iframe.routes";
 import { AlertTriangle } from "@untitled-ui/icons-react";
 import { useLocation } from "~wallets/router/router.utils";
+import { EMBEDDED_SKIP_UNPARTITIONED_STATE_UI_CHECK } from "~utils/embedded/iframe.utils";
 import clsx from "clsx";
 
 import styles from "./NoUnpartitionedStateBanner.module.scss";
@@ -16,7 +17,9 @@ export function NoUnpartitionedStateBanner({ className, disableLink }: NoUnparti
   const { location } = useLocation();
   const { unpartitionedStateStatus } = useEmbedded();
 
-  return unpartitionedStateStatus !== "supported" && location !== EmbeddedPaths.SupportUnpartitionedStateMissing ? (
+  return !EMBEDDED_SKIP_UNPARTITIONED_STATE_UI_CHECK &&
+    unpartitionedStateStatus !== "supported" &&
+    location !== EmbeddedPaths.SupportUnpartitionedStateMissing ? (
     <div className={clsx(styles.root, className)}>
       <AlertTriangle className={styles.icon} />
       <span>

--- a/src/utils/embedded/iframe.utils.ts
+++ b/src/utils/embedded/iframe.utils.ts
@@ -1,4 +1,4 @@
-import type { ThemeMode } from "~utils/theme/theme.hook";
+import type { ThemeMode } from "~utils/theme/theme.types";
 
 const { search = "", ancestorOrigins = [] } =
   import.meta.env?.VITE_IS_EMBEDDED_APP === "1" && typeof document !== "undefined" ? document.location : {};
@@ -44,6 +44,7 @@ const PARAM_ANCESTOR_ORIGIN = "ancestor-origin";
 const PARAM_HIDE_BE = "hide-be";
 const PARAM_INJECTED_BE = "injected-be";
 const PARAM_SERVER_BASE_URL = "server-base-url";
+const PARAM_SKIP_STORAGE_ACCESS_WARNING = "skip-storage-access-warning";
 
 export const EMBEDDED_CLIENT_ID = searchParams.get(PARAM_CLIENT_ID) || EMBEDDED_ENV_VARS.DEFAULT_EMBEDDED_CLIENT_ID;
 
@@ -57,6 +58,9 @@ export const EMBEDDED_INJECTED_BE = searchParams.get(PARAM_INJECTED_BE) === "1" 
 
 export const EMBEDDED_SERVER_BASE_URL =
   searchParams.get(PARAM_SERVER_BASE_URL) || EMBEDDED_ENV_VARS.DEFAULT_EMBEDDED_SERVER_BASE_URL;
+
+export const EMBEDDED_SKIP_STORAGE_ACCESS_WARNING =
+  searchParams.get(PARAM_SKIP_STORAGE_ACCESS_WARNING) === "1" || false;
 
 // Note: DO NOT use document.referrer here as that will return the "incorrect" value when the user is redirected from
 // an auth provider domain to back to Wander Embedded.

--- a/src/wallets/router/iframe/iframe-router.hook.ts
+++ b/src/wallets/router/iframe/iframe-router.hook.ts
@@ -6,6 +6,7 @@ import type { ExtensionRouteOverride } from "~wallets/router/extension/extension
 import { EmbeddedPaths } from "~wallets/router/iframe/iframe.routes";
 import type { WanderRoutePath, BaseLocationHook, RoutePath } from "~wallets/router/router.types";
 import { isRouteOverride, routeTrapMatches, routeTrapOutside, withRouterRedirects } from "~wallets/router/router.utils";
+import { EMBEDDED_SKIP_STORAGE_ACCESS_WARNING } from "~utils/embedded/iframe.utils";
 
 const AUTH_STATUS_TO_OVERRIDE: Record<AuthStatus, null | ExtensionRouteOverride> = {
   // TODO: Redefine these override paths:
@@ -33,7 +34,12 @@ export function useEmbeddedOverride(location?: RoutePath) {
     return "/__OVERRIDES/cover";
   }
 
-  if (unpartitionedStateStatus !== "supported" && !unpartitionedStateConfirmed && authStatus === "noAuth") {
+  if (
+    !EMBEDDED_SKIP_STORAGE_ACCESS_WARNING &&
+    unpartitionedStateStatus !== "supported" &&
+    !unpartitionedStateConfirmed &&
+    authStatus === "noAuth"
+  ) {
     return routeTrapMatches(
       location,
       [EmbeddedPaths.SupportUnpartitionedStateMissing],

--- a/wander-connect-sdk/package.json
+++ b/wander-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wanderapp/connect",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Wander Connect SDK.",
   "author": "wanderapp",
   "license": "MIT",

--- a/wander-connect-sdk/src/utils/url/url.utils.ts
+++ b/wander-connect-sdk/src/utils/url/url.utils.ts
@@ -15,6 +15,7 @@ const PARAM_ANCESTOR_ORIGIN = "ancestor-origin";
 const PARAM_HIDE_BE = "hide-be";
 const PARAM_INJECTED_BE = "injected-be";
 const PARAM_SERVER_BASE_URL = "server-base-url";
+const PARAM_SKIP_STORAGE_ACCESS_WARNING = "skip-storage-access-warning";
 
 export interface getWanderConnectAppURL {
   baseURL: string;
@@ -23,6 +24,7 @@ export interface getWanderConnectAppURL {
   hideBE?: boolean;
   injectedBE?: boolean;
   baseServerURL?: string;
+  skipStorageAccessWarning?: boolean;
 }
 
 export function getWanderConnectAppURL({
@@ -32,6 +34,7 @@ export function getWanderConnectAppURL({
   hideBE,
   injectedBE,
   baseServerURL,
+  skipStorageAccessWarning,
 }: getWanderConnectAppURL) {
   const url = new URL(baseURL);
   const { searchParams } = url;
@@ -44,6 +47,7 @@ export function getWanderConnectAppURL({
   if (hideBE) searchParams.set(PARAM_HIDE_BE, "1");
   if (injectedBE) searchParams.set(PARAM_INJECTED_BE, "1");
   if (baseServerURL) searchParams.set(PARAM_SERVER_BASE_URL, baseServerURL);
+  if (skipStorageAccessWarning) searchParams.set(PARAM_SKIP_STORAGE_ACCESS_WARNING, "1");
 
   return url.toString();
 }

--- a/wander-connect-sdk/src/wander-connect.ts
+++ b/wander-connect-sdk/src/wander-connect.ts
@@ -165,6 +165,7 @@ export class WanderConnect {
           clickOutsideBehavior: true,
         },
         button: true,
+        skipStorageAccessWarning: false,
       } satisfies WanderConnectOptions,
       options || {},
     );
@@ -280,6 +281,7 @@ export class WanderConnect {
       theme = WanderConnect.DEFAULT_THEME,
       hideBE,
       baseServerURL,
+      skipStorageAccessWarning,
     } = options;
 
     // Deep clone these objects so that we don't mutate the original, developer-provider ones:
@@ -301,6 +303,7 @@ export class WanderConnect {
       hideBE,
       injectedBE: this.isBrowserWalletEnabled,
       baseServerURL,
+      skipStorageAccessWarning,
     });
 
     if (iframeOptions instanceof HTMLElement) {

--- a/wander-connect-sdk/src/wander-connect.types.ts
+++ b/wander-connect-sdk/src/wander-connect.types.ts
@@ -294,6 +294,14 @@ export interface WanderConnectOptions {
   baseServerURL?: string;
 
   /**
+   * Skip the storage access warning UI.
+   * When enabled, bypasses the browser storage access warning that appears
+   * when the iframe cannot access unpartitioned storage (localStorage, cookies, etc.).
+   * @default false
+   */
+  skipStorageAccessWarning?: boolean;
+
+  /**
    * Configuration options for the iframe component or an existing iframe element.
    */
   iframe?: IframeOptions | HTMLIFrameElement;

--- a/wander-connect-sdk/src/wander-connect.types.ts
+++ b/wander-connect-sdk/src/wander-connect.types.ts
@@ -294,9 +294,9 @@ export interface WanderConnectOptions {
   baseServerURL?: string;
 
   /**
-   * Skip the storage access warning UI.
-   * When enabled, bypasses the browser storage access warning that appears
-   * when the iframe cannot access unpartitioned storage (localStorage, cookies, etc.).
+   * Skip the unpartitioned storage access warning UI.
+   * When enabled, bypasses the warning UI that appears when the iframe cannot access
+   * unpartitioned storage (localStorage, cookies, etc.).
    * @default false
    */
   skipStorageAccessWarning?: boolean;


### PR DESCRIPTION
## Summary

This PR introduces the `skipStorageAccessWarning` parameter to the SDK, allowing the UI to skip checks and warnings related to storage access.

## How to Test
1. Open: [Wander Connect Test](https://wander-connect-test.netlify.app) and Use this as the **Base URL**:  [Embed Dev Preview](https://wander-embed-dev-git-arc-1571-skip-storag-95d405-community-labs.vercel.app)  
2. Toggle the **Skip Storage Access Warning** switch.  
3. Confirm that UI/warnings for unpartitioned storage no longer appear.

## Question
- Besides the ones in this PR, are there any other warnings we should disable?