### PR TITLE
fix: sdk build

### DIFF
--- a/wander-connect-sdk/package.json
+++ b/wander-connect-sdk/package.json
@@ -23,13 +23,14 @@
   "jsdelivr": "sdk-dist/index.global.js",
   "types": "sdk-dist/index.d.ts",
   "scripts": {
-    "build": "tsup",
+    "build": "cross-env NODE_ENV=production tsup",
     "dev": "tsup --watch",
     "clean": "rm -rf sdk-dist wallet-api-dist",
     "nuke": "pnpm clean && rm -rf pnpm-lock.yaml node_modules",
     "prepare": "pnpm build"
   },
   "devDependencies": {
+    "cross-env": "^10.1.0",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3"
   },

--- a/wander-connect-sdk/package.json
+++ b/wander-connect-sdk/package.json
@@ -23,8 +23,9 @@
   "jsdelivr": "sdk-dist/index.global.js",
   "types": "sdk-dist/index.d.ts",
   "scripts": {
-    "build": "cross-env NODE_ENV=production tsup",
-    "dev": "tsup --watch",
+    "clean-dist": "rm -rf sdk-dist",
+    "build": "pnpm clean-dist && cross-env NODE_ENV=production tsup",
+    "dev": "pnpm clean-dist && tsup --watch",
     "clean": "rm -rf sdk-dist wallet-api-dist",
     "nuke": "pnpm clean && rm -rf pnpm-lock.yaml node_modules",
     "prepare": "pnpm build"

--- a/wander-connect-sdk/pnpm-lock.yaml
+++ b/wander-connect-sdk/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
     devDependencies:
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       tsup:
         specifier: ^8.4.0
         version: 8.5.0(typescript@5.8.3)
@@ -20,6 +23,9 @@ importers:
         version: 5.8.3
 
 packages:
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@esbuild/aix-ppc64@0.25.6':
     resolution: {integrity: sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==}
@@ -363,6 +369,11 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -645,6 +656,8 @@ packages:
 
 snapshots:
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@esbuild/aix-ppc64@0.25.6':
     optional: true
 
@@ -853,6 +866,11 @@ snapshots:
   confbox@0.1.8: {}
 
   consola@3.4.2: {}
+
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:

--- a/wander-connect-sdk/tsup.config.ts
+++ b/wander-connect-sdk/tsup.config.ts
@@ -4,7 +4,6 @@ const env = process.env.NODE_ENV;
 
 const common: Options = {
   splitting: false,
-  clean: true, // clean up the dist folder
   bundle: true,
   skipNodeModulesBundle: true,
   entryPoints: ["src/index.ts"],
@@ -34,6 +33,7 @@ const iifeOptions: Options = {
   format: ["iife"],
   minify: true,
   sourcemap: false,
+  globalName: "WanderConnect",
   ...common,
 };
 

--- a/wander-connect-sdk/tsup.config.ts
+++ b/wander-connect-sdk/tsup.config.ts
@@ -1,4 +1,5 @@
 import type { Options } from "tsup";
+import fs from "node:fs";
 
 const env = process.env.NODE_ENV;
 
@@ -14,7 +15,7 @@ export const tsup: Options = {
   watch: env === "development",
   target: "es2020",
   outDir: "sdk-dist",
-  entry: ["src/**/*.ts", "!src/**/__tests__/**", "!src/**/*.test.*"], //include all files under src
+  entry: ["src/index.ts", "!src/**/__tests__/**", "!src/**/*.test.*"], //include all files under src
   shims: true,
   sourcemap: true,
   treeshake: true,
@@ -22,5 +23,8 @@ export const tsup: Options = {
     options.alias = {
       "wallet-api": "./wallet-api-dist",
     };
+  },
+  onSuccess: () => {
+    return Promise.resolve(fs.rmSync("sdk-dist/index.global.js.map", { force: true }));
   },
 };

--- a/wander-connect-sdk/tsup.config.ts
+++ b/wander-connect-sdk/tsup.config.ts
@@ -1,14 +1,10 @@
 import type { Options } from "tsup";
-import fs from "node:fs";
 
 const env = process.env.NODE_ENV;
 
-export const tsup: Options = {
+const common: Options = {
   splitting: false,
   clean: true, // clean up the dist folder
-  dts: true, // generate dts files
-  format: ["cjs", "esm", "iife"], // generate cjs, iife and esm files
-  minify: env === "production",
   bundle: true,
   skipNodeModulesBundle: true,
   entryPoints: ["src/index.ts"],
@@ -17,14 +13,28 @@ export const tsup: Options = {
   outDir: "sdk-dist",
   entry: ["src/index.ts", "!src/**/__tests__/**", "!src/**/*.test.*"], //include all files under src
   shims: true,
-  sourcemap: true,
   treeshake: true,
   esbuildOptions: (options) => {
     options.alias = {
       "wallet-api": "./wallet-api-dist",
     };
   },
-  onSuccess: () => {
-    return Promise.resolve(fs.rmSync("sdk-dist/index.global.js.map", { force: true }));
-  },
 };
+
+const cjsEsmOptions: Options = {
+  dts: true, // generate dts files
+  format: ["cjs", "esm"], // generate cjs and esm files
+  minify: env === "production",
+  sourcemap: true,
+  ...common,
+};
+
+const iifeOptions: Options = {
+  dts: false,
+  format: ["iife"],
+  minify: true,
+  sourcemap: false,
+  ...common,
+};
+
+export default [cjsEsmOptions, iifeOptions];


### PR DESCRIPTION
## Summary

This PR updates the tsup config to reduce the build size while building.

### Build size improvement for npm
The changes made in tsup config:
- Minify code for production with changes made in `package.json` scripts.
- Use single file `src/index.ts` in entry (Didn't see usage of multiple entries `src/**/*.ts` as modular import doesn't seem to be needed)
- Separate configuration for `iife` so we can disable sourcemap & dts.

#### Build sizes
- New build size: `1.7MB`
- Previous build size: `6MB`