### PR TITLE
fix: update components package & tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   "dependencies": {
     "@ar.io/sdk": "^3.18.0",
     "@arconnect/components": "^1.0.0",
-    "@arconnect/components-rebrand": "https://github.com/wanderwallet/components-rebrand.git#fix/tooltip",
     "@arconnect/keystone-sdk": "^0.0.5",
     "@dha-team/arbundles": "^1.0.2",
     "@iconicicons/react": "^1.5.0",
@@ -77,6 +76,7 @@
     "@tanstack/react-query-persist-client": "^5.84.2",
     "@untitled-ui/icons-react": "^0.1.1",
     "@vitejs/plugin-react": "^4.3.4",
+    "@wanderapp/components": "https://github.com/wanderwallet/components.git#fix/tooltip-styles",
     "@wanderapp/webext-bridge": "^5.0.7",
     "ao-tokens": "^0.0.6",
     "ar-gql": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@tanstack/react-query-persist-client": "^5.84.2",
     "@untitled-ui/icons-react": "^0.1.1",
     "@vitejs/plugin-react": "^4.3.4",
-    "@wanderapp/components": "https://github.com/wanderwallet/components.git#fix/tooltip-styles",
+    "@wanderapp/components": "^1.0.1",
     "@wanderapp/webext-bridge": "^5.0.7",
     "ao-tokens": "^0.0.6",
     "ar-gql": "3.1.1",

--- a/shim.d.ts
+++ b/shim.d.ts
@@ -1,4 +1,4 @@
-import type { DisplayTheme } from "@arconnect/components-rebrand";
+import type { DisplayTheme } from "@wanderapp/components";
 import type { Chunk } from "~api/modules/sign/chunks";
 import type { InjectedEvents } from "~utils/events";
 import "styled-components";

--- a/src/components/AdaptiveBalanceDisplay.tsx
+++ b/src/components/AdaptiveBalanceDisplay.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import styled from "styled-components";
 import { formatTokenBalance } from "~tokens/currency";
 import { TokenLogo } from "~components/popup/TokenLogo";

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { Text, type TextProps } from "@arconnect/components-rebrand";
+import { Text, type TextProps } from "@wanderapp/components";
 import { useCallback, useMemo, type HTMLAttributes, type HTMLProps } from "react";
 import styled from "styled-components";
 

--- a/src/components/CodeArea.tsx
+++ b/src/components/CodeArea.tsx
@@ -1,4 +1,4 @@
-import type { DisplayTheme } from "@arconnect/components-rebrand";
+import type { DisplayTheme } from "@wanderapp/components";
 import type { PropsWithChildren } from "react";
 import styled from "styled-components";
 import { useTheme } from "~utils/theme/theme.hook";

--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import styled from "styled-components";
-import { Text, useToasts } from "@arconnect/components-rebrand";
+import { Text, useToasts } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import copy from "copy-to-clipboard";
 import { Check, Copy02 } from "@untitled-ui/icons-react";

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,5 +1,5 @@
 import styled, { css, keyframes } from "styled-components";
-import { Button } from "@arconnect/components-rebrand";
+import { Button } from "@wanderapp/components";
 
 export const IconButton = styled(Button)`
   padding: 1.2rem;

--- a/src/components/InputMenu.tsx
+++ b/src/components/InputMenu.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
 import { hoverEffect } from "~utils/theme";
-import type { DisplayTheme } from "@arconnect/components-rebrand";
+import type { DisplayTheme } from "@wanderapp/components";
 import { CloseIcon, ChevronDownIcon, SearchIcon } from "@iconicicons/react";
 import amex from "url:/assets/ecosystem/amex.svg";
 import mastercard from "url:/assets/ecosystem/mastercard.svg";

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import styled from "styled-components";
 import browser from "webextension-polyfill";
 import { motion } from "framer-motion";

--- a/src/components/Paragraph.tsx
+++ b/src/components/Paragraph.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import styled from "styled-components";
 
 const Paragraph = styled(Text).attrs({

--- a/src/components/SeedInput.tsx
+++ b/src/components/SeedInput.tsx
@@ -3,7 +3,7 @@ import { type DragEvent, useCallback, useEffect, useMemo, useState } from "react
 import { CloseIcon, FolderIcon, WalletIcon } from "@iconicicons/react";
 import type { JWKInterface } from "arweave/web/lib/wallet";
 import styled, { keyframes, useTheme } from "styled-components";
-import { Loading, Text } from "@arconnect/components-rebrand";
+import { Loading, Text } from "@wanderapp/components";
 import { formatAddress } from "~utils/format";
 import { readFileString } from "~utils/file";
 import { wordlists } from "bip39-web-crypto";

--- a/src/components/SendInput.tsx
+++ b/src/components/SendInput.tsx
@@ -1,4 +1,4 @@
-import { type InputStatus, Text } from "@arconnect/components-rebrand";
+import { type InputStatus, Text } from "@wanderapp/components";
 import { ChevronDown, AlertCircle, SearchSm } from "@untitled-ui/icons-react";
 import { type HTMLProps, useState, useMemo, type CSSProperties, type ReactNode } from "react";
 import styled from "styled-components";

--- a/src/components/Slider.tsx
+++ b/src/components/Slider.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, forwardRef } from "react";
 import styled from "styled-components";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import throttle from "lodash/throttle";
 
 interface SliderProps {

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,4 +1,4 @@
-import { Section } from "@arconnect/components-rebrand";
+import { Section } from "@wanderapp/components";
 import { type CSSProperties, type Dispatch, type SetStateAction } from "react";
 import styled from "styled-components";
 import browser from "webextension-polyfill";

--- a/src/components/arlocal/InputWrapper.tsx
+++ b/src/components/arlocal/InputWrapper.tsx
@@ -1,5 +1,5 @@
 import { IconButton } from "~components/IconButton";
-import { Button } from "@arconnect/components-rebrand";
+import { Button } from "@wanderapp/components";
 import styled from "styled-components";
 
 export const InputWithBtn = styled.div`

--- a/src/components/arlocal/Mint.tsx
+++ b/src/components/arlocal/Mint.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Text, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Button, Input, Text, useInput, useToasts } from "@wanderapp/components";
 import { InputWithBtn, InputWrapper } from "./InputWrapper";
 import { useStorage } from "~utils/storage";
 import { ExtensionStorage } from "~utils/storage";

--- a/src/components/arlocal/Transaction.tsx
+++ b/src/components/arlocal/Transaction.tsx
@@ -8,7 +8,7 @@ import { IconButton } from "~components/IconButton";
 import { readFileBinary } from "~utils/file";
 import { useRef, useState } from "react";
 import { unlock } from "~wallets/auth";
-import { Button, Input, Spacer, useInput, Text, FileInput, useToasts } from "@arconnect/components-rebrand";
+import { Button, Input, Spacer, useInput, Text, FileInput, useToasts } from "@wanderapp/components";
 import type Arweave from "arweave";
 import browser from "webextension-polyfill";
 import styled from "styled-components";

--- a/src/components/arlocal/Tutorial.tsx
+++ b/src/components/arlocal/Tutorial.tsx
@@ -1,4 +1,4 @@
-import { Input, type InputStatus, Spacer, Text } from "@arconnect/components-rebrand";
+import { Input, type InputStatus, Spacer, Text } from "@wanderapp/components";
 import { InputWithBtn, InputWrapper } from "./InputWrapper";
 import { IconButton } from "~components/IconButton";
 import { CopyIcon } from "@iconicicons/react";

--- a/src/components/auth/App.tsx
+++ b/src/components/auth/App.tsx
@@ -1,4 +1,4 @@
-import { type DisplayTheme, Section, Spacer, Text, ListItem } from "@arconnect/components-rebrand";
+import { type DisplayTheme, Section, Spacer, Text, ListItem } from "@wanderapp/components";
 import { type Gateway } from "~gateways/gateway";
 import type { Allowance } from "~applications/allowance";
 import { GridIcon } from "@iconicicons/react";

--- a/src/components/auth/AuthButtons.tsx
+++ b/src/components/auth/AuthButtons.tsx
@@ -1,4 +1,4 @@
-import { Button, Spacer, type ButtonProps } from "@arconnect/components-rebrand";
+import { Button, Spacer, type ButtonProps } from "@wanderapp/components";
 import { useThrottledRequestAnimationFrame } from "@swyg/corre";
 import { useRef, type MouseEvent } from "react";
 import styled from "styled-components";

--- a/src/components/auth/CustomGatewayWarning.tsx
+++ b/src/components/auth/CustomGatewayWarning.tsx
@@ -1,6 +1,6 @@
 import { WarningTriangleIcon } from "@iconicicons/react";
 import { motion, type Variants } from "framer-motion";
-import { Section } from "@arconnect/components-rebrand";
+import { Section } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
 

