### PR TITLE
refactor: use contentId for backup existence check

### DIFF
--- a/src/utils/embedded/cloud/cloud.utils.ts
+++ b/src/utils/embedded/cloud/cloud.utils.ts
@@ -1,0 +1,22 @@
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * Generate a unique ID for a file using SHA-256 hash and base64url encoding.
+ * @param file - The file to generate an ID for.
+ * @returns A unique ID for the file.
+ * @throws If the file is not a valid file or the hash generation fails.
+ */
+export async function fileToId(file: File | Blob): Promise<string> {
+  try {
+    const buffer = await file.arrayBuffer();
+    const hash = await crypto.subtle.digest("SHA-256", buffer); // hash bytes
+    // convert to base64url (compact, 43 chars)
+    const id = btoa(String.fromCharCode(...new Uint8Array(hash)))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    return id;
+  } catch {
+    return uuidv4();
+  }
+}

--- a/src/utils/embedded/cloud/hooks/useAppleCloud.ts
+++ b/src/utils/embedded/cloud/hooks/useAppleCloud.ts
@@ -262,14 +262,14 @@ export const useAppleCloud = (): UseAppleCloudReturn => {
 
         setAuthState((prev) => ({ ...prev, isLoading: true }));
 
-        const uniqueId = await fileToId(file);
-        const existingFile = await getFile(uniqueId);
+        const contentId = await fileToId(file);
+        const existingFile = await getFile(contentId);
         if (existingFile) return existingFile;
 
         const fileType = mimeType || (file instanceof File ? file.type : "application/json");
 
         // Create a unique record name
-        const recordName = uniqueId;
+        const recordName = contentId;
 
         // Create the record with minimal data - CloudKit handles the rest
         const record: RecordToCreate = {

--- a/src/utils/embedded/cloud/hooks/useAppleCloud.ts
+++ b/src/utils/embedded/cloud/hooks/useAppleCloud.ts
@@ -3,7 +3,7 @@ import type { Container, UserIdentity, RecordField, RecordToCreate, RecordToSave
 import { useScript } from "~utils/script/script.hooks";
 import type { AppDataFile } from "../cloud.types";
 import type { RecoveryJSON } from "~utils/embedded/embedded.types";
-import { v4 as uuidv4 } from "uuid";
+import { fileToId } from "../cloud.utils";
 
 interface AppleAuthState {
   isAuthenticated: boolean;
@@ -262,13 +262,14 @@ export const useAppleCloud = (): UseAppleCloudReturn => {
 
         setAuthState((prev) => ({ ...prev, isLoading: true }));
 
-        // const existingFile = await getFile(walletAddress);
-        // if (existingFile) return existingFile;
+        const uniqueId = await fileToId(file);
+        const existingFile = await getFile(uniqueId);
+        if (existingFile) return existingFile;
 
         const fileType = mimeType || (file instanceof File ? file.type : "application/json");
 
         // Create a unique record name
-        const recordName = uuidv4();
+        const recordName = uniqueId;
 
         // Create the record with minimal data - CloudKit handles the rest
         const record: RecordToCreate = {

--- a/src/utils/embedded/cloud/hooks/useAppleCloud.ts
+++ b/src/utils/embedded/cloud/hooks/useAppleCloud.ts
@@ -3,6 +3,7 @@ import type { Container, UserIdentity, RecordField, RecordToCreate, RecordToSave
 import { useScript } from "~utils/script/script.hooks";
 import type { AppDataFile } from "../cloud.types";
 import type { RecoveryJSON } from "~utils/embedded/embedded.types";
+import { v4 as uuidv4 } from "uuid";
 
 interface AppleAuthState {
   isAuthenticated: boolean;
@@ -261,13 +262,13 @@ export const useAppleCloud = (): UseAppleCloudReturn => {
 
         setAuthState((prev) => ({ ...prev, isLoading: true }));
 
-        const existingFile = await getFile(walletAddress);
-        if (existingFile) return existingFile;
+        // const existingFile = await getFile(walletAddress);
+        // if (existingFile) return existingFile;
 
         const fileType = mimeType || (file instanceof File ? file.type : "application/json");
 
         // Create a unique record name
-        const recordName = walletAddress;
+        const recordName = uuidv4();
 
         // Create the record with minimal data - CloudKit handles the rest
         const record: RecordToCreate = {

--- a/src/utils/embedded/cloud/hooks/useGoogleCloud.ts
+++ b/src/utils/embedded/cloud/hooks/useGoogleCloud.ts
@@ -39,7 +39,7 @@ interface UseGoogleCloudReturn {
   // File operations methods
   uploadFile: (file: File | Blob, fileName: string, walletAddress: string, mimeType?: string) => Promise<AppDataFile>;
   getFileContent: (fileId: string) => Promise<RecoveryJSON>;
-  getFile: (uniqueId: string, fileId?: string) => Promise<AppDataFile | null>;
+  getFile: (contentId: string, fileId?: string) => Promise<AppDataFile | null>;
   updateFile: (fileId: string, file: File | Blob, fileName?: string, mimeType?: string) => Promise<AppDataFile>;
   downloadFile: (fileId: string, fileName: string) => Promise<void>;
   deleteFile: (fileId: string) => Promise<void>;
@@ -326,13 +326,13 @@ export const useGoogleCloud = (): UseGoogleCloudReturn => {
   }, []);
 
   const getFile = useCallback(
-    async (uniqueId: string, fileId?: string): Promise<AppDataFile | null> => {
+    async (contentId: string, fileId?: string): Promise<AppDataFile | null> => {
       try {
         const token = await ensureValidToken();
 
         const url = fileId
           ? `https://www.googleapis.com/drive/v3/files/${fileId}?fields=id,name,mimeType,createdTime,modifiedTime,appProperties`
-          : `https://www.googleapis.com/drive/v3/files?spaces=appDataFolder&q=appProperties has { key='uniqueId' and value='${uniqueId}' }&fields=files(id,name,mimeType,createdTime,modifiedTime,appProperties)`;
+          : `https://www.googleapis.com/drive/v3/files?spaces=appDataFolder&q=appProperties has { key='contentId' and value='${contentId}' }&fields=files(id,name,mimeType,createdTime,modifiedTime,appProperties)`;
 
         const response = await fetch(url, {
           headers: {
@@ -372,8 +372,8 @@ export const useGoogleCloud = (): UseGoogleCloudReturn => {
 
         setAuthState((prev) => ({ ...prev, isLoading: true }));
 
-        const uniqueId = await fileToId(file);
-        const existingFile = await getFile(uniqueId);
+        const contentId = await fileToId(file);
+        const existingFile = await getFile(contentId);
         if (existingFile) return existingFile;
 
         const fileType = mimeType || (file instanceof File ? file.type : "application/octet-stream");
@@ -383,7 +383,7 @@ export const useGoogleCloud = (): UseGoogleCloudReturn => {
           name: fileName,
           mimeType: fileType,
           parents: ["appDataFolder"], // This is key for storing in app data folder,
-          appProperties: { walletAddress, uniqueId },
+          appProperties: { walletAddress, contentId },
         };
 
         // Create form data for multipart upload

--- a/src/utils/embedded/cloud/hooks/useGoogleCloud.ts
+++ b/src/utils/embedded/cloud/hooks/useGoogleCloud.ts
@@ -368,8 +368,8 @@ export const useGoogleCloud = (): UseGoogleCloudReturn => {
 
         setAuthState((prev) => ({ ...prev, isLoading: true }));
 
-        const existingFile = await getFile(walletAddress);
-        if (existingFile) return existingFile;
+        // const existingFile = await getFile(walletAddress);
+        // if (existingFile) return existingFile;
 
         const fileType = mimeType || (file instanceof File ? file.type : "application/octet-stream");
 

--- a/src/utils/embedded/cloud/hooks/useGoogleCloud.ts
+++ b/src/utils/embedded/cloud/hooks/useGoogleCloud.ts
@@ -11,6 +11,7 @@ import {
   getAuthErrorMessage,
 } from "~utils/authentication/authentication.utils";
 import type { RecoveryJSON } from "~utils/embedded/embedded.types";
+import { fileToId } from "../cloud.utils";
 
 interface GoogleCloudAuthState {
   isAuthenticated: boolean;
@@ -38,7 +39,7 @@ interface UseGoogleCloudReturn {
   // File operations methods
   uploadFile: (file: File | Blob, fileName: string, walletAddress: string, mimeType?: string) => Promise<AppDataFile>;
   getFileContent: (fileId: string) => Promise<RecoveryJSON>;
-  getFile: (walletAddress: string, fileId?: string) => Promise<AppDataFile | null>;
+  getFile: (uniqueId: string, fileId?: string) => Promise<AppDataFile | null>;
   updateFile: (fileId: string, file: File | Blob, fileName?: string, mimeType?: string) => Promise<AppDataFile>;
   downloadFile: (fileId: string, fileName: string) => Promise<void>;
   deleteFile: (fileId: string) => Promise<void>;
@@ -325,15 +326,15 @@ export const useGoogleCloud = (): UseGoogleCloudReturn => {
   }, []);
 
   const getFile = useCallback(
-    async (walletAddress: string, fileId?: string): Promise<AppDataFile | null> => {
+    async (uniqueId: string, fileId?: string): Promise<AppDataFile | null> => {
       try {
         const token = await ensureValidToken();
 
         const url = fileId
-          ? `https://www.googleapis.com/drive/v3/files/${fileId}`
-          : `https://www.googleapis.com/drive/v3/files?q=appProperties has { key: 'walletAddress', value: '${walletAddress}' }`;
+          ? `https://www.googleapis.com/drive/v3/files/${fileId}?fields=id,name,mimeType,createdTime,modifiedTime,appProperties`
+          : `https://www.googleapis.com/drive/v3/files?spaces=appDataFolder&q=appProperties has { key='uniqueId' and value='${uniqueId}' }&fields=files(id,name,mimeType,createdTime,modifiedTime,appProperties)`;
 
-        const response = await fetch(`${url}&fields=id,name,mimeType,createdTime,modifiedTime,appProperties`, {
+        const response = await fetch(url, {
           headers: {
             Authorization: `Bearer ${token}`,
           },
@@ -344,13 +345,16 @@ export const useGoogleCloud = (): UseGoogleCloudReturn => {
         }
 
         const data = await response.json();
+        const fileData = fileId ? data : data.files?.[0];
+        if (!fileData) return null;
+
         return {
-          id: data.id,
-          name: data.name,
-          mimeType: data.mimeType,
-          createdTime: data.createdTime,
-          modifiedTime: data.modifiedTime,
-          walletAddress: data?.appProperties?.walletAddress || "",
+          id: fileData.id,
+          name: fileData.name,
+          mimeType: fileData.mimeType,
+          createdTime: fileData.createdTime,
+          modifiedTime: fileData.modifiedTime,
+          walletAddress: fileData?.appProperties?.walletAddress || "",
         } as AppDataFile;
       } catch (err) {
         const errorMessage = err?.message || err?.reason || "Failed to get wallet backup.";
@@ -368,8 +372,9 @@ export const useGoogleCloud = (): UseGoogleCloudReturn => {
 
         setAuthState((prev) => ({ ...prev, isLoading: true }));
 
-        // const existingFile = await getFile(walletAddress);
-        // if (existingFile) return existingFile;
+        const uniqueId = await fileToId(file);
+        const existingFile = await getFile(uniqueId);
+        if (existingFile) return existingFile;
 
         const fileType = mimeType || (file instanceof File ? file.type : "application/octet-stream");
 
@@ -378,7 +383,7 @@ export const useGoogleCloud = (): UseGoogleCloudReturn => {
           name: fileName,
           mimeType: fileType,
           parents: ["appDataFolder"], // This is key for storing in app data folder,
-          appProperties: { walletAddress },
+          appProperties: { walletAddress, uniqueId },
         };
 
         // Create form data for multipart upload


### PR DESCRIPTION
## Summary

This PR introduces `fileToId` to generate a unique contentId for each backup, allowing the system to check for existing backups before creating a new one.