### PR TITLE
fix: handle undefined process.version in dev for arweave-storage-sdk

### DIFF
--- a/src/contents/injected/setup-wallet-sdk.injected-script.ts
+++ b/src/contents/injected/setup-wallet-sdk.injected-script.ts
@@ -5,9 +5,9 @@ log(LOG_GROUP.SETUP, "injected/setup-wallet-sdk.injected-script.ts");
 
 // Added as a fix for arweave-storage-sdk issue in development mode where process.version is undefined:
 if (process.env.NODE_ENV === "development" && import.meta.env?.VITE_IS_EMBEDDED_APP !== "1") {
-  const windowProcess = (window as any).process;
-  if (windowProcess?.version === undefined) {
-    windowProcess.version = "";
+  const wp = (window as any).process;
+  if (wp && typeof wp === "object" && wp.version === undefined) {
+    wp.version = "";
   }
 }
 

--- a/src/contents/injected/setup-wallet-sdk.injected-script.ts
+++ b/src/contents/injected/setup-wallet-sdk.injected-script.ts
@@ -3,4 +3,12 @@ import { log, LOG_GROUP } from "~utils/log/log.utils";
 
 log(LOG_GROUP.SETUP, "injected/setup-wallet-sdk.injected-script.ts");
 
+// Added as a fix for arweave-storage-sdk issue in development mode where process.version is undefined:
+if (process.env.NODE_ENV === "development" && import.meta.env?.VITE_IS_EMBEDDED_APP !== "1") {
+  const windowProcess = (window as any).process;
+  if (windowProcess?.version === undefined) {
+    windowProcess.version = "";
+  }
+}
+
 injectWanderWalletAPI();


### PR DESCRIPTION
## Summary

This PR fixes a development build issue where `process.version` was undefined, causing errors in app using `arweave-storage-sdk`.