--- a/src/components/auth/Label.tsx
+++ b/src/components/auth/Label.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import styled from "styled-components";
 
 const Label = styled(Text).attrs({

--- a/src/components/auth/Message.tsx
+++ b/src/components/auth/Message.tsx
@@ -1,4 +1,4 @@
-import { Card, Spacer, Text } from "@arconnect/components-rebrand";
+import { Card, Spacer, Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { useMemo, useState } from "react";
 import styled from "styled-components";

--- a/src/components/auth/PermissionCheckbox.tsx
+++ b/src/components/auth/PermissionCheckbox.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import styled from "styled-components";
 import { ToggleSwitch } from "~components/ToggleSwitch";
 

--- a/src/components/auth/Permissions.tsx
+++ b/src/components/auth/Permissions.tsx
@@ -1,4 +1,4 @@
-import { Section, Text } from "@arconnect/components-rebrand";
+import { Section, Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
 import { permissionData, type PermissionType } from "~applications/permissions";

--- a/src/components/common/IconButton.tsx
+++ b/src/components/common/IconButton.tsx
@@ -1,4 +1,4 @@
-import { Loading } from "@arconnect/components-rebrand";
+import { Loading } from "@wanderapp/components";
 import styled from "styled-components";
 
 export const IconButton = styled.button.attrs<ButtonProps>((props) => ({

--- a/src/components/common/InputButton.tsx
+++ b/src/components/common/InputButton.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import styled from "styled-components";
 
 export const InputButton = ({

--- a/src/components/common/ParseTextWithLinks.tsx
+++ b/src/components/common/ParseTextWithLinks.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import styled from "styled-components";
 import { isURL } from "~utils/urls/isURL";
-import { Button, type ButtonProps } from "@arconnect/components-rebrand";
+import { Button, type ButtonProps } from "@wanderapp/components";
 import type { WanderRoutePath, NavigateFn } from "~wallets/router/router.types";
 import browser from "webextension-polyfill";
 import { useLocation } from "~wallets/router/router.utils";

--- a/src/components/dashboard/About.tsx
+++ b/src/components/dashboard/About.tsx
@@ -1,4 +1,4 @@
-import { Spacer, Text } from "@arconnect/components-rebrand";
+import { Spacer, Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
 import { getPreReleaseVersionLabel, getVersionLabel } from "~utils/runtime";

--- a/src/components/dashboard/Analytics.tsx
+++ b/src/components/dashboard/Analytics.tsx
@@ -1,4 +1,4 @@
-import { Spacer, Text } from "@arconnect/components-rebrand";
+import { Spacer, Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
 import { ExtensionStorage } from "~utils/storage";

--- a/src/components/dashboard/Applications.tsx
+++ b/src/components/dashboard/Applications.tsx
@@ -1,4 +1,4 @@
-import { Text, useInput } from "@arconnect/components-rebrand";
+import { Text, useInput } from "@wanderapp/components";
 import { useEffect, useMemo, useState } from "react";
 import { PersistentStorage, useStorage } from "~utils/storage";
 import { SettingsList } from "./list/BaseElement";

--- a/src/components/dashboard/Contacts.tsx
+++ b/src/components/dashboard/Contacts.tsx
@@ -1,4 +1,4 @@
-import { Button, Spacer, Text, useInput } from "@arconnect/components-rebrand";
+import { Button, Spacer, Text, useInput } from "@wanderapp/components";
 import React, { useState, useEffect, useMemo } from "react";
 import { useStorage } from "~utils/storage";
 import { ExtensionStorage } from "~utils/storage";

--- a/src/components/dashboard/NotificationSettings.tsx
+++ b/src/components/dashboard/NotificationSettings.tsx
@@ -1,7 +1,7 @@
 import { useStorage } from "~utils/storage";
 import styled from "styled-components";
 import { ExtensionStorage } from "~utils/storage";
-import { Checkbox, Spacer, Text } from "@arconnect/components-rebrand";
+import { Checkbox, Spacer, Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { RadioWrapper } from "./Setting";
 import { ToggleSwitch } from "~components/ToggleSwitch";

--- a/src/components/dashboard/Reset.tsx
+++ b/src/components/dashboard/Reset.tsx
@@ -1,4 +1,4 @@
-import { Text, Spacer, Button, useModal, Modal, useToasts, type DisplayTheme } from "@arconnect/components-rebrand";
+import { Text, Spacer, Button, useModal, Modal, useToasts, type DisplayTheme } from "@wanderapp/components";
 import { TrashIcon } from "@iconicicons/react";
 import browser from "webextension-polyfill";
 import styled from "styled-components";

--- a/src/components/dashboard/SearchInput.tsx
+++ b/src/components/dashboard/SearchInput.tsx
@@ -1,4 +1,4 @@
-import { Input } from "@arconnect/components-rebrand";
+import { Input } from "@wanderapp/components";
 import type { HTMLProps } from "react";
 import styled from "styled-components";
 

--- a/src/components/dashboard/Setting.tsx
+++ b/src/components/dashboard/Setting.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Input, Text, useInput } from "@arconnect/components-rebrand";
+import { Checkbox, Input, Text, useInput } from "@wanderapp/components";
 import { setting_element_padding } from "./list/BaseElement";
 import type SettingType from "~settings/setting";
 import browser from "webextension-polyfill";

--- a/src/components/dashboard/SignSettings.tsx
+++ b/src/components/dashboard/SignSettings.tsx
@@ -1,4 +1,4 @@
-import { Text, Input } from "@arconnect/components-rebrand";
+import { Text, Input } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
 import { ExtensionStorage } from "~utils/storage";

--- a/src/components/dashboard/Tokens.tsx
+++ b/src/components/dashboard/Tokens.tsx
@@ -7,7 +7,7 @@ import { Reorder } from "framer-motion";
 import TokenListItem from "./list/TokenListItem";
 import styled from "styled-components";
 import browser from "webextension-polyfill";
-import { Button, Spacer } from "@arconnect/components-rebrand";
+import { Button, Spacer } from "@wanderapp/components";
 import { type TokenInfoWithBalance } from "~tokens/aoTokens/ao";
 import { useLocation } from "~wallets/router/router.utils";
 

--- a/src/components/dashboard/Wallets.tsx
+++ b/src/components/dashboard/Wallets.tsx
@@ -1,4 +1,4 @@
-import { Button, useInput } from "@arconnect/components-rebrand";
+import { Button, useInput } from "@wanderapp/components";
 import { Reorder } from "framer-motion";
 import { useEffect, useMemo } from "react";
 import styled from "styled-components";

--- a/src/components/dashboard/list/AppListItem.tsx
+++ b/src/components/dashboard/list/AppListItem.tsx
@@ -1,4 +1,4 @@
-import { ListItem } from "@arconnect/components-rebrand";
+import { ListItem } from "@wanderapp/components";
 import { GridIcon } from "@iconicicons/react";
 import type { HTMLProps } from "react";
 import { Image } from "~components/common/Image/Image";

--- a/src/components/dashboard/list/BaseElement.tsx
+++ b/src/components/dashboard/list/BaseElement.tsx
@@ -1,6 +1,6 @@
 import type { DragControls } from "framer-motion";
 import { SettingsIcon } from "@iconicicons/react";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import type { HTMLProps, ReactNode } from "react";
 import Squircle from "~components/Squircle";
 import ReorderIcon from "../ReorderIcon";

--- a/src/components/dashboard/list/ContactListItem.tsx
+++ b/src/components/dashboard/list/ContactListItem.tsx
@@ -1,4 +1,4 @@
-import { ListItem } from "@arconnect/components-rebrand";
+import { ListItem } from "@wanderapp/components";
 import type { HTMLProps } from "react";
 import { NoAvatarIcon } from "~components/Avatar";
 

--- a/src/components/dashboard/list/SettingListItem.tsx
+++ b/src/components/dashboard/list/SettingListItem.tsx
@@ -1,4 +1,4 @@
-import { ListItem } from "@arconnect/components-rebrand";
+import { ListItem } from "@wanderapp/components";
 import type { Icon } from "~settings/setting";
 import browser from "webextension-polyfill";
 import type { HTMLProps } from "react";

--- a/src/components/dashboard/list/TokenListItem.tsx
+++ b/src/components/dashboard/list/TokenListItem.tsx
@@ -1,7 +1,7 @@
 import { type Token } from "~tokens/token";
 import { Reorder, useDragControls } from "framer-motion";
 import { useMemo } from "react";
-import { ListItem } from "@arconnect/components-rebrand";
+import { ListItem } from "@wanderapp/components";
 import { formatAddress } from "~utils/format";
 import styled from "styled-components";
 import { useLocation } from "~wallets/router/router.utils";

--- a/src/components/dashboard/list/WalletListItem.tsx
+++ b/src/components/dashboard/list/WalletListItem.tsx
@@ -4,7 +4,7 @@ import { formatAddress } from "~utils/format";
 import type { StoredWallet } from "~wallets";
 import HardwareWalletIcon from "~components/hardware/HardwareWalletIcon";
 import keystoneLogo from "url:/assets/hardware/keystone.png";
-import { ListItem, ListItemIcon, Text } from "@arconnect/components-rebrand";
+import { ListItem, ListItemIcon, Text } from "@wanderapp/components";
 import Online from "~components/Online";
 import { NoAvatarIcon } from "~components/Avatar";
 

--- a/src/components/dashboard/subsettings/AddContact.tsx
+++ b/src/components/dashboard/subsettings/AddContact.tsx
@@ -13,7 +13,7 @@ import {
   SubTitle,
   Title,
 } from "./ContactSettings";
-import { Button, Modal, Spacer, useModal, useToasts } from "@arconnect/components-rebrand";
+import { Button, Modal, Spacer, useModal, useToasts } from "@wanderapp/components";
 import { useStorage } from "~utils/storage";
 import { ExtensionStorage } from "~utils/storage";
 import { useEffect, useState } from "react";

--- a/src/components/dashboard/subsettings/AddToken.tsx
+++ b/src/components/dashboard/subsettings/AddToken.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Select, Spacer, Text, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Button, Input, Select, Spacer, Text, useInput, useToasts } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { useEffect, useState } from "react";
 import { fetchTokenByProcessId, type TokenInfo } from "~tokens/aoTokens/ao";

--- a/src/components/dashboard/subsettings/AddWallet.tsx
+++ b/src/components/dashboard/subsettings/AddWallet.tsx
@@ -5,7 +5,7 @@ import type { JWKInterface } from "arweave/web/lib/wallet";
 import { checkPassword } from "~wallets/auth";
 import { useEffect, useState } from "react";
 import { addWallet, getWalletKeyLength } from "~wallets";
-import { Text, useInput, Spacer, useToasts, Button, Input, useModal, Tooltip } from "@arconnect/components-rebrand";
+import { Text, useInput, Spacer, useToasts, Button, Input, useModal, Tooltip } from "@wanderapp/components";
 import BackupWalletPage from "~components/welcome/generate/BackupWalletPage";
 import KeystoneButton from "~components/hardware/KeystoneButton";
 import SeedInput from "~components/SeedInput";

--- a/src/components/dashboard/subsettings/AppSettings.tsx
+++ b/src/components/dashboard/subsettings/AppSettings.tsx
@@ -16,7 +16,7 @@ import {
   useInput,
   useModal,
   useToasts,
-} from "@arconnect/components-rebrand";
+} from "@wanderapp/components";
 import { concatGatewayURL, urlToGateway } from "~gateways/utils";
 import Application from "~applications/application";
 import browser from "webextension-polyfill";

--- a/src/components/dashboard/subsettings/ContactSettings.tsx
+++ b/src/components/dashboard/subsettings/ContactSettings.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
   useModal,
   useToasts,
-} from "@arconnect/components-rebrand";
+} from "@wanderapp/components";
 import { useState, useEffect, type MouseEventHandler } from "react";
 import { Share04, Upload01 } from "@untitled-ui/icons-react";
 import { uploadUserAvatar, getUserAvatar } from "~lib/avatar";

--- a/src/components/dashboard/subsettings/TokenSettings.tsx
+++ b/src/components/dashboard/subsettings/TokenSettings.tsx
@@ -1,4 +1,4 @@
-import { Button, Select, Spacer, Text, Tooltip, useToasts } from "@arconnect/components-rebrand";
+import { Button, Select, Spacer, Text, Tooltip, useToasts } from "@wanderapp/components";
 import type { TokenType } from "~tokens/token";
 import { Token as aoToken } from "ao-tokens";
 import { PersistentStorage, useStorage } from "~utils/storage";

--- a/src/components/dashboard/subsettings/WalletSettings.tsx
+++ b/src/components/dashboard/subsettings/WalletSettings.tsx
@@ -1,14 +1,4 @@
-import {
-  Button,
-  Input,
-  Modal,
-  Spacer,
-  Text,
-  Tooltip,
-  useInput,
-  useModal,
-  useToasts,
-} from "@arconnect/components-rebrand";
+import { Button, Input, Modal, Spacer, Text, Tooltip, useInput, useModal, useToasts } from "@wanderapp/components";
 import { CopyIcon, DownloadIcon, TrashIcon } from "@iconicicons/react";
 import copy from "copy-to-clipboard";
 import { useEffect, useMemo } from "react";

--- a/src/components/devtools/Connector.tsx
+++ b/src/components/devtools/Connector.tsx
@@ -1,5 +1,5 @@
 import { permissionData, type PermissionType } from "~applications/permissions";
-import { Button, Spacer, useToasts, Text } from "@arconnect/components-rebrand";
+import { Button, Spacer, useToasts, Text } from "@wanderapp/components";
 import type { AppInfo } from "~applications/application";
 import { PermissionDescription } from "~components/auth/PermissionCheckbox";
 import { useState } from "react";

--- a/src/components/hardware/AnimatedQRPlayer.tsx
+++ b/src/components/hardware/AnimatedQRPlayer.tsx
@@ -1,7 +1,7 @@
 import { AnimatedQRPlayer as Player } from "@arconnect/keystone-sdk";
 import styled, { useTheme } from "styled-components";
 import { type ComponentProps, useMemo } from "react";
-import { Loading } from "@arconnect/components-rebrand";
+import { Loading } from "@wanderapp/components";
 
 export default function AnimatedQRPlayer(props: ComponentProps<typeof Player>) {
   // global theme

--- a/src/components/hardware/KeystoneButton.tsx
+++ b/src/components/hardware/KeystoneButton.tsx
@@ -4,7 +4,7 @@ import { useScanner } from "@arconnect/keystone-sdk";
 import { Alert, Icon as WarningIcon } from "~components/auth/CustomGatewayWarning";
 import { useState } from "react";
 import { Modal, Spacer, Text, useModal, useToasts } from "@arconnect/components";
-import { Button } from "@arconnect/components-rebrand";
+import { Button } from "@wanderapp/components";
 import AnimatedQRScanner from "./AnimatedQRScanner";
 import browser from "webextension-polyfill";
 import styled from "styled-components";

--- a/src/components/help/HelpListItems.tsx
+++ b/src/components/help/HelpListItems.tsx
@@ -1,7 +1,7 @@
 import { LinkExternal02 } from "@untitled-ui/icons-react";
 import styled, { useTheme } from "styled-components";
 import browser from "webextension-polyfill";
-import { ListItem, Text } from "@arconnect/components-rebrand";
+import { ListItem, Text } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import { TierTag } from "~components/popup/tier/TierTag";
 import { HelpCircle, Mail01, VideoRecorder } from "@untitled-ui/icons-react";

--- a/src/components/modals/QRModal.tsx
+++ b/src/components/modals/QRModal.tsx
@@ -1,4 +1,4 @@
-import { Modal } from "@arconnect/components-rebrand";
+import { Modal } from "@wanderapp/components";
 import { useRef } from "react";
 import { ContentWrapper, Content } from "./Components";
 import { QRCodeSVG } from "qrcode.react";

--- a/src/components/popup/ActionButtons.tsx
+++ b/src/components/popup/ActionButtons.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@arconnect/components-rebrand";
+import { Button } from "@wanderapp/components";
 import styled from "styled-components";
 import type { WanderRoutePath } from "~wallets/router/router.types";
 import { useLocation } from "~wallets/router/router.utils";

--- a/src/components/popup/FeedFilterPopup.tsx
+++ b/src/components/popup/FeedFilterPopup.tsx
@@ -1,4 +1,4 @@
-import { ListItem } from "@arconnect/components-rebrand";
+import { ListItem } from "@wanderapp/components";
 import { ContentWrapper } from "~components/modals/Components";
 import SliderMenu from "~components/SliderMenu";
 import { Check } from "@untitled-ui/icons-react";

--- a/src/components/popup/HeadV2.tsx
+++ b/src/components/popup/HeadV2.tsx
@@ -1,4 +1,4 @@
-import { type DisplayTheme, Section, Text, Tooltip } from "@arconnect/components-rebrand";
+import { type DisplayTheme, Section, Text, Tooltip } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { Action, CloseLayer } from "./WalletHeader";
 import { AnimatePresence } from "framer-motion";

--- a/src/components/popup/Navigation.tsx
+++ b/src/components/popup/Navigation.tsx
@@ -9,7 +9,7 @@ import HedgehogHeadIcon from "url:/assets/agents/images/hedgehog-head.svg";
 import { useAOMintingStatus } from "~utils/agents/hooks";
 import { EventType, trackEvent } from "~utils/analytics";
 import { useHasClaimableBalance } from "~utils/fair_launch/fair_launch.hooks";
-import { Tooltip } from "@arconnect/components-rebrand";
+import { Tooltip } from "@wanderapp/components";
 import { MaintenanceTag } from "./home/MaintenanceTag";
 
 const Home05Active = () => (

--- a/src/components/popup/PendingTransactionsNotice.tsx
+++ b/src/components/popup/PendingTransactionsNotice.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import clockwiseIcon from "url:/assets/icons/clockwise.svg";
 import {
   useTokenPendingTransactionsStats,

--- a/src/components/popup/PendingTransactionsTooltip.tsx
+++ b/src/components/popup/PendingTransactionsTooltip.tsx
@@ -1,4 +1,4 @@
-import { Tooltip, Text } from "@arconnect/components-rebrand";
+import { Tooltip } from "@wanderapp/components";
 import styled from "styled-components";
 import clockwiseIcon from "url:/assets/icons/clockwise.svg";
 import {
@@ -19,19 +19,8 @@ export function PendingTransactionsTooltip({ tokenId, ticker }: PendingTransacti
 
   return (
     <Tooltip
-      content={
-        <Text
-          size="sm"
-          style={{
-            textAlign: "center",
-            maxWidth: "200px",
-            whiteSpace: "normal",
-            wordWrap: "break-word",
-          }}
-          noMargin>
-          {message}
-        </Text>
-      }
+      style={{ textAlign: "center", maxWidth: "200px", whiteSpace: "normal", wordWrap: "break-word" }}
+      content={message}
       position="top">
       <PendingIcon src={clockwiseIcon} alt="Pending" />
     </Tooltip>

--- a/src/components/popup/Title.tsx
+++ b/src/components/popup/Title.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import styled from "styled-components";
 
 const Title = styled(Text)`

--- a/src/components/popup/Token.tsx
+++ b/src/components/popup/Token.tsx
@@ -4,7 +4,7 @@ import { hoverEffect } from "~utils/theme";
 import { type Token } from "~tokens/token";
 import { useStorage } from "~utils/storage";
 import { ExtensionStorage } from "~utils/storage";
-import { Button, Text, Tooltip, type TextProps, type TooltipProps } from "@arconnect/components-rebrand";
+import { Button, Text, Tooltip, type TextProps, type TooltipProps } from "@wanderapp/components";
 import useSetting from "~settings/hook";
 import styled from "styled-components";
 import { formatAddress, formatBalance } from "~utils/format";

--- a/src/components/popup/WalletHeader.tsx
+++ b/src/components/popup/WalletHeader.tsx
@@ -7,7 +7,7 @@ import { useHardwareApi } from "~wallets/hooks";
 import type { StoredWallet } from "~wallets";
 import { formatAddress, getAppURL, truncateMiddle } from "~utils/format";
 import { removeApp } from "~applications";
-import { Button, Card, type DisplayTheme, Text, useToasts, Tooltip } from "@arconnect/components-rebrand";
+import { Button, Card, type DisplayTheme, Text, useToasts, Tooltip } from "@wanderapp/components";
 import { CheckIcon, CopyIcon, GlobeIcon, LogOutIcon, SettingsIcon } from "@iconicicons/react";
 import WalletSwitcher, { popoverAnimation } from "./WalletSwitcher";
 import Application, { type AppInfo } from "~applications/application";

--- a/src/components/popup/WalletSwitcher.tsx
+++ b/src/components/popup/WalletSwitcher.tsx
@@ -1,4 +1,4 @@
-import { Button, ListItem, Spacer, Text, useToasts } from "@arconnect/components-rebrand";
+import { Button, ListItem, Spacer, Text, useToasts } from "@wanderapp/components";
 import { PlusCircle, QrCode02, XClose } from "@untitled-ui/icons-react";
 import BigNumber from "bignumber.js";
 import { type Variants } from "framer-motion";

--- a/src/components/popup/chart/LineChart.tsx
+++ b/src/components/popup/chart/LineChart.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import styled, { useTheme } from "styled-components";
 import { LineChart as RechartsLineChart, Line, ResponsiveContainer, YAxis } from "recharts";
-import { Text, Loading } from "@arconnect/components-rebrand";
+import { Text, Loading } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 
 export interface ChartDataPoint {

--- a/src/components/popup/earn/AddTokenPopup.tsx
+++ b/src/components/popup/earn/AddTokenPopup.tsx
@@ -1,10 +1,9 @@
 import browser from "webextension-polyfill";
 import SliderMenu from "~components/SliderMenu";
-import { Input, Section, useInput } from "@wanderapp/components";
+import { Input, Section, useInput, Text, useToasts } from "@wanderapp/components";
 import styled from "styled-components";
 import { useCallback, useMemo, type MouseEventHandler } from "react";
 import { type Token } from "~tokens/token";
-import { Text, useToasts } from "@wanderapp/components";
 import { ToggleSwitch } from "~components/ToggleSwitch";
 import type { FlpTokenInfo } from "~utils/fair_launch/fair_launch.types";
 import { useActiveAddress } from "~wallets/hooks";

--- a/src/components/popup/earn/AddTokenPopup.tsx
+++ b/src/components/popup/earn/AddTokenPopup.tsx
@@ -1,10 +1,10 @@
 import browser from "webextension-polyfill";
 import SliderMenu from "~components/SliderMenu";
-import { Input, Section, useInput } from "@arconnect/components-rebrand";
+import { Input, Section, useInput } from "@wanderapp/components";
 import styled from "styled-components";
 import { useCallback, useMemo, type MouseEventHandler } from "react";
 import { type Token } from "~tokens/token";
-import { Text, useToasts } from "@arconnect/components-rebrand";
+import { Text, useToasts } from "@wanderapp/components";
 import { ToggleSwitch } from "~components/ToggleSwitch";
 import type { FlpTokenInfo } from "~utils/fair_launch/fair_launch.types";
 import { useActiveAddress } from "~wallets/hooks";

--- a/src/components/popup/earn/EarnAOTokensDetectedNotice.tsx
+++ b/src/components/popup/earn/EarnAOTokensDetectedNotice.tsx
@@ -1,4 +1,4 @@
-import { Text, Button } from "@arconnect/components-rebrand";
+import { Text, Button } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { Flex } from "~components/common/Flex";
 import { AnimatedStarContainer, defaultStars } from "~components/common/AnimatedStarContainer";

--- a/src/components/popup/earn/EarnDelegationNotice.tsx
+++ b/src/components/popup/earn/EarnDelegationNotice.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRight } from "@untitled-ui/icons-react";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { Flex } from "~components/common/Flex";
 import { AnimatedStarContainer, defaultStars } from "~components/common/AnimatedStarContainer";

--- a/src/components/popup/earn/EarnPopup.tsx
+++ b/src/components/popup/earn/EarnPopup.tsx
@@ -1,6 +1,6 @@
 import { Flex } from "~components/common/Flex";
 import SliderMenu from "~components/SliderMenu";
-import { Text, Button } from "@arconnect/components-rebrand";
+import { Text, Button } from "@wanderapp/components";
 import earnPopupImage from "~assets/images/earn/earn-popup.svg";
 import { StarIcon } from "../tier/StarIcon";
 import browser from "webextension-polyfill";

--- a/src/components/popup/earn/EarnTabs.tsx
+++ b/src/components/popup/earn/EarnTabs.tsx
@@ -3,7 +3,7 @@ import { useLocation, useSearchParams } from "~wallets/router/router.utils";
 import Tabs from "~components/Tabs";
 import { Flex } from "~components/common/Flex";
 import styled, { useTheme } from "styled-components";
-import { Text, Loading, useToasts, Tooltip } from "@arconnect/components-rebrand";
+import { Text, Loading, useToasts, Tooltip } from "@wanderapp/components";
 import { useTokenBalance } from "~tokens/hooks";
 import { useActiveAddress } from "~wallets/hooks";
 import { formatBalance } from "~utils/format";

--- a/src/components/popup/home/ArNSBanner.tsx
+++ b/src/components/popup/home/ArNSBanner.tsx
@@ -7,7 +7,7 @@ import { useNameServiceProfile } from "~lib/nameservice";
 import { ExtensionStorage } from "~utils/storage";
 import { PopupPaths } from "~wallets/router/popup/popup.routes";
 import browser from "webextension-polyfill";
-import { type DisplayTheme, Text } from "@arconnect/components-rebrand";
+import { type DisplayTheme, Text } from "@wanderapp/components";
 import { ExitButton } from "~components/ExitButton";
 import { EventType, trackEvent } from "~utils/analytics";
 

--- a/src/components/popup/home/AstroBetaAccessAnnouncementPopup.tsx
+++ b/src/components/popup/home/AstroBetaAccessAnnouncementPopup.tsx
@@ -1,4 +1,4 @@
-import { Button, Text, ARCONNECT_DARK_THEME } from "@arconnect/components-rebrand";
+import { Button, Text, ARCONNECT_DARK_THEME } from "@wanderapp/components";
 import { ExtensionStorage } from "~utils/storage";
 import { Flex } from "~components/common/Flex";
 import SliderMenu from "~components/SliderMenu";

--- a/src/components/popup/home/Balance.tsx
+++ b/src/components/popup/home/Balance.tsx
@@ -1,4 +1,4 @@
-import { Loading } from "@arconnect/components-rebrand";
+import { Loading } from "@wanderapp/components";
 import { useEffect, useMemo, useState } from "react";
 import { useStorage } from "~utils/storage";
 import { PersistentStorage } from "~utils/storage";
@@ -6,7 +6,7 @@ import { useBalance } from "~wallets/hooks";
 import { getToken24hChange, useArPrice } from "~lib/coingecko";
 import useSetting from "~settings/hook";
 import styled, { useTheme } from "styled-components";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import BigNumber from "bignumber.js";
 import { useTotalFiatBalance } from "~tokens/hooks";
 import NumberFlow from "@number-flow/react";

--- a/src/components/popup/home/Balance.tsx
+++ b/src/components/popup/home/Balance.tsx
@@ -1,4 +1,4 @@
-import { Loading } from "@wanderapp/components";
+import { Loading, Text } from "@wanderapp/components";
 import { useEffect, useMemo, useState } from "react";
 import { useStorage } from "~utils/storage";
 import { PersistentStorage } from "~utils/storage";
@@ -6,7 +6,6 @@ import { useBalance } from "~wallets/hooks";
 import { getToken24hChange, useArPrice } from "~lib/coingecko";
 import useSetting from "~settings/hook";
 import styled, { useTheme } from "styled-components";
-import { Text } from "@wanderapp/components";
 import BigNumber from "bignumber.js";
 import { useTotalFiatBalance } from "~tokens/hooks";
 import NumberFlow from "@number-flow/react";

--- a/src/components/popup/home/MaintenanceTag.tsx
+++ b/src/components/popup/home/MaintenanceTag.tsx
@@ -2,7 +2,7 @@
 // import { WanderIcon } from "./WanderIcon";
 import styled, { useTheme } from "styled-components";
 import { InfoIcon } from "~components/embed";
-import { Tooltip } from "@arconnect/components-rebrand";
+import { Tooltip } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 
 interface MaintenanceTagProps {

--- a/src/components/popup/home/ManageAssets.tsx
+++ b/src/components/popup/home/ManageAssets.tsx
@@ -1,7 +1,7 @@
 import browser from "webextension-polyfill";
 import { useLocation } from "~wallets/router/router.utils";
 import SliderMenu from "~components/SliderMenu";
-import { Button, Input, Section, useInput } from "@arconnect/components-rebrand";
+import { Button, Input, Section, useInput } from "@wanderapp/components";
 import Token from "~components/popup/Token";
 import styled from "styled-components";
 import { type TokenInfo } from "~tokens/aoTokens/ao";

--- a/src/components/popup/home/StargridAccessAnnouncementPopup.tsx
+++ b/src/components/popup/home/StargridAccessAnnouncementPopup.tsx
@@ -1,4 +1,4 @@
-import { Button, Text, ARCONNECT_DARK_THEME } from "@arconnect/components-rebrand";
+import { Button, Text, ARCONNECT_DARK_THEME } from "@wanderapp/components";
 import { ExtensionStorage } from "~utils/storage";
 import { Flex } from "~components/common/Flex";
 import SliderMenu from "~components/SliderMenu";

--- a/src/components/popup/home/Tokens.tsx
+++ b/src/components/popup/home/Tokens.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import styled, { useTheme } from "styled-components";
 import Token from "../Token";

--- a/src/components/popup/home/Transactions.tsx
+++ b/src/components/popup/home/Transactions.tsx
@@ -1,7 +1,7 @@
 import browser from "webextension-polyfill";
 import { useEffect, useMemo, useState } from "react";
 import { ExtensionStorage } from "~utils/storage";
-import { Loading, Text } from "@arconnect/components-rebrand";
+import { Loading, Text } from "@wanderapp/components";
 import { useStorage } from "~utils/storage";
 import { gql } from "~gateways/api";
 import styled from "styled-components";

--- a/src/components/popup/home/WandAnnouncementPopup.tsx
+++ b/src/components/popup/home/WandAnnouncementPopup.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Button, Text } from "@arconnect/components-rebrand";
+import { Button, Text } from "@wanderapp/components";
 import { ExtensionStorage } from "~utils/storage";
 import { Flex } from "~components/common/Flex";
 import SliderMenu from "~components/SliderMenu";

--- a/src/components/popup/list/SettingListItem.tsx
+++ b/src/components/popup/list/SettingListItem.tsx
@@ -1,4 +1,4 @@
-import { ListItem } from "@arconnect/components-rebrand";
+import { ListItem } from "@wanderapp/components";
 import type { Icon } from "~settings/setting";
 import type { HTMLProps } from "react";
 import { LinkExternal02 } from "@untitled-ui/icons-react";

--- a/src/components/popup/settings/BackupSeedphraseWarning.tsx
+++ b/src/components/popup/settings/BackupSeedphraseWarning.tsx
@@ -1,4 +1,4 @@
-import { ListItem } from "@arconnect/components-rebrand";
+import { ListItem } from "@wanderapp/components";
 import { AlertTriangle } from "@untitled-ui/icons-react";
 import { useTheme } from "styled-components";
 import browser from "webextension-polyfill";

--- a/src/components/popup/settings/RevealRecoveryPhraseModal.tsx
+++ b/src/components/popup/settings/RevealRecoveryPhraseModal.tsx
@@ -3,7 +3,7 @@ import { useLocation } from "~wallets/router/router.utils";
 import SliderMenu from "~components/SliderMenu";
 import { AlertTriangle } from "@untitled-ui/icons-react";
 import { Flex } from "~components/common/Flex";
-import { Button, Text } from "@arconnect/components-rebrand";
+import { Button, Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { ExtensionStorage, useStorage } from "~utils/storage";
 

--- a/src/components/popup/tier/GetTokensButton.tsx
+++ b/src/components/popup/tier/GetTokensButton.tsx
@@ -2,7 +2,7 @@ import { TierButton } from "~components/popup/tier/TierButton";
 import browser from "webextension-polyfill";
 import type { Tier } from "~utils/tier/types";
 import { EventType, trackEvent } from "~utils/analytics";
-import { Button } from "@arconnect/components-rebrand";
+import { Button } from "@wanderapp/components";
 
 interface GetTokensButtonProps {
   tier?: Tier;

--- a/src/components/popup/tier/ProgressBar.tsx
+++ b/src/components/popup/tier/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import styled from "styled-components";

--- a/src/components/popup/tier/TierButton.tsx
+++ b/src/components/popup/tier/TierButton.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@arconnect/components-rebrand";
+import { Button } from "@wanderapp/components";
 import styled from "styled-components";
 import type { Tier } from "~utils/tier/types";
 

--- a/src/components/popup/tier/TierProgress.tsx
+++ b/src/components/popup/tier/TierProgress.tsx
@@ -1,4 +1,4 @@
-import { Text, Tooltip } from "@arconnect/components-rebrand";
+import { Text, Tooltip } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import type { ActiveTier, Tier } from "~utils/tier/types";
 import { ProgressBar } from "./ProgressBar";

--- a/src/components/popup/tier/TierProgressPopup.tsx
+++ b/src/components/popup/tier/TierProgressPopup.tsx
@@ -1,4 +1,4 @@
-import { Spacer, Text } from "@arconnect/components-rebrand";
+import { Spacer, Text } from "@wanderapp/components";
 import SliderMenu from "~components/SliderMenu";
 import styled from "styled-components";
 import { Flex } from "~components/common/Flex";

--- a/src/components/popup/tier/TierTag.tsx
+++ b/src/components/popup/tier/TierTag.tsx
@@ -1,5 +1,5 @@
 import styled, { useTheme, type DefaultTheme } from "styled-components";
-import { Loading, Text } from "@arconnect/components-rebrand";
+import { Loading, Text } from "@wanderapp/components";
 import { useActiveTier } from "~utils/tier/hooks";
 import { useLocation } from "~wallets/router/router.utils";
 import { WanderIcon } from "./WanderIcon";

--- a/src/components/popup/tier/TierWrapper.tsx
+++ b/src/components/popup/tier/TierWrapper.tsx
@@ -1,4 +1,4 @@
-import { Section } from "@arconnect/components-rebrand";
+import { Section } from "@wanderapp/components";
 import styled from "styled-components";
 import type { Tier } from "~utils/tier/types";
 

--- a/src/components/popup/tier/TiersPopup.tsx
+++ b/src/components/popup/tier/TiersPopup.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import SliderMenu from "~components/SliderMenu";
 import { Carousel } from "~components/Carousel";
 import styled from "styled-components";

--- a/src/components/popup/tokens/ActiveAgentsSlider.tsx
+++ b/src/components/popup/tokens/ActiveAgentsSlider.tsx
@@ -1,5 +1,5 @@
 import { Flex } from "~components/common/Flex";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { AO_PROCESS_ID, AR_PROCESS_ID } from "~tokens/aoTokens/ao.constants";
 import { useAOYieldLatestAgent } from "~utils/agents/hooks";

--- a/src/components/popup/tokens/PriceChart.tsx
+++ b/src/components/popup/tokens/PriceChart.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useCallback, useState } from "react";
 import styled, { useTheme } from "styled-components";
 import { useArPrice, type CoinGeckoSymbol } from "~lib/coingecko";
 import { formatFiatBalance } from "~tokens/currency";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import { useTokenMarketData } from "~tokens/hooks/useTokenMarketData";
 import useSetting from "~settings/hook";
 import TriangleIcon from "~components/icons/TriangleIcon";

--- a/src/components/popup/tokens/PriceChartModal.tsx
+++ b/src/components/popup/tokens/PriceChartModal.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useState } from "react";
 import styled, { useTheme } from "styled-components";
 import BigNumber from "bignumber.js";
 import browser from "webextension-polyfill";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import SliderMenu from "~components/SliderMenu";
 import { type CoinGeckoSymbol } from "~lib/coingecko";
 import useSetting from "~settings/hook";

--- a/src/components/popup/tokens/TokenActivity.tsx
+++ b/src/components/popup/tokens/TokenActivity.tsx
@@ -1,7 +1,7 @@
 import { useActiveAddress, useTokenTransactions } from "~wallets/hooks";
 import { TierTransactionItemComponent } from "../home/Transactions";
 import styled from "styled-components";
-import { Loading, Button, Text } from "@arconnect/components-rebrand";
+import { Loading, Button, Text } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import browser from "webextension-polyfill";
 

--- a/src/components/popup/tokens/TokenInfo.tsx
+++ b/src/components/popup/tokens/TokenInfo.tsx
@@ -6,7 +6,7 @@ import { useAoToken } from "~tokens/hooks";
 import { useTokenPriceChange } from "~tokens/hooks/useTokenPriceChange";
 import { useFormattedTokenBalance } from "~tokens/hooks/useFormattedTokenBalance";
 import useSetting from "~settings/hook";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import Skeleton from "~components/Skeleton";
 import TriangleIcon from "~components/icons/TriangleIcon";

--- a/src/components/popup/tokens/TokenLinks.tsx
+++ b/src/components/popup/tokens/TokenLinks.tsx
@@ -4,7 +4,7 @@ import browser from "webextension-polyfill";
 import { CopyToClipboard } from "~components/CopyToClipboard";
 import { getKnownTokenInfo } from "~tokens/knownTokens";
 import { formatAddress } from "~utils/format";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import { ArrowUpRight } from "@untitled-ui/icons-react";
 import styled from "styled-components";

--- a/src/components/welcome/PasswordStrength.tsx
+++ b/src/components/welcome/PasswordStrength.tsx
@@ -1,5 +1,5 @@
 import { type DiversityType, passwordStrength } from "check-password-strength";
-import { Spacer, Text } from "@arconnect/components-rebrand";
+import { Spacer, Text } from "@wanderapp/components";
 import { useMemo } from "react";
 import browser from "webextension-polyfill";
 import styled from "styled-components";

--- a/src/components/welcome/load/QRLoopScanner.tsx
+++ b/src/components/welcome/load/QRLoopScanner.tsx
@@ -1,11 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import QrReader from "react-qr-reader";
 import styled from "styled-components";
-import { Text, useToasts } from "@wanderapp/components";
+import { Text, useToasts, Loading, Spacer } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { parseFramesReducer, areFramesComplete, framesToData, progressOfFrames } from "qrloop";
 import { CameraOffIcon } from "@iconicicons/react";
-import { Loading, Spacer } from "@wanderapp/components";
 import { useAsyncEffect } from "~utils/react/useAsyncEffect";
 
 interface QRScannerProps {

--- a/src/components/welcome/load/QRLoopScanner.tsx
+++ b/src/components/welcome/load/QRLoopScanner.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 import QrReader from "react-qr-reader";
 import styled from "styled-components";
-import { Text, useToasts } from "@arconnect/components-rebrand";
+import { Text, useToasts } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { parseFramesReducer, areFramesComplete, framesToData, progressOfFrames } from "qrloop";
 import { CameraOffIcon } from "@iconicicons/react";
-import { Loading, Spacer } from "@arconnect/components-rebrand";
+import { Loading, Spacer } from "@wanderapp/components";
 import { useAsyncEffect } from "~utils/react/useAsyncEffect";
 
 interface QRScannerProps {

--- a/src/components/welcome/load/QRScanner.tsx
+++ b/src/components/welcome/load/QRScanner.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import QrScanner from "qr-scanner";
 import styled from "styled-components";
-import { Text, useToasts } from "@arconnect/components-rebrand";
+import { Text, useToasts } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { parseFramesReducer, areFramesComplete, framesToData, progressOfFrames } from "qrloop";
 

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -12,7 +12,7 @@ import { FallbackView } from "~components/page/common/Fallback/fallback.view";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ExtensionStorage } from "~utils/storage";
 import styled from "styled-components";
-import { Section } from "@arconnect/components-rebrand";
+import { Section } from "@wanderapp/components";
 import UpdateSplash from "~routes/welcome/UpdateSplash";
 import StarIcons from "~components/welcome/StarIcons";
 import { useActivityTracking } from "~utils/inactivity/inactivity.hooks";

--- a/src/routes/auth/allowance.tsx
+++ b/src/routes/auth/allowance.tsx
@@ -2,7 +2,7 @@ import { type AllowanceBigNumber, defaultAllowance } from "~applications/allowan
 import Application, { type AppInfo } from "~applications/application";
 import { checkPassword } from "~wallets/auth";
 import { useEffect, useState } from "react";
-import { Input, Section, Spacer, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Input, Section, Spacer, useInput, useToasts } from "@wanderapp/components";
 import Wrapper from "~components/auth/Wrapper";
 import browser from "webextension-polyfill";
 import App from "~components/auth/App";

--- a/src/routes/auth/batchSignDataItem.tsx
+++ b/src/routes/auth/batchSignDataItem.tsx
@@ -1,5 +1,5 @@
 import { useCurrentAuthRequest } from "~utils/auth/auth.hooks";
-import { Input, ListItem, Section, Spacer, Text, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Input, ListItem, Section, Spacer, Text, useInput, useToasts } from "@wanderapp/components";
 import Wrapper from "~components/auth/Wrapper";
 import browser from "webextension-polyfill";
 import { useState } from "react";

--- a/src/routes/auth/connect.tsx
+++ b/src/routes/auth/connect.tsx
@@ -1,4 +1,4 @@
-import { Input, Section, Spacer, Text, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Input, Section, Spacer, Text, useInput, useToasts } from "@wanderapp/components";
 import { permissionData, signPolicyOptions, type PermissionType } from "~applications/permissions";
 import { useCurrentAuthRequest } from "~utils/auth/auth.hooks";
 import { AnimatePresence, motion } from "framer-motion";

--- a/src/routes/auth/decrypt.tsx
+++ b/src/routes/auth/decrypt.tsx
@@ -1,4 +1,4 @@
-import { Input, Section, Text, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Input, Section, Text, useInput, useToasts } from "@wanderapp/components";
 import Message from "~components/auth/Message";
 import Wrapper from "~components/auth/Wrapper";
 import browser from "webextension-polyfill";

--- a/src/routes/auth/sign.tsx
+++ b/src/routes/auth/sign.tsx
@@ -18,7 +18,7 @@ import {
   TagValue,
   TransactionProperty,
 } from "~routes/popup/transaction/[id]";
-import { Input, Section, Spacer, Text, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Input, Section, Spacer, Text, useInput, useToasts } from "@wanderapp/components";
 import AnimatedQRScanner from "~components/hardware/AnimatedQRScanner";
 import AnimatedQRPlayer from "~components/hardware/AnimatedQRPlayer";
 import Wrapper from "~components/auth/Wrapper";

--- a/src/routes/auth/signDataItem.tsx
+++ b/src/routes/auth/signDataItem.tsx
@@ -1,4 +1,4 @@
-import { Input, Loading, Section, Spacer, Text, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Input, Loading, Section, Spacer, Text, useInput, useToasts } from "@wanderapp/components";
 import {
   FiatAmount,
   AmountTitle,

--- a/src/routes/auth/signKeystone.tsx
+++ b/src/routes/auth/signKeystone.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from "react";
 import { useScanner } from "@arconnect/keystone-sdk";
 import { useActiveWallet } from "~wallets/hooks";
 import type { UR } from "@ngraveio/bc-ur";
-import { Section, Spacer, Text, useToasts } from "@arconnect/components-rebrand";
+import { Section, Spacer, Text, useToasts } from "@wanderapp/components";
 import AnimatedQRScanner from "~components/hardware/AnimatedQRScanner";
 import AnimatedQRPlayer from "~components/hardware/AnimatedQRPlayer";
 import Wrapper from "~components/auth/Wrapper";

--- a/src/routes/auth/signature.tsx
+++ b/src/routes/auth/signature.tsx
@@ -1,4 +1,4 @@
-import { Input, Section, Text, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Input, Section, Text, useInput, useToasts } from "@wanderapp/components";
 import Message from "~components/auth/Message";
 import Wrapper from "~components/auth/Wrapper";
 import browser from "webextension-polyfill";

--- a/src/routes/auth/subscription.tsx
+++ b/src/routes/auth/subscription.tsx
@@ -1,4 +1,4 @@
-import { Tooltip, useToasts } from "@arconnect/components-rebrand";
+import { Tooltip, useToasts } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
 import {

--- a/src/routes/auth/unlock.tsx
+++ b/src/routes/auth/unlock.tsx
@@ -1,5 +1,5 @@
 import { setPasswordFreshness, unlock } from "~wallets/auth";
-import { Input, Section, Spacer, Text, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Input, Section, Spacer, Text, useInput, useToasts } from "@wanderapp/components";
 import Wrapper from "~components/auth/Wrapper";
 import browser from "webextension-polyfill";
 import { HeadAuth } from "~components/HeadAuth";

--- a/src/routes/dashboard/index.tsx
+++ b/src/routes/dashboard/index.tsx
@@ -1,4 +1,4 @@
-import { Input, Spacer, Text, useInput } from "@arconnect/components-rebrand";
+import { Input, Spacer, Text, useInput } from "@wanderapp/components";
 import SettingListItem from "~components/dashboard/list/SettingListItem";
 import { SettingsList } from "~components/dashboard/list/BaseElement";
 import { useEffect, useMemo, useState } from "react";

--- a/src/routes/embedded/account/backup-wallet/cloud/backup-cloud-import.view.tsx
+++ b/src/routes/embedded/account/backup-wallet/cloud/backup-cloud-import.view.tsx
@@ -11,7 +11,7 @@ import { EmbeddedPaths } from "~wallets/router/iframe/iframe.routes";
 import { navigate } from "wouter/use-hash-location";
 import { signOut } from "~utils/embedded/embedded.utils";
 import { sleep } from "~utils/promises/sleep";
-import { Loading } from "@arconnect/components-rebrand";
+import { Loading } from "@wanderapp/components";
 import { toast } from "react-toastify";
 import { Upload01 } from "@untitled-ui/icons-react";
 import { CloudProvider, PendingOperation } from "~utils/embedded/cloud/cloud.types";

--- a/src/routes/embedded/auth-request/connect/connect-settings.view.tsx
+++ b/src/routes/embedded/auth-request/connect/connect-settings.view.tsx
@@ -2,7 +2,7 @@ import { permissionData, signPolicyOptions, type PermissionType } from "~applica
 import { Box, Radio, Snackbar, Text, Row, ChevronRight } from "~components/embed/ui";
 import { useLocation } from "~wallets/router/router.utils";
 import browser from "webextension-polyfill";
-import { Spacer } from "@arconnect/components-rebrand";
+import { Spacer } from "@wanderapp/components";
 import type { SignPolicy } from "~applications/application";
 import { useCurrentAuthRequest } from "~utils/auth/auth.hooks";
 import { ExtensionStorage, useStorage } from "~utils/storage";

--- a/src/routes/embedded/auth-request/sign/signDataItem.view.tsx
+++ b/src/routes/embedded/auth-request/sign/signDataItem.view.tsx
@@ -9,7 +9,7 @@ import { fetchTokenByProcessId, getTagValue, type TokenInfo } from "~tokens/aoTo
 import { ExtensionStorage, PersistentStorage, useStorage } from "~utils/storage";
 import { humanizeTimestampTags } from "~utils/timestamp";
 import { useTokenBalance } from "~tokens/hooks";
-import { Loading } from "@arconnect/components-rebrand";
+import { Loading } from "@wanderapp/components";
 import TransactionMessage from "~components/embed/auth/TransactionMessage";
 import { formatBalance } from "~utils/format";
 import { AuthRequestCard } from "~components/embed/ui/molecules/card/auth-request-card/AuthRequestCard";

--- a/src/routes/embedded/wallet/buy/components/selector/CurrencySelector.tsx
+++ b/src/routes/embedded/wallet/buy/components/selector/CurrencySelector.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import React from "react";
 import { Coins03 } from "@untitled-ui/icons-react";
-import { useInput } from "@arconnect/components-rebrand";
+import { useInput } from "@wanderapp/components";
 import SelectorContainer from "./SelectorContainer";
 import SelectorItem from "./SelectorItem";
 import { TextInput } from "~components/embed";

--- a/src/routes/embedded/wallet/transactions-history/transactions-history.view.tsx
+++ b/src/routes/embedded/wallet/transactions-history/transactions-history.view.tsx
@@ -1,4 +1,4 @@
-import { Loading } from "@arconnect/components-rebrand";
+import { Loading } from "@wanderapp/components";
 import { Text, Box, Button } from "~components/embed/ui";
 import browser from "~iframe/browser";
 import { useActiveWallet, useTransactions } from "~wallets/hooks";

--- a/src/routes/embedded/wallet/transactions/transactions.view.tsx
+++ b/src/routes/embedded/wallet/transactions/transactions.view.tsx
@@ -2,7 +2,7 @@ import { Text, Box, Button } from "~components/embed/ui";
 import { useActiveWallet, useTransactions } from "~wallets/hooks";
 import { useLocation } from "~wallets/router/router.utils";
 import browser from "webextension-polyfill";
-import { Loading } from "@arconnect/components-rebrand";
+import { Loading } from "@wanderapp/components";
 import TransactionGroup from "./components/TransactionGroup";
 import { AuthRequestCard } from "~components/embed/ui/molecules/card/auth-request-card/AuthRequestCard";
 import { EmbeddedPaths } from "~wallets/router/iframe/iframe.routes";

--- a/src/routes/popup/agents/ao-yield/agent-activated.tsx
+++ b/src/routes/popup/agents/ao-yield/agent-activated.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Button, Section, Text } from "@arconnect/components-rebrand";
+import { Button, Section, Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { Flex } from "~components/common/Flex";
 import agentActivated from "url:/assets/agents/images/agent-activated.svg";

--- a/src/routes/popup/agents/ao-yield/agent-history.tsx
+++ b/src/routes/popup/agents/ao-yield/agent-history.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Button, Section, Text, Loading } from "@arconnect/components-rebrand";
+import { Button, Section, Text, Loading } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import HeadV2 from "~components/popup/HeadV2";
 import { Flex } from "~components/common/Flex";

--- a/src/routes/popup/agents/ao-yield/agent-transaction-history.tsx
+++ b/src/routes/popup/agents/ao-yield/agent-transaction-history.tsx
@@ -1,5 +1,5 @@
 import styled, { useTheme } from "styled-components";
-import { Button, Section, Text, ListItem } from "@arconnect/components-rebrand";
+import { Button, Section, Text, ListItem } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import HeadV2 from "~components/popup/HeadV2";
 import { Flex } from "~components/common/Flex";

--- a/src/routes/popup/agents/ao-yield/confirm-agent.tsx
+++ b/src/routes/popup/agents/ao-yield/confirm-agent.tsx
@@ -1,5 +1,5 @@
 import styled, { useTheme } from "styled-components";
-import { Button, Input, Section, useInput, useToasts, Text } from "@arconnect/components-rebrand";
+import { Button, Input, Section, useInput, useToasts, Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import HeadV2 from "~components/popup/HeadV2";
 import { Flex } from "~components/common/Flex";

--- a/src/routes/popup/agents/ao-yield/create-agent.tsx
+++ b/src/routes/popup/agents/ao-yield/create-agent.tsx
@@ -1,5 +1,5 @@
 import styled, { useTheme } from "styled-components";
-import { Button, Section, Text, Tooltip } from "@arconnect/components-rebrand";
+import { Button, Section, Text, Tooltip } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import HeadV2 from "~components/popup/HeadV2";
 import { Flex } from "~components/common/Flex";

--- a/src/routes/popup/agents/ao-yield/edit-agent.tsx
+++ b/src/routes/popup/agents/ao-yield/edit-agent.tsx
@@ -1,5 +1,5 @@
 import styled, { useTheme } from "styled-components";
-import { Button, Section, Text, Tooltip, useToasts } from "@arconnect/components-rebrand";
+import { Button, Section, Text, Tooltip, useToasts } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import HeadV2 from "~components/popup/HeadV2";
 import { Flex } from "~components/common/Flex";

--- a/src/routes/popup/agents/components/AODelegationModal.tsx
+++ b/src/routes/popup/agents/components/AODelegationModal.tsx
@@ -1,7 +1,7 @@
 import browser from "webextension-polyfill";
 import { Flex } from "~components/common/Flex";
 import SliderMenu from "~components/SliderMenu";
-import { Button, Text } from "@arconnect/components-rebrand";
+import { Button, Text } from "@wanderapp/components";
 import alertWarning from "url:/assets/agents/images/alert-warning.svg";
 import { useEffect, useState } from "react";
 import { useAODelegationInfo } from "~utils/agents/hooks";

--- a/src/routes/popup/agents/components/AOMintingPausedListItem.tsx
+++ b/src/routes/popup/agents/components/AOMintingPausedListItem.tsx
@@ -1,6 +1,6 @@
 import { AlertCircle, XClose } from "@untitled-ui/icons-react";
 import { Flex } from "~components/common/Flex";
-import { Button, Text } from "@arconnect/components-rebrand";
+import { Button, Text } from "@wanderapp/components";
 import styled, { useTheme } from "styled-components";
 import { useAOMintingStatus } from "~utils/agents/hooks";
 import { ExtensionStorage, useStorage } from "~utils/storage";

--- a/src/routes/popup/agents/components/AOMintingStatusModal.tsx
+++ b/src/routes/popup/agents/components/AOMintingStatusModal.tsx
@@ -1,7 +1,7 @@
 import browser from "webextension-polyfill";
 import { Flex } from "~components/common/Flex";
 import SliderMenu from "~components/SliderMenu";
-import { Button, Text } from "@arconnect/components-rebrand";
+import { Button, Text } from "@wanderapp/components";
 import alertWarning from "url:/assets/agents/images/alert-warning.svg";
 import alertSuccess from "url:/assets/agents/images/alert-success.svg";
 import { useState } from "react";

--- a/src/routes/popup/agents/components/AOYieldAgentListItem.tsx
+++ b/src/routes/popup/agents/components/AOYieldAgentListItem.tsx
@@ -1,4 +1,4 @@
-import { ListItem, Text } from "@arconnect/components-rebrand";
+import { ListItem, Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { Flex } from "~components/common/Flex";
 import aoLogo from "url:/assets/ecosystem/ao-logo.svg";

--- a/src/routes/popup/agents/components/CreateWanderAgentCTA.tsx
+++ b/src/routes/popup/agents/components/CreateWanderAgentCTA.tsx
@@ -1,4 +1,4 @@
-import { Button, Text } from "@arconnect/components-rebrand";
+import { Button, Text } from "@wanderapp/components";
 import styled from "styled-components";
 import { Flex } from "~components/common/Flex";
 import { ExtensionStorage } from "~utils/storage";

--- a/src/routes/popup/agents/components/LiquidOpsAgentListItem.tsx
+++ b/src/routes/popup/agents/components/LiquidOpsAgentListItem.tsx
@@ -1,4 +1,4 @@
-import { ListItem, Text } from "@arconnect/components-rebrand";
+import { ListItem, Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { Flex } from "~components/common/Flex";
 import LiquidOpsIcon from "url:/assets/ecosystem/liquidops.svg";

--- a/src/routes/popup/agents/components/StatusLabel.tsx
+++ b/src/routes/popup/agents/components/StatusLabel.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { Flex } from "~components/common/Flex";
-import { Text, type DisplayTheme } from "@arconnect/components-rebrand";
+import { Text, type DisplayTheme } from "@wanderapp/components";
 import { useTheme } from "~utils/theme/theme.hook";
 
 export const StatusLabel = ({ status, label }: Props) => {

--- a/src/routes/popup/agents/components/WanderAgentExplainerPopup.tsx
+++ b/src/routes/popup/agents/components/WanderAgentExplainerPopup.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import SliderMenu from "~components/SliderMenu";
 import { XClose } from "@untitled-ui/icons-react";
-import { Button, Text } from "@arconnect/components-rebrand";
+import { Button, Text } from "@wanderapp/components";
 import HedgehogPopupImage from "url:/assets/agents/images/hedgehog-popup.svg";
 import { Flex } from "~components/common/Flex";
 import browser from "webextension-polyfill";

--- a/src/routes/popup/agents/components/ao-yield/AgentCancelModal.tsx
+++ b/src/routes/popup/agents/components/ao-yield/AgentCancelModal.tsx
@@ -1,7 +1,7 @@
 import browser from "webextension-polyfill";
 import { Flex } from "~components/common/Flex";
 import SliderMenu from "~components/SliderMenu";
-import { Button, Input, Text, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Button, Input, Text, useInput, useToasts } from "@wanderapp/components";
 import { updateAOYieldAgent } from "~utils/agents/utils";
 import { useMemo, useState } from "react";
 import { useAskPassword } from "~wallets/hooks";

--- a/src/routes/popup/agents/components/ao-yield/AssetSelectorModal.tsx
+++ b/src/routes/popup/agents/components/ao-yield/AssetSelectorModal.tsx
@@ -1,4 +1,4 @@
-import { ListItem } from "@arconnect/components-rebrand";
+import { ListItem } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { Flex } from "~components/common/Flex";
 import { TokenLogo } from "~components/popup/TokenLogo";

--- a/src/routes/popup/agents/components/ao-yield/CustomSelect.tsx
+++ b/src/routes/popup/agents/components/ao-yield/CustomSelect.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import styled, { useTheme } from "styled-components";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import { ChevronRight } from "@untitled-ui/icons-react";
 
 interface CustomSelectOption {

--- a/src/routes/popup/agents/components/ao-yield/DateSelectorModal.tsx
+++ b/src/routes/popup/agents/components/ao-yield/DateSelectorModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback } from "react";
 import styled, { css, useTheme } from "styled-components";
 import browser from "webextension-polyfill";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import SliderMenu from "~components/SliderMenu";
 import { ChevronLeft, ChevronRight } from "@untitled-ui/icons-react";
 import { CustomSelect } from "./CustomSelect";

--- a/src/routes/popup/agents/components/ao-yield/SlippageSelectorModal.tsx
+++ b/src/routes/popup/agents/components/ao-yield/SlippageSelectorModal.tsx
@@ -2,7 +2,7 @@ import browser from "webextension-polyfill";
 import { Flex } from "~components/common/Flex";
 import { useState, useRef, useCallback } from "react";
 import SliderMenu from "~components/SliderMenu";
-import { Button, Text, useToasts } from "@arconnect/components-rebrand";
+import { Button, Text, useToasts } from "@wanderapp/components";
 import { AlertTriangle } from "@untitled-ui/icons-react";
 import styled from "styled-components";
 import { MinusIcon, PlusIcon } from "@iconicicons/react";

--- a/src/routes/popup/agents/components/ao-yield/agent-info.tsx
+++ b/src/routes/popup/agents/components/ao-yield/agent-info.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Section, Text, ListItem, Loading, Button } from "@arconnect/components-rebrand";
+import { Section, Text, ListItem, Loading, Button } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import HeadV2 from "~components/popup/HeadV2";
 import { Flex } from "~components/common/Flex";

--- a/src/routes/popup/agents/components/liquidops/Agent.tsx
+++ b/src/routes/popup/agents/components/liquidops/Agent.tsx
@@ -1,4 +1,4 @@
-import { ListItem, Text } from "@arconnect/components-rebrand";
+import { ListItem, Text } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import { SvgImageWithBackground } from "../SvgImage";
 import AoLogo from "url:/assets/ecosystem/ao-logo.svg";

--- a/src/routes/popup/agents/components/liquidops/AgentStats.tsx
+++ b/src/routes/popup/agents/components/liquidops/AgentStats.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { Flex } from "~components/common/Flex";
 import { SvgImageWithBackground } from "../SvgImage";

--- a/src/routes/popup/agents/index.tsx
+++ b/src/routes/popup/agents/index.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Section, Text } from "@arconnect/components-rebrand";
+import { Section, Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import HeadV2 from "~components/popup/HeadV2";
 import HedgehogHeadIcon from "url:/assets/agents/images/hedgehog-head.svg";

--- a/src/routes/popup/agents/liquidops/agent.tsx
+++ b/src/routes/popup/agents/liquidops/agent.tsx
@@ -1,7 +1,7 @@
 import HeadV2 from "~components/popup/HeadV2";
 import browser from "webextension-polyfill";
 import { Flex } from "~components/common/Flex";
-import { Button, Section, Text } from "@arconnect/components-rebrand";
+import { Button, Section, Text } from "@wanderapp/components";
 import styled from "styled-components";
 import { SvgImageWithBackground } from "../components/SvgImage";
 import { Spacer } from "~components/embed";
@@ -22,7 +22,7 @@ import { useEarnings } from "./utils/hooks/useEarnings";
 import { useGateway } from "./utils/hooks/useGateway";
 import { useTokenStatus } from "./utils/hooks/useTokenStatus";
 import { useLOAssetBalance } from "./utils/hooks/useLOAssetBalance";
-import { Loading } from "@arconnect/components-rebrand";
+import { Loading } from "@wanderapp/components";
 import { useTokenBalance, useTokenPrice } from "~tokens/hooks";
 import BigNumber from "bignumber.js";
 import { formatNumber } from "./utils/format";

--- a/src/routes/popup/agents/liquidops/agent.tsx
+++ b/src/routes/popup/agents/liquidops/agent.tsx
@@ -1,7 +1,7 @@
 import HeadV2 from "~components/popup/HeadV2";
 import browser from "webextension-polyfill";
 import { Flex } from "~components/common/Flex";
-import { Button, Section, Text } from "@wanderapp/components";
+import { Button, Section, Text, Loading } from "@wanderapp/components";
 import styled from "styled-components";
 import { SvgImageWithBackground } from "../components/SvgImage";
 import { Spacer } from "~components/embed";
@@ -22,7 +22,6 @@ import { useEarnings } from "./utils/hooks/useEarnings";
 import { useGateway } from "./utils/hooks/useGateway";
 import { useTokenStatus } from "./utils/hooks/useTokenStatus";
 import { useLOAssetBalance } from "./utils/hooks/useLOAssetBalance";
-import { Loading } from "@wanderapp/components";
 import { useTokenBalance, useTokenPrice } from "~tokens/hooks";
 import BigNumber from "bignumber.js";
 import { formatNumber } from "./utils/format";

--- a/src/routes/popup/agents/liquidops/agents.tsx
+++ b/src/routes/popup/agents/liquidops/agents.tsx
@@ -1,7 +1,7 @@
 import HeadV2 from "~components/popup/HeadV2";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
-import { Section, Text } from "@arconnect/components-rebrand";
+import { Section, Text } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import { Line } from "~routes/popup/purchase";
 import { Agent } from "../components/liquidops/Agent";

--- a/src/routes/popup/agents/liquidops/confirm.tsx
+++ b/src/routes/popup/agents/liquidops/confirm.tsx
@@ -1,5 +1,5 @@
 import HeadV2 from "~components/popup/HeadV2";
-import { Button, Section, Text, Spacer, Input, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Button, Section, Text, Spacer, Input, useInput, useToasts } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
 import { Flex } from "~components/common/Flex";

--- a/src/routes/popup/agents/liquidops/depositwithdraw.tsx
+++ b/src/routes/popup/agents/liquidops/depositwithdraw.tsx
@@ -2,7 +2,7 @@ import HeadV2 from "~components/popup/HeadV2";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import browser from "webextension-polyfill";
 import styled, { useTheme } from "styled-components";
-import { Section, Input, Text, Spacer, Button } from "@arconnect/components-rebrand";
+import { Section, Input, Text, Spacer, Button } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import { SvgImageWithBackground } from "../components/SvgImage";
 import { AmountValidationState, getErrorMessage, MaxButton, validateAmount } from "~routes/popup/send/amount";

--- a/src/routes/popup/agents/liquidops/result.tsx
+++ b/src/routes/popup/agents/liquidops/result.tsx
@@ -1,4 +1,4 @@
-import { Button, Section, Text } from "@arconnect/components-rebrand";
+import { Button, Section, Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
 import { Flex } from "~components/common/Flex";

--- a/src/routes/popup/announcement.tsx
+++ b/src/routes/popup/announcement.tsx
@@ -6,7 +6,7 @@ import { getAnnouncement } from "~utils/announcements";
 import { useMemo } from "react";
 import { Flex } from "~components/common/Flex";
 import dayjs from "dayjs";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import { Announcement01 } from "@untitled-ui/icons-react";
 import { ParseTextWithLinks } from "~components/common/ParseTextWithLinks";
 

--- a/src/routes/popup/arns/ArNSConfirmPurchaseView.tsx
+++ b/src/routes/popup/arns/ArNSConfirmPurchaseView.tsx
@@ -1,4 +1,4 @@
-import { Button, Text } from "@arconnect/components-rebrand";
+import { Button, Text } from "@wanderapp/components";
 import { useEffect, useMemo, useState } from "react";
 import { Flex } from "~components/common/Flex";
 import { ArioIcon } from "~components/embed";

--- a/src/routes/popup/arns/ArNSManageView.tsx
+++ b/src/routes/popup/arns/ArNSManageView.tsx
@@ -1,4 +1,4 @@
-import { Card, Text } from "@arconnect/components-rebrand";
+import { Card, Text } from "@wanderapp/components";
 import { PlusIcon } from "@iconicicons/react";
 import { LinkExternal02, Star01, RefreshCw01 } from "@untitled-ui/icons-react";
 import styled, { keyframes, css } from "styled-components";

--- a/src/routes/popup/arns/ArNSNamePurchaseView.tsx
+++ b/src/routes/popup/arns/ArNSNamePurchaseView.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Text } from "@arconnect/components-rebrand";
+import { Button, Card, Text } from "@wanderapp/components";
 import { MinusIcon, PlusIcon } from "@iconicicons/react";
 import { useEffect, useMemo, useState } from "react";
 import styled from "styled-components";

--- a/src/routes/popup/arns/ArNSNameSearchView.tsx
+++ b/src/routes/popup/arns/ArNSNameSearchView.tsx
@@ -1,5 +1,5 @@
 import { mARIOToken, type AoArNSNameData } from "@ar.io/sdk/web";
-import { Button, Spacer, Text, useInput } from "@arconnect/components-rebrand";
+import { Button, Spacer, Text, useInput } from "@wanderapp/components";
 import { useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import { Flex } from "~components/common/Flex";

--- a/src/routes/popup/arns/ArNSPurchaseErrorView.tsx
+++ b/src/routes/popup/arns/ArNSPurchaseErrorView.tsx
@@ -1,4 +1,4 @@
-import { Button, Text } from "@arconnect/components-rebrand";
+import { Button, Text } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import { PopupPaths } from "~wallets/router/popup/popup.routes";
 import type { CommonRouteProps } from "~wallets/router/router.types";

--- a/src/routes/popup/arns/ArNSPurchaseStartView.tsx
+++ b/src/routes/popup/arns/ArNSPurchaseStartView.tsx
@@ -1,11 +1,11 @@
 import { useLocation } from "~wallets/router/router.utils";
 import { useEffect } from "react";
 import styled from "styled-components";
-import { Button } from "@arconnect/components-rebrand";
+import { Button } from "@wanderapp/components";
 import HeadV2 from "~components/popup/HeadV2";
 import { useActiveAddress } from "~wallets/hooks";
 import { formatAddress } from "~utils/format";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import { Wander2Icon, ArioIcon } from "~components/embed";
 import { PopupPaths } from "~wallets/router/popup/popup.routes";

--- a/src/routes/popup/arns/ArNSPurchaseStartView.tsx
+++ b/src/routes/popup/arns/ArNSPurchaseStartView.tsx
@@ -1,11 +1,10 @@
 import { useLocation } from "~wallets/router/router.utils";
 import { useEffect } from "react";
 import styled from "styled-components";
-import { Button } from "@wanderapp/components";
+import { Button, Text } from "@wanderapp/components";
 import HeadV2 from "~components/popup/HeadV2";
 import { useActiveAddress } from "~wallets/hooks";
 import { formatAddress } from "~utils/format";
-import { Text } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import { Wander2Icon, ArioIcon } from "~components/embed";
 import { PopupPaths } from "~wallets/router/popup/popup.routes";

--- a/src/routes/popup/arns/ArNSPurchaseSuccessView.tsx
+++ b/src/routes/popup/arns/ArNSPurchaseSuccessView.tsx
@@ -1,4 +1,4 @@
-import { Card, Text, Button } from "@arconnect/components-rebrand";
+import { Card, Text, Button } from "@wanderapp/components";
 import styled from "styled-components";
 import { Flex } from "~components/common/Flex";
 import { truncateMiddle } from "~utils/format";

--- a/src/routes/popup/arns/CardContainer.tsx
+++ b/src/routes/popup/arns/CardContainer.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Card } from "@arconnect/components-rebrand";
+import { Card } from "@wanderapp/components";
 
 export const CardContainer = styled(Card)`
   display: flex;

--- a/src/routes/popup/arns/RegisteringCard.tsx
+++ b/src/routes/popup/arns/RegisteringCard.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import { Line } from "../purchase";
 import { CardContainer } from "./CardContainer";

--- a/src/routes/popup/arns/TransactionStatusModal.tsx
+++ b/src/routes/popup/arns/TransactionStatusModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, Text } from "@arconnect/components-rebrand";
+import { Modal, Text } from "@wanderapp/components";
 import { useRef } from "react";
 import { Content, ContentWrapper } from "~components/modals/Components";
 

--- a/src/routes/popup/arns/setPrimaryName/ArNSConfirmSetPrimaryNameView.tsx
+++ b/src/routes/popup/arns/setPrimaryName/ArNSConfirmSetPrimaryNameView.tsx
@@ -1,4 +1,4 @@
-import { Button, Text } from "@arconnect/components-rebrand";
+import { Button, Text } from "@wanderapp/components";
 import { useEffect, useMemo, useState } from "react";
 import { Flex } from "~components/common/Flex";
 import HeadV2 from "~components/popup/HeadV2";

--- a/src/routes/popup/arns/setPrimaryName/ArNSPrimaryNameErrorView.tsx
+++ b/src/routes/popup/arns/setPrimaryName/ArNSPrimaryNameErrorView.tsx
@@ -1,4 +1,4 @@
-import { Button, Text } from "@arconnect/components-rebrand";
+import { Button, Text } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import { PopupPaths } from "~wallets/router/popup/popup.routes";
 import type { CommonRouteProps } from "~wallets/router/router.types";

--- a/src/routes/popup/arns/setPrimaryName/ArNSPrimaryNameSuccessView.tsx
+++ b/src/routes/popup/arns/setPrimaryName/ArNSPrimaryNameSuccessView.tsx
@@ -1,5 +1,4 @@
-import { Button } from "@wanderapp/components";
-import { Text } from "@wanderapp/components";
+import { Button, Text } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import { truncateMiddle } from "~utils/format";
 import { PopupPaths } from "~wallets/router/popup/popup.routes";

--- a/src/routes/popup/arns/setPrimaryName/ArNSPrimaryNameSuccessView.tsx
+++ b/src/routes/popup/arns/setPrimaryName/ArNSPrimaryNameSuccessView.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@arconnect/components-rebrand";
-import { Text } from "@arconnect/components-rebrand";
+import { Button } from "@wanderapp/components";
+import { Text } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import { truncateMiddle } from "~utils/format";
 import { PopupPaths } from "~wallets/router/popup/popup.routes";

--- a/src/routes/popup/collectible/[id].tsx
+++ b/src/routes/popup/collectible/[id].tsx
@@ -1,5 +1,5 @@
 import { concatGatewayURL } from "~gateways/utils";
-import { Section, Spacer, Text } from "@arconnect/components-rebrand";
+import { Section, Spacer, Text } from "@wanderapp/components";
 import { useEffect, useMemo, useState } from "react";
 import { AnimatePresence } from "framer-motion";
 import { Link } from "~components/common/Link";

--- a/src/routes/popup/earn/allocation-set.tsx
+++ b/src/routes/popup/earn/allocation-set.tsx
@@ -1,4 +1,4 @@
-import { Button, Text } from "@arconnect/components-rebrand";
+import { Button, Text } from "@wanderapp/components";
 import { useLocation } from "~wallets/router/router.utils";
 import styled from "styled-components";
 import Lottie from "react-lottie";

--- a/src/routes/popup/earn/index.tsx
+++ b/src/routes/popup/earn/index.tsx
@@ -5,7 +5,7 @@ import { EarnPopup } from "~components/popup/earn/EarnPopup";
 import { useAsyncEffect } from "~utils/react/useAsyncEffect";
 import { ExtensionStorage } from "~utils/storage";
 import { HelpCircle, LinkExternal01 } from "@untitled-ui/icons-react";
-import { Section, Text, Tooltip, Button } from "@arconnect/components-rebrand";
+import { Section, Text, Tooltip, Button } from "@wanderapp/components";
 import { Divider } from "~components/Divider";
 import { PieChart } from "~components/popup/chart/PieChart";
 import browser from "webextension-polyfill";

--- a/src/routes/popup/earn/manage.tsx
+++ b/src/routes/popup/earn/manage.tsx
@@ -1,7 +1,7 @@
 import styled, { useTheme } from "styled-components";
 import HeadV2 from "~components/popup/HeadV2";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Section, Button, Text, Tooltip, Loading, useToasts } from "@arconnect/components-rebrand";
+import { Section, Button, Text, Tooltip, Loading, useToasts } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { ArrowUpRight, HelpCircle, InfoCircle, Plus, Trash02 } from "@untitled-ui/icons-react";
 import { useAOYieldDelegations, useDelegationInfo, useFairLaunchTokens } from "~utils/fair_launch/fair_launch.hooks";

--- a/src/routes/popup/gettingStarted.tsx
+++ b/src/routes/popup/gettingStarted.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence } from "framer-motion";
-import { Button, Text } from "@arconnect/components-rebrand";
+import { Button, Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
 

--- a/src/routes/popup/index.tsx
+++ b/src/routes/popup/index.tsx
@@ -11,7 +11,7 @@ import { useActiveWallet } from "~wallets/hooks";
 import Tabs from "~components/popup/home/Tabs";
 import { scheduleImportAoTokens } from "~tokens/aoTokens/sync";
 import WalletActions from "~components/popup/home/WalletActions";
-import { Text, useToasts } from "@arconnect/components-rebrand";
+import { Text, useToasts } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import { useLocation } from "~wallets/router/router.utils";
 import browser from "webextension-polyfill";

--- a/src/routes/popup/purchase.tsx
+++ b/src/routes/popup/purchase.tsx
@@ -1,4 +1,4 @@
-import { Text, Input, useInput, Section, Button, Loading, ListItem, ListItemIcon } from "@arconnect/components-rebrand";
+import { Text, Input, useInput, Section, Button, Loading, ListItem, ListItemIcon } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { Bank, BankNote01, ChevronDown, SwitchVertical02 } from "@untitled-ui/icons-react";
 import styled from "styled-components";

--- a/src/routes/popup/receive.tsx
+++ b/src/routes/popup/receive.tsx
@@ -1,4 +1,4 @@
-import { Section, Text } from "@arconnect/components-rebrand";
+import { Section, Text } from "@wanderapp/components";
 import { CopyIcon } from "@iconicicons/react";
 import { QRCodeSVG } from "qrcode.react";
 import browser from "webextension-polyfill";

--- a/src/routes/popup/send/amount.tsx
+++ b/src/routes/popup/send/amount.tsx
@@ -1,7 +1,7 @@
 import { PageType, trackPage } from "~utils/analytics";
 import { useState, useEffect, useMemo, useCallback } from "react";
 import styled from "styled-components";
-import { Button, Input, Section, Spacer, Text, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Button, Input, Section, Spacer, Text, useInput, useToasts } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import Token, { LogoAndDetails, TokenName } from "~components/popup/Token";
 import useSetting from "~settings/hook";

--- a/src/routes/popup/send/completed.tsx
+++ b/src/routes/popup/send/completed.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, type Variants, motion } from "framer-motion";
-import { Button, Section, Text } from "@arconnect/components-rebrand";
+import { Button, Section, Text } from "@wanderapp/components";
 import { useLocation, useSearchParams } from "~wallets/router/router.utils";
 import browser from "webextension-polyfill";
 import styled from "styled-components";

--- a/src/routes/popup/send/confirm.tsx
+++ b/src/routes/popup/send/confirm.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Section, Spacer, Text, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Button, Input, Section, Spacer, Text, useInput, useToasts } from "@wanderapp/components";
 import { ArrowRightIcon } from "@iconicicons/react";
 import styled from "styled-components";
 import browser from "webextension-polyfill";

--- a/src/routes/popup/send/index.tsx
+++ b/src/routes/popup/send/index.tsx
@@ -1,7 +1,7 @@
 import { PageType, trackPage } from "~utils/analytics";
 import { useState, useEffect, useMemo, useCallback } from "react";
 import styled from "styled-components";
-import { Button, Input, Section, useInput, Text, ListItem, useToasts } from "@arconnect/components-rebrand";
+import { Button, Input, Section, useInput, Text, ListItem, useToasts } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { type Token as TokenInterface } from "~tokens/token";
 import HeadV2 from "~components/popup/HeadV2";

--- a/src/routes/popup/send/note.tsx
+++ b/src/routes/popup/send/note.tsx
@@ -1,6 +1,6 @@
 import { PageType, trackPage } from "~utils/analytics";
 import { useEffect } from "react";
-import { Section } from "@arconnect/components-rebrand";
+import { Section } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import HeadV2 from "~components/popup/HeadV2";
 import { useStorage } from "@plasmohq/storage/hook";

--- a/src/routes/popup/settings/index.tsx
+++ b/src/routes/popup/settings/index.tsx
@@ -5,7 +5,7 @@ import { useLocation } from "~wallets/router/router.utils";
 import { quickSettingsMenuItems } from "~routes/dashboard/dashboard.constants";
 import { SettingListItem } from "~components/popup/list/SettingListItem";
 import type { PopupRoutePath } from "~wallets/router/popup/popup.routes";
-import { Button, ListItem, ListItemIcon, Section, Spacer, Text, Tooltip } from "@arconnect/components-rebrand";
+import { Button, ListItem, ListItemIcon, Section, Spacer, Text, Tooltip } from "@wanderapp/components";
 import { useActiveWallet } from "~wallets/hooks";
 import { formatAddress } from "~utils/format";
 import { Users01 } from "@untitled-ui/icons-react";

--- a/src/routes/popup/settings/tokens/[id]/index.tsx
+++ b/src/routes/popup/settings/tokens/[id]/index.tsx
@@ -1,5 +1,5 @@
 import { ButtonV2, Spacer, Text, TooltipV2 } from "@arconnect/components";
-import { Select as SelectV2, useToasts } from "@arconnect/components-rebrand";
+import { Select as SelectV2, useToasts } from "@wanderapp/components";
 import type { TokenType } from "~tokens/token";
 import { PersistentStorage, useStorage } from "~utils/storage";
 import { ExtensionStorage } from "~utils/storage";

--- a/src/routes/popup/settings/wallets/[address]/export.tsx
+++ b/src/routes/popup/settings/wallets/[address]/export.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Section, Text, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Button, Input, Section, Text, useInput, useToasts } from "@wanderapp/components";
 import { type StoredWallet } from "~wallets";
 import { useMemo, useState } from "react";
 import { useStorage } from "~utils/storage";

--- a/src/routes/popup/settings/wallets/[address]/index.tsx
+++ b/src/routes/popup/settings/wallets/[address]/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, ListItem, Section, Text, Tooltip, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Button, Input, ListItem, Section, Text, Tooltip, useInput, useToasts } from "@wanderapp/components";
 import { CopyIcon } from "@iconicicons/react";
 import {
   AlertCircle,

--- a/src/routes/popup/settings/wallets/[address]/qr.tsx
+++ b/src/routes/popup/settings/wallets/[address]/qr.tsx
@@ -1,4 +1,4 @@
-import { useToasts, Section, useInput, Button, Input, Text } from "@arconnect/components-rebrand";
+import { useToasts, Section, useInput, Button, Input, Text } from "@wanderapp/components";
 import { useEffect, useState } from "react";
 import HeadV2 from "~components/popup/HeadV2";
 import { WarningIcon } from "~components/icons/WarningIcon";

--- a/src/routes/popup/settings/wallets/[address]/recovery-phrase.tsx
+++ b/src/routes/popup/settings/wallets/[address]/recovery-phrase.tsx
@@ -6,7 +6,7 @@ import { useLocation } from "~wallets/router/router.utils";
 import copy from "copy-to-clipboard";
 import Paragraph from "~components/Paragraph";
 import browser from "webextension-polyfill";
-import { Button, Spacer, Text } from "@arconnect/components-rebrand";
+import { Button, Spacer, Text } from "@wanderapp/components";
 import { AlertTriangle, Check, Copy01, Eye, EyeOff } from "@untitled-ui/icons-react";
 import styled from "styled-components";
 import { PageType, trackPage } from "~utils/analytics";

--- a/src/routes/popup/settings/wallets/index.tsx
+++ b/src/routes/popup/settings/wallets/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Section } from "@arconnect/components-rebrand";
+import { Button, Section } from "@wanderapp/components";
 import styled from "styled-components";
 import browser from "webextension-polyfill";
 import WalletListItem from "~components/dashboard/list/WalletListItem";

--- a/src/routes/popup/swap/complete.tsx
+++ b/src/routes/popup/swap/complete.tsx
@@ -1,4 +1,4 @@
-import { Section, Button, Text, Loading } from "@arconnect/components-rebrand";
+import { Section, Button, Text, Loading } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import styled, { useTheme } from "styled-components";
 import HeadV2 from "~components/popup/HeadV2";

--- a/src/routes/popup/swap/components/AnnouncementsCarousel.tsx
+++ b/src/routes/popup/swap/components/AnnouncementsCarousel.tsx
@@ -1,5 +1,5 @@
 import { Flex } from "~components/common/Flex";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { useMemo, useState } from "react";
 import { Carousel } from "~components/Carousel";

--- a/src/routes/popup/swap/components/AutoTag.tsx
+++ b/src/routes/popup/swap/components/AutoTag.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import styled from "styled-components";
 import browser from "webextension-polyfill";
 

--- a/src/routes/popup/swap/components/Disclosure.tsx
+++ b/src/routes/popup/swap/components/Disclosure.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import { HorizontalLine } from "~components/HorizontalLine";
 import { Flex } from "~components/common/Flex";
 import { ChevronDown, ChevronUp } from "@untitled-ui/icons-react";

--- a/src/routes/popup/swap/components/SlippageInputButton.tsx
+++ b/src/routes/popup/swap/components/SlippageInputButton.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown } from "@untitled-ui/icons-react";
 import { Flex } from "~components/common/Flex";
 import { InputButton } from "~components/common/InputButton";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import styled, { useTheme } from "styled-components";
 import { SlippageSelectorModal } from "~routes/popup/agents/components/ao-yield/SlippageSelectorModal";

--- a/src/routes/popup/swap/components/SwapAnnouncementPopup.tsx
+++ b/src/routes/popup/swap/components/SwapAnnouncementPopup.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import { ExtensionStorage } from "~utils/storage";
 import { Flex } from "~components/common/Flex";
 import SliderMenu from "~components/SliderMenu";

--- a/src/routes/popup/swap/components/SwapGatingPopup.tsx
+++ b/src/routes/popup/swap/components/SwapGatingPopup.tsx
@@ -1,4 +1,4 @@
-import { Spacer, Text } from "@arconnect/components-rebrand";
+import { Spacer, Text } from "@wanderapp/components";
 import SliderMenu from "~components/SliderMenu";
 import styled from "styled-components";
 import { Flex } from "~components/common/Flex";

--- a/src/routes/popup/swap/components/SwapInput.tsx
+++ b/src/routes/popup/swap/components/SwapInput.tsx
@@ -1,4 +1,4 @@
-import { Input, Loading, Text } from "@arconnect/components-rebrand";
+import { Input, Loading, Text } from "@wanderapp/components";
 import { useTheme } from "styled-components";
 import { Flex } from "~components/common/Flex";
 import browser from "webextension-polyfill";

--- a/src/routes/popup/swap/components/TokenSelectorPopup.tsx
+++ b/src/routes/popup/swap/components/TokenSelectorPopup.tsx
@@ -1,4 +1,4 @@
-import { useInput, Loading, Input, Text, Spacer } from "@arconnect/components-rebrand";
+import { useInput, Loading, Input, Text, Spacer } from "@wanderapp/components";
 import { useRef, useCallback } from "react";
 import { Flex } from "~components/common/Flex";
 import SliderMenu from "~components/SliderMenu";

--- a/src/routes/popup/swap/components/TokenValueWithTooltip.tsx
+++ b/src/routes/popup/swap/components/TokenValueWithTooltip.tsx
@@ -1,4 +1,4 @@
-import { Text, Tooltip, type TextProps, type TooltipProps } from "@arconnect/components-rebrand";
+import { Text, Tooltip, type TextProps, type TooltipProps } from "@wanderapp/components";
 import styled from "styled-components";
 import type { formatBalance } from "~utils/format";
 

--- a/src/routes/popup/swap/components/TransactionDetailItem.tsx
+++ b/src/routes/popup/swap/components/TransactionDetailItem.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import Skeleton from "~components/Skeleton";
 

--- a/src/routes/popup/swap/failed.tsx
+++ b/src/routes/popup/swap/failed.tsx
@@ -1,4 +1,4 @@
-import { Section, Button, Text, Loading } from "@arconnect/components-rebrand";
+import { Section, Button, Text, Loading } from "@wanderapp/components";
 import styled, { useTheme } from "styled-components";
 import { Flex } from "~components/common/Flex";
 import { TokenLogo } from "~components/popup/TokenLogo";

--- a/src/routes/popup/swap/history.tsx
+++ b/src/routes/popup/swap/history.tsx
@@ -1,7 +1,6 @@
 import styled from "styled-components";
-import { Button, Loading, Section } from "@wanderapp/components";
+import { Button, Loading, Section, ListItem, Text } from "@wanderapp/components";
 import HeadV2 from "~components/popup/HeadV2";
-import { ListItem, Text } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import { useLocation } from "~wallets/router/router.utils";
 import { PopupPaths } from "~wallets/router/popup/popup.routes";

--- a/src/routes/popup/swap/history.tsx
+++ b/src/routes/popup/swap/history.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
-import { Button, Loading, Section } from "@arconnect/components-rebrand";
+import { Button, Loading, Section } from "@wanderapp/components";
 import HeadV2 from "~components/popup/HeadV2";
-import { ListItem, Text } from "@arconnect/components-rebrand";
+import { ListItem, Text } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import { useLocation } from "~wallets/router/router.utils";
 import { PopupPaths } from "~wallets/router/popup/popup.routes";

--- a/src/routes/popup/swap/index.tsx
+++ b/src/routes/popup/swap/index.tsx
@@ -1,4 +1,4 @@
-import { Text, Section, Button } from "@arconnect/components-rebrand";
+import { Text, Section, Button } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { ArrowDown, ClockRewind } from "@untitled-ui/icons-react";
 import styled from "styled-components";

--- a/src/routes/popup/swap/progress.tsx
+++ b/src/routes/popup/swap/progress.tsx
@@ -1,4 +1,4 @@
-import { Section, Text, Loading, Button } from "@arconnect/components-rebrand";
+import { Section, Text, Loading, Button } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import styled, { useTheme } from "styled-components";
 import HeadV2 from "~components/popup/HeadV2";

--- a/src/routes/popup/swap/review.tsx
+++ b/src/routes/popup/swap/review.tsx
@@ -1,4 +1,4 @@
-import { Section, Button, Text, Loading, useToasts } from "@arconnect/components-rebrand";
+import { Section, Button, Text, Loading, useToasts } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import styled, { useTheme } from "styled-components";
 import HeadV2 from "~components/popup/HeadV2";

--- a/src/routes/popup/swap/transaction-details.tsx
+++ b/src/routes/popup/swap/transaction-details.tsx
@@ -1,9 +1,9 @@
 import styled, { useTheme } from "styled-components";
-import { Button, Section } from "@arconnect/components-rebrand";
+import { Button, Section } from "@wanderapp/components";
 import HeadV2 from "~components/popup/HeadV2";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import { Flex } from "~components/common/Flex";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { TokenValueWithTooltip } from "./components/TokenValueWithTooltip";
 import { HorizontalLine } from "~components/HorizontalLine";

--- a/src/routes/popup/swap/transaction-details.tsx
+++ b/src/routes/popup/swap/transaction-details.tsx
@@ -1,9 +1,8 @@
 import styled, { useTheme } from "styled-components";
-import { Button, Section } from "@wanderapp/components";
+import { Button, Section, Text } from "@wanderapp/components";
 import HeadV2 from "~components/popup/HeadV2";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import { Flex } from "~components/common/Flex";
-import { Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import { TokenValueWithTooltip } from "./components/TokenValueWithTooltip";
 import { HorizontalLine } from "~components/HorizontalLine";

--- a/src/routes/popup/tier.tsx
+++ b/src/routes/popup/tier.tsx
@@ -4,7 +4,7 @@ import HeadV2 from "~components/popup/HeadV2";
 import { ArrowUpRight, Award03 } from "@untitled-ui/icons-react";
 import { WanderIcon } from "~components/popup/tier/WanderIcon";
 import { EXPLORE_TIER_BENEFITS, TierTypes } from "~utils/tier/constants";
-import { Loading, Text, Tooltip } from "@arconnect/components-rebrand";
+import { Loading, Text, Tooltip } from "@wanderapp/components";
 import { Flex } from "~components/common/Flex";
 import wanderIcon from "~assets/ecosystem/wander.svg";
 import { defaultStars, AnimatedStarContainer } from "~components/common/AnimatedStarContainer";

--- a/src/routes/popup/tokens/token-detail.tsx
+++ b/src/routes/popup/tokens/token-detail.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Section, Text } from "@arconnect/components-rebrand";
+import { Section, Text } from "@wanderapp/components";
 import HeadV2 from "~components/popup/HeadV2";
 import { useParams } from "wouter";
 import { useAoToken } from "~tokens/hooks";

--- a/src/routes/popup/transaction/[id].tsx
+++ b/src/routes/popup/transaction/[id].tsx
@@ -1,6 +1,6 @@
 import { balanceToFractioned, formatFiatBalance } from "~tokens/currency";
 import { AnimatePresence, type Variants, motion } from "framer-motion";
-import { Button, Section, Spacer, Text } from "@arconnect/components-rebrand";
+import { Button, Section, Spacer, Text } from "@wanderapp/components";
 import type { GQLNodeInterface, GQLTagInterface } from "ar-gql/dist/faces";
 import { useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
 import { STAKED_GQL_FULL_HISTORY, useGateway, useGraphqlGateways } from "~gateways/wayfinder";

--- a/src/routes/popup/transaction/transactions.tsx
+++ b/src/routes/popup/transaction/transactions.tsx
@@ -1,7 +1,7 @@
 import HeadV2 from "~components/popup/HeadV2";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
-import { Button, Loading, Text } from "@arconnect/components-rebrand";
+import { Button, Loading, Text } from "@wanderapp/components";
 import { getFullMonthNameWithYear } from "~lib/transactions";
 import {
   TransactionItemComponent,

--- a/src/routes/popup/unlock.tsx
+++ b/src/routes/popup/unlock.tsx
@@ -1,6 +1,6 @@
 import { unlock } from "~wallets/auth";
 import browser from "webextension-polyfill";
-import { Button, Input, Section, Text, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Button, Input, Section, Text, useInput, useToasts } from "@wanderapp/components";
 import styled, { useTheme } from "styled-components";
 import WanderIcon from "url:assets/icon.svg";
 import IconText from "~components/IconText";

--- a/src/routes/welcome/PinExtension.tsx
+++ b/src/routes/welcome/PinExtension.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import { Pin02 } from "@untitled-ui/icons-react";
 import { Flex } from "~components/common/Flex";
 import Arrow from "url:/assets/setup/arrow.svg";

--- a/src/routes/welcome/generate/account.tsx
+++ b/src/routes/welcome/generate/account.tsx
@@ -7,7 +7,7 @@ import { PageType, trackPage } from "~utils/analytics";
 import { useLocation } from "~wallets/router/router.utils";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import styled from "styled-components";
-import { Button, Input } from "@arconnect/components-rebrand";
+import { Button, Input } from "@wanderapp/components";
 
 export type AccountWelcomeViewProps = CommonRouteProps<SetupWelcomeViewParams>;
 

--- a/src/routes/welcome/generate/backup.tsx
+++ b/src/routes/welcome/generate/backup.tsx
@@ -7,7 +7,7 @@ import copy from "copy-to-clipboard";
 import { PageType, trackPage } from "~utils/analytics";
 import { useLocation } from "~wallets/router/router.utils";
 import type { CommonRouteProps } from "~wallets/router/router.types";
-import { Button, Spacer, Text } from "@arconnect/components-rebrand";
+import { Button, Spacer, Text } from "@wanderapp/components";
 import { AlertTriangle, Check, Copy01, Eye, EyeOff } from "@untitled-ui/icons-react";
 
 export type BackupWelcomeViewProps = CommonRouteProps<SetupWelcomeViewParams>;

--- a/src/routes/welcome/generate/confirm.tsx
+++ b/src/routes/welcome/generate/confirm.tsx
@@ -8,7 +8,7 @@ import { PageType, trackPage } from "~utils/analytics";
 import { useLocation } from "~wallets/router/router.utils";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import styled from "styled-components";
-import { Button } from "@arconnect/components-rebrand";
+import { Button } from "@wanderapp/components";
 
 export type ConfirmWelcomeViewProps = CommonRouteProps<SetupWelcomeViewParams>;
 

--- a/src/routes/welcome/generate/done.tsx
+++ b/src/routes/welcome/generate/done.tsx
@@ -1,4 +1,4 @@
-import { Button, Spacer, Text } from "@arconnect/components-rebrand";
+import { Button, Spacer, Text } from "@wanderapp/components";
 import { WalletContext, type SetupWelcomeViewParams } from "../setup";
 import browser from "webextension-polyfill";
 import { useContext, useEffect } from "react";

--- a/src/routes/welcome/generate/loading.tsx
+++ b/src/routes/welcome/generate/loading.tsx
@@ -6,7 +6,7 @@ import { useLocation } from "~wallets/router/router.utils";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import styled from "styled-components";
 import { Flex } from "~components/common/Flex";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import { addWallet } from "~wallets";
 import { useHardwareApi } from "~wallets/hooks";
 import { loadTokens } from "~tokens/token";

--- a/src/routes/welcome/generate/permissions.tsx
+++ b/src/routes/welcome/generate/permissions.tsx
@@ -6,7 +6,7 @@ import { EventType, isUserInGDPRCountry, PageType, trackEvent, trackPage } from 
 import { useLocation } from "~wallets/router/router.utils";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import styled from "styled-components";
-import { Button, Text, Spacer } from "@arconnect/components-rebrand";
+import { Button, Text, Spacer } from "@wanderapp/components";
 import { ToggleSwitch } from "~components/ToggleSwitch";
 import { useStorage } from "@plasmohq/storage/hook";
 import { ExtensionStorage } from "~utils/storage";

--- a/src/routes/welcome/gettingStarted.tsx
+++ b/src/routes/welcome/gettingStarted.tsx
@@ -1,6 +1,6 @@
 import { AnimatePresence } from "framer-motion";
 import { useCallback, useState } from "react";
-import { Button, Spacer, Text } from "@arconnect/components-rebrand";
+import { Button, Spacer, Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import styled from "styled-components";
 

--- a/src/routes/welcome/gettingStarted/connect.tsx
+++ b/src/routes/welcome/gettingStarted/connect.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import xLogo from "url:/assets/setup/x-logo.svg";
 import discordLogo from "url:/assets/setup/discord-logo.svg";
 import browser from "webextension-polyfill";

--- a/src/routes/welcome/gettingStarted/explore.tsx
+++ b/src/routes/welcome/gettingStarted/explore.tsx
@@ -2,7 +2,7 @@ import styled, { useTheme } from "styled-components";
 import { useEffect } from "react";
 import { PageType, trackPage } from "~utils/analytics";
 import { Container, Content } from "~components/welcome/Wrapper";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import ExploreImage from "url:/assets/setup/explore_tour.png";
 import ExploreImageLight from "url:/assets/setup/explore_tour_light.png";

--- a/src/routes/welcome/gettingStarted/onramp.tsx
+++ b/src/routes/welcome/gettingStarted/onramp.tsx
@@ -2,7 +2,7 @@ import styled, { useTheme } from "styled-components";
 import { useEffect } from "react";
 import { PageType, trackPage } from "~utils/analytics";
 import { Container, Content } from "~components/welcome/Wrapper";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import BuyImage from "url:/assets/setup/buy_tour.png";
 import BuyImageLight from "url:/assets/setup/buy_tour_light.png";

--- a/src/routes/welcome/gettingStarted/personalize.tsx
+++ b/src/routes/welcome/gettingStarted/personalize.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { PageType, trackPage } from "~utils/analytics";
 import { Container, Content } from "~components/welcome/Wrapper";
-import { Checkbox, Input, Text, useInput, useToasts } from "@arconnect/components-rebrand";
+import { Checkbox, Input, Text, useInput, useToasts } from "@wanderapp/components";
 import { useStorage, ExtensionStorage } from "~utils/storage";
 import type { StoredWallet } from "~wallets";
 import browser from "webextension-polyfill";

--- a/src/routes/welcome/gettingStarted/pin.tsx
+++ b/src/routes/welcome/gettingStarted/pin.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { useEffect } from "react";
 import { PageType, trackPage } from "~utils/analytics";
 import { Container, Content } from "~components/welcome/Wrapper";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import PinExtension from "url:/assets/setup/pin-extension.png";
 

--- a/src/routes/welcome/gettingStarted/tokens.tsx
+++ b/src/routes/welcome/gettingStarted/tokens.tsx
@@ -2,7 +2,7 @@ import styled, { useTheme } from "styled-components";
 import { useEffect } from "react";
 import { PageType, trackPage } from "~utils/analytics";
 import { Container, Content } from "~components/welcome/Wrapper";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 import browser from "webextension-polyfill";
 import SendTourImage from "url:/assets/setup/send_tour.png";
 import SendTourImageLight from "url:/assets/setup/send_tour_light.png";

--- a/src/routes/welcome/gettingStarted/welcome.tsx
+++ b/src/routes/welcome/gettingStarted/welcome.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import { PageType, trackPage } from "~utils/analytics";
 import WanderIcon from "url:assets/icon.svg";
 import { Container, Content } from "~components/welcome/Wrapper";
-import { Text } from "@arconnect/components-rebrand";
+import { Text } from "@wanderapp/components";
 
 export function GettingStartedWelcomeView() {
   // Segment

--- a/src/routes/welcome/index.tsx
+++ b/src/routes/welcome/index.tsx
@@ -1,5 +1,5 @@
 import { Spacer } from "@arconnect/components";
-import { Button } from "@arconnect/components-rebrand";
+import { Button } from "@wanderapp/components";
 import { AnimatePresence, motion } from "framer-motion";
 import styled from "styled-components";
 import browser from "webextension-polyfill";

--- a/src/routes/welcome/load/options.tsx
+++ b/src/routes/welcome/load/options.tsx
@@ -5,7 +5,7 @@ import { type SetupWelcomeViewParams, type WelcomeSetupMode } from "../setup";
 import { useLocation } from "~wallets/router/router.utils";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import styled from "styled-components";
-import { Button, ListItem, ListItemIcon } from "@arconnect/components-rebrand";
+import { Button, ListItem, ListItemIcon } from "@wanderapp/components";
 import { FolderShield, Key01, QrCode02 } from "@untitled-ui/icons-react";
 import KeystoneIcon from "url:assets/setup/keystone.svg";
 

--- a/src/routes/welcome/load/password.tsx
+++ b/src/routes/welcome/load/password.tsx
@@ -8,7 +8,7 @@ import { PageType, trackPage } from "~utils/analytics";
 import { useLocation } from "~wallets/router/router.utils";
 import type { CommonRouteProps } from "~wallets/router/router.types";
 import styled from "styled-components";
-import { Button, Input, Spacer } from "@arconnect/components-rebrand";
+import { Button, Input, Spacer } from "@wanderapp/components";
 
 export type PasswordWelcomeViewProps = CommonRouteProps<SetupWelcomeViewParams>;
 

--- a/src/routes/welcome/load/theme.tsx
+++ b/src/routes/welcome/load/theme.tsx
@@ -7,7 +7,7 @@ import { PageType, trackPage } from "~utils/analytics";
 import { useLocation } from "~wallets/router/router.utils";
 import type { SetupWelcomeViewParams } from "~routes/welcome/setup";
 import type { CommonRouteProps } from "~wallets/router/router.types";
-import { Button } from "@arconnect/components-rebrand";
+import { Button } from "@wanderapp/components";
 import Paragraph from "~components/Paragraph";
 import Checkbox from "~components/Checkbox";
 

--- a/src/routes/welcome/load/wallets.tsx
+++ b/src/routes/welcome/load/wallets.tsx
@@ -6,7 +6,7 @@ import type { JWKInterface } from "arweave/web/lib/wallet";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { useStorage } from "~utils/storage";
 import { PasswordContext, WalletContext, type SetupWelcomeViewParams } from "../setup";
-import { Button, Modal, Spacer, Text, useModal, useToasts } from "@arconnect/components-rebrand";
+import { Button, Modal, Spacer, Text, useModal, useToasts } from "@wanderapp/components";
 import Migrate from "~components/welcome/load/Migrate";
 import SeedInput from "~components/SeedInput";
 import Paragraph from "~components/Paragraph";

--- a/src/routes/welcome/setup.tsx
+++ b/src/routes/welcome/setup.tsx
@@ -1,7 +1,7 @@
 import { AnimatePresence, type Variants, motion } from "framer-motion";
 import { createContext, useCallback, useEffect, useState } from "react";
 import { Spacer, useToasts } from "@arconnect/components";
-import { Card, Text } from "@arconnect/components-rebrand";
+import { Card, Text } from "@wanderapp/components";
 import type { JWKInterface } from "arweave/web/lib/wallet";
 import { jwkFromMnemonic } from "~wallets/generator";
 import browser from "webextension-polyfill";

--- a/src/tabs/arlocal.tsx
+++ b/src/tabs/arlocal.tsx
@@ -5,7 +5,7 @@ import { urlToGateway } from "~gateways/utils";
 import { useStorage } from "~utils/storage";
 import { ExtensionStorage } from "~utils/storage";
 import { RefreshIcon } from "@iconicicons/react";
-import { Button, Input, Spacer, useInput, Text, useToasts } from "@arconnect/components-rebrand";
+import { Button, Input, Spacer, useInput, Text, useToasts } from "@wanderapp/components";
 import { CardBody, ConnectionStatus, ConnectionText, Title, Wrapper } from "./devtools";
 import { ArLocalTransaction } from "~components/arlocal/Transaction";
 import NoWallets from "~components/devtools/NoWallets";

--- a/src/tabs/devtools.tsx
+++ b/src/tabs/devtools.tsx
@@ -1,4 +1,4 @@
-import { Card, Spacer, Text } from "@arconnect/components-rebrand";
+import { Card, Spacer, Text } from "@wanderapp/components";
 import { useMemo, useState } from "react";
 import { PersistentStorage, useStorage } from "~utils/storage";
 import { getTab } from "~applications/tab";

--- a/src/utils/theme/observer/theme-observer.component.tsx
+++ b/src/utils/theme/observer/theme-observer.component.tsx
@@ -1,4 +1,4 @@
-import type { DisplayTheme } from "@arconnect/components-rebrand";
+import type { DisplayTheme } from "@wanderapp/components";
 import { useEffect } from "react";
 import { useTheme as useStyledComponentsTheme } from "styled-components";
 import { ARCONNECT_THEME_BACKGROUND_COLOR, ARCONNECT_THEME_TEXT_COLOR } from "~utils/storage.utils";

--- a/src/utils/theme/styled-components/styled-components.provider.tsx
+++ b/src/utils/theme/styled-components/styled-components.provider.tsx
@@ -5,7 +5,7 @@ import {
   ARCONNECT_LIGHT_THEME,
   Provider as ThemeProvider,
   type ArconnectTheme,
-} from "@arconnect/components-rebrand";
+} from "@wanderapp/components";
 import { useTheme } from "~utils/theme/theme.hook";
 import { ThemeBackgroundObserver } from "~utils/theme/observer/theme-observer.component";
 

--- a/src/utils/theme/theme.types.ts
+++ b/src/utils/theme/theme.types.ts
@@ -1,4 +1,4 @@
-import type { DisplayTheme } from "@arconnect/components-rebrand";
+import type { DisplayTheme } from "@wanderapp/components";
 import type { commonTokens, themeTokens } from "~components/embed/themes/theme-config";
 
 export type ThemeMode = "light" | "dark" | "system";

--- a/src/utils/toast/toast.hooks.tsx
+++ b/src/utils/toast/toast.hooks.tsx
@@ -1,5 +1,5 @@
-import { useToasts, type DisplayTheme } from "@arconnect/components-rebrand";
-import { Text } from "@arconnect/components-rebrand";
+import { useToasts, type DisplayTheme } from "@wanderapp/components";
+import { Text } from "@wanderapp/components";
 import { Link } from "~components/common/Link";
 import browser from "webextension-polyfill";
 import { useTheme } from "styled-components";

--- a/src/utils/toast/toast.hooks.tsx
+++ b/src/utils/toast/toast.hooks.tsx
@@ -1,5 +1,4 @@
-import { useToasts, type DisplayTheme } from "@wanderapp/components";
-import { Text } from "@wanderapp/components";
+import { useToasts, type DisplayTheme, Text } from "@wanderapp/components";
 import { Link } from "~components/common/Link";
 import browser from "webextension-polyfill";
 import { useTheme } from "styled-components";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4984,9 +4984,10 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.18.tgz#529f24a88d3ed678d50fd5c07455841fbe8ac95e"
   integrity sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==
 
-"@wanderapp/components@https://github.com/wanderwallet/components.git#fix/tooltip-styles":
+"@wanderapp/components@^1.0.1":
   version "1.0.1"
-  resolved "https://github.com/wanderwallet/components.git#8bfa71106eed07ca5a0c767c7f6a00e7e2283159"
+  resolved "https://registry.npmjs.org/@wanderapp/components/-/components-1.0.1.tgz#eca30809b43ddde71754c8403ba39df20c176062"
+  integrity sha512-z0fF2/hpDy4xTA6GHCTZiDYc+Ds+wX38YQMVfxfFw2Rvl0XnmhorfwNJISPj/qJOzApBObqnJ+vUKzqu2UmYNw==
   dependencies:
     "@iconicicons/react" "^1.5.1"
     "@untitled-ui/icons-react" "^0.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,18 +28,6 @@
     winston "^3.13.0"
     zod "^3.23.8"
 
-"@arconnect/components-rebrand@https://github.com/wanderwallet/components-rebrand.git#fix/tooltip":
-  version "1.0.0"
-  resolved "https://github.com/wanderwallet/components-rebrand.git#81010adb3414f726927d211e25b57b59ee1bde98"
-  dependencies:
-    "@iconicicons/react" "^1.5.1"
-    "@untitled-ui/icons-react" "^0.1.4"
-    axios "^1.6.7"
-    framer-motion "^7.5.3"
-    nanoid "^4.0.1"
-    react-tooltip "^5.30.0"
-    uuid "^9.0.1"
-
 "@arconnect/components@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@arconnect/components/-/components-1.0.0.tgz#4186b98cccb1e4a0241cd69bccb33459a7b4cf93"
@@ -4995,6 +4983,18 @@
   version "3.5.18"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.18.tgz#529f24a88d3ed678d50fd5c07455841fbe8ac95e"
   integrity sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==
+
+"@wanderapp/components@https://github.com/wanderwallet/components.git#fix/tooltip-styles":
+  version "1.0.1"
+  resolved "https://github.com/wanderwallet/components.git#8bfa71106eed07ca5a0c767c7f6a00e7e2283159"
+  dependencies:
+    "@iconicicons/react" "^1.5.1"
+    "@untitled-ui/icons-react" "^0.1.4"
+    axios "^1.6.7"
+    framer-motion "^7.5.3"
+    nanoid "^4.0.1"
+    react-tooltip "^5.30.0"
+    uuid "^9.0.1"
 
 "@wanderapp/webext-bridge@^5.0.7":
   version "5.0.7"


### PR DESCRIPTION
## Summary

This PR replaces `@arconnect/components-rebrand` with `@wanderapp/components` and uses the updated tooltip for better theme support. 

Related components PR: https://github.com/wanderwallet/components/pull/25