### PR TITLE
Add home route to `open()` in connect sdk

### DIFF
--- a/src/utils/embedded/embedded.provider.tsx
+++ b/src/utils/embedded/embedded.provider.tsx
@@ -1320,6 +1320,14 @@ export function EmbeddedProvider({ children }: EmbeddedProviderProps) {
         navigate("/account/backup-wallet");
       } else if (data === "home") {
         navigate("/");
+      } else if (data === "receive") {
+        navigate("/wallet/receive/options");
+      } else if (data === "receive-address") {
+        navigate("/wallet/deposit");
+      } else if (data === "buy") {
+        navigate("/wallet/buy/cash");
+      } else if (data === "transactions") {
+        navigate("/wallet/transactions");
       }
     });
   }, []);

--- a/src/utils/embedded/embedded.provider.tsx
+++ b/src/utils/embedded/embedded.provider.tsx
@@ -1314,9 +1314,13 @@ export function EmbeddedProvider({ children }: EmbeddedProviderProps) {
     isomorphicOnMessage("embedded_navigate", ({ data }) => {
       const navigate = navigateRef.current;
 
-      if (data !== "backup" || !navigate) return;
+      if (!navigate) return;
 
-      navigate("/account/backup-wallet");
+      if (data === "backup") {
+        navigate("/account/backup-wallet");
+      } else if (data === "home") {
+        navigate("/");
+      }
     });
   }, []);
 

--- a/src/wallets/router/iframe/iframe.routes.tsx
+++ b/src/wallets/router/iframe/iframe.routes.tsx
@@ -76,7 +76,7 @@ import { AccountBackupCloudImportSuccessEmbeddedView } from "~routes/embedded/ac
 /**
  * Developers can manually navigate to these flows:
  */
-export type DirectAccess = "backup" | "home";
+export type DirectAccess = "backup" | "home" | "receive" | "receive-address" | "buy" | "transactions";
 
 export type EmbeddedRoutePath =
   | "/support/unpartitioned-state"

--- a/src/wallets/router/iframe/iframe.routes.tsx
+++ b/src/wallets/router/iframe/iframe.routes.tsx
@@ -76,7 +76,7 @@ import { AccountBackupCloudImportSuccessEmbeddedView } from "~routes/embedded/ac
 /**
  * Developers can manually navigate to these flows:
  */
-export type DirectAccess = "backup";
+export type DirectAccess = "backup" | "home";
 
 export type EmbeddedRoutePath =
   | "/support/unpartitioned-state"

--- a/wander-connect-sdk/package.json
+++ b/wander-connect-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wanderapp/connect",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Wander Connect SDK.",
   "author": "wanderapp",
   "license": "MIT",

--- a/wander-connect-sdk/src/wander-connect.types.ts
+++ b/wander-connect-sdk/src/wander-connect.types.ts
@@ -4,7 +4,7 @@ export type OpenReason = "manually" | "embedded_open" | "embedded_request";
 
 // Routes and layouts:
 
-export type DirectAccess = "backup" | "home";
+export type DirectAccess = "backup" | "home" | "receive" | "receive-address" | "buy" | "transactions";
 
 /**
  * Types of routes available in the Wander Connect SDK.

--- a/wander-connect-sdk/src/wander-connect.types.ts
+++ b/wander-connect-sdk/src/wander-connect.types.ts
@@ -4,7 +4,7 @@ export type OpenReason = "manually" | "embedded_open" | "embedded_request";
 
 // Routes and layouts:
 
-export type DirectAccess = "backup";
+export type DirectAccess = "backup" | "home";
 
 /**
  * Types of routes available in the Wander Connect SDK.


### PR DESCRIPTION
This PR adds another route option to `open()` in Wander Connect SDK