### PR TITLE
refactor: remove ardrive cu from balance dryrun

### DIFF
--- a/src/tokens/aoTokens/ao.ts
+++ b/src/tokens/aoTokens/ao.ts
@@ -16,17 +16,8 @@ import BigNumber from "bignumber.js";
 import { CACHE_API } from "~constants/api";
 import Arweave from "arweave";
 import { queryClient } from "~utils/tanstack";
-import {
-  USDA_PROCESS_ID,
-  Id,
-  Owner,
-  AR_PROCESS_ID,
-  AO_PROCESS_ID,
-  UTD_PROCESS_ID,
-  WNDR_PROCESS_ID,
-} from "~tokens/aoTokens/ao.constants";
+import { Id, Owner, AR_PROCESS_ID, AO_PROCESS_ID, UTD_PROCESS_ID } from "~tokens/aoTokens/ao.constants";
 import type { Token } from "~tokens/token";
-import { ARIO_MAINNET_PROCESS_ID, ARIO_TESTNET_PROCESS_ID } from "@ar.io/sdk/web";
 import type { FlpTokenInfo } from "~utils/fair_launch/fair_launch.types";
 
 export let tokens: TokenInfo[] = null;
@@ -58,14 +49,10 @@ export const ARDRIVE_CU_URL = "https://cu.ardrive.io";
 export const AO_DEV_CU_URL = "https://aodev.fun/ao/cu";
 export const DEFAULT_CU_URL = "https://cu.ao-testnet.xyz";
 
-const { dryrun: arDriveDryrun } = connect({ CU_URL: ARDRIVE_CU_URL });
 const { dryrun: aoDevDryrun } = connect({ CU_URL: AO_DEV_CU_URL });
-
-const ARDRIVE_PROCESSES = [ARIO_MAINNET_PROCESS_ID, ARIO_TESTNET_PROCESS_ID];
 
 export const getDryrunForProcess = (processId: string) => {
   if (processId === UTD_PROCESS_ID) return { dryrunFn: aoDevDryrun, isCustomDryrun: true };
-  if (ARDRIVE_PROCESSES.includes(processId)) return { dryrunFn: arDriveDryrun, isCustomDryrun: true };
 
   return { dryrunFn: dryrun, isCustomDryrun: false };
 };

--- a/src/tokens/aoTokens/ao.ts
+++ b/src/tokens/aoTokens/ao.ts
@@ -61,7 +61,7 @@ export const DEFAULT_CU_URL = "https://cu.ao-testnet.xyz";
 const { dryrun: arDriveDryrun } = connect({ CU_URL: ARDRIVE_CU_URL });
 const { dryrun: aoDevDryrun } = connect({ CU_URL: AO_DEV_CU_URL });
 
-const ARDRIVE_PROCESSES = [ARIO_MAINNET_PROCESS_ID, ARIO_TESTNET_PROCESS_ID, WNDR_PROCESS_ID, USDA_PROCESS_ID];
+const ARDRIVE_PROCESSES = [ARIO_MAINNET_PROCESS_ID, ARIO_TESTNET_PROCESS_ID];
 
 export const getDryrunForProcess = (processId: string) => {
   if (processId === UTD_PROCESS_ID) return { dryrunFn: aoDevDryrun, isCustomDryrun: true };


### PR DESCRIPTION
## Summary

This PR removes WNDR & USDA process from using ardrive cu and leaves ARIO token processes as it is